### PR TITLE
feat: add docker startup logic

### DIFF
--- a/proposer/succinct/bin/cost_estimator.rs
+++ b/proposer/succinct/bin/cost_estimator.rs
@@ -292,7 +292,8 @@ fn aggregate_execution_stats(execution_stats: &[ExecutionStats]) -> ExecutionSta
     aggregate_stats
 }
 
-/// Build and manage the Docker container for the span batch server.
+/// Build and manage the Docker container for the span batch server. Note: All logs are piped to
+/// /dev/null, so the user doesn't see them.
 fn manage_span_batch_server_container() -> Result<()> {
     // Check if port 8080 is already in use
     if TcpListener::bind("0.0.0.0:8080").is_err() {
@@ -332,7 +333,7 @@ fn manage_span_batch_server_container() -> Result<()> {
     Ok(())
 }
 
-/// Shut down Docker container.
+/// Shut down Docker container. Note: All logs are piped to /dev/null, so the user doesn't see them.
 fn shutdown_span_batch_server_container() -> Result<()> {
     // Get the container ID associated with the span_batch_server image.
     let container_id = String::from_utf8(

--- a/proposer/succinct/bin/cost_estimator.rs
+++ b/proposer/succinct/bin/cost_estimator.rs
@@ -350,7 +350,6 @@ fn shutdown_span_batch_server_container() -> Result<()> {
     }
 
     // Stop the container.
-    // TODO: The container ID shows up in stdout, and so do the Docker logs. Quiet these.
     let stop_status = Command::new("docker")
         .args(["stop", &container_id])
         .stdout(Stdio::null())

--- a/proposer/succinct/bin/cost_estimator.rs
+++ b/proposer/succinct/bin/cost_estimator.rs
@@ -295,7 +295,7 @@ fn aggregate_execution_stats(execution_stats: &[ExecutionStats]) -> ExecutionSta
 fn manage_span_batch_server_container() -> Result<()> {
     // Build the Docker container if it doesn't exist.
     let build_status = Command::new("docker")
-        .args(&[
+        .args([
             "build",
             "-t",
             "span_batch_server",
@@ -310,7 +310,7 @@ fn manage_span_batch_server_container() -> Result<()> {
 
     // Start the Docker container.
     let run_status = Command::new("docker")
-        .args(&["run", "-p", "8080:8080", "-d", "span_batch_server"])
+        .args(["run", "-p", "8080:8080", "-d", "span_batch_server"])
         .status()?;
     if !run_status.success() {
         return Err(anyhow::anyhow!("Failed to start Docker container"));
@@ -320,7 +320,7 @@ fn manage_span_batch_server_container() -> Result<()> {
 
 /// Shut down Docker container.
 fn shutdown_span_batch_server_container() -> Result<()> {
-    let stop_status = Command::new("docker").args(&["stop", "span_batch_server"]).status()?;
+    let stop_status = Command::new("docker").args(["stop", "span_batch_server"]).status()?;
     if !stop_status.success() {
         return Err(anyhow::anyhow!("Failed to stop Docker container"));
     }

--- a/proposer/succinct/bin/cost_estimator.rs
+++ b/proposer/succinct/bin/cost_estimator.rs
@@ -330,9 +330,12 @@ fn manage_span_batch_server_container() -> Result<()> {
 
 /// Shut down Docker container.
 fn shutdown_span_batch_server_container() -> Result<()> {
-    // Get the container ID
+    // Get the container ID associated with the span_batch_server image.
     let container_id = String::from_utf8(
-        Command::new("docker").args(["ps", "-q", "-f", "ancestor=span_batch_server"]).output()?.stdout,
+        Command::new("docker")
+            .args(["ps", "-q", "-f", "ancestor=span_batch_server"])
+            .output()?
+            .stdout,
     )?
     .trim()
     .to_string();


### PR DESCRIPTION
Handle the startup & shutdown logic for the span batch server inside of the cost estimator, rather than relying on user startup commands.