### PR TITLE
fix: `op-proposer` logic

### DIFF
--- a/contracts/zkconfig.json
+++ b/contracts/zkconfig.json
@@ -1,5 +1,5 @@
 {
-    "startingBlockNumber": 16795981,
+    "startingBlockNumber": 16833525,
     "l2RollupNode": "",
     "submissionInterval": 150,
     "l2BlockTime": 2,


### PR DESCRIPTION
Small fixes to the `op-proposer` logic:

1. When an agg proof failed, we incorrectly retried a span proof with the same bounds, which caused issues. We had not run into this issue before because AGG proofs typically didn't fail. The Modal proof server was not up, which is why the AGG proofs failed.
2. In the start of the `ProcessPendingProofs` loop, we should only retry failed proofs IF they did not reach the prover network. Otherwise, we will constantly retry failed proofs from the prover network, which causes issues.