### PR TITLE
chore: Reset witnessgen data directory

### DIFF
--- a/proposer/succinct/bin/cost_estimator.rs
+++ b/proposer/succinct/bin/cost_estimator.rs
@@ -166,6 +166,10 @@ async fn run_native_data_generation(
                 ProgramType::Multi,
             ))
             .expect("Failed to get host CLI args.");
+
+            // Overwrite existing data directory.
+            fs::create_dir_all(&host_cli.data_dir.clone().unwrap()).unwrap();
+
             batch_host_clis.push(BatchHostCli {
                 host_cli: host_cli.clone(),
                 start: range.start,

--- a/proposer/succinct/build.rs
+++ b/proposer/succinct/build.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-// use sp1_build::{build_program_with_args, BuildArgs};
+use sp1_build::{build_program_with_args, BuildArgs};
 
 /// Build a native program.
 fn build_native_program(program: &str) {
@@ -41,17 +41,18 @@ fn build_native_host_runner() {
     println!("cargo:warning=native_host_runner built with release profile",);
 }
 
-// /// Build a program for the zkVM.
-// fn build_zkvm_program(program: &str) {
-//     build_program_with_args(
-//         &format!("../../programs/{}", program),
-//         BuildArgs {
-//             elf_name: format!("{}-elf", program),
-//             // docker: true,
-//             ..Default::default()
-//         },
-//     );
-// }
+/// Build a program for the zkVM.
+#[allow(dead_code)]
+fn build_zkvm_program(program: &str) {
+    build_program_with_args(
+        &format!("../../programs/{}", program),
+        BuildArgs {
+            elf_name: format!("{}-elf", program),
+            // docker: true,
+            ..Default::default()
+        },
+    );
+}
 
 fn main() {
     let programs = vec!["range"];


### PR DESCRIPTION
Clear the data directory before each witness generation run in the event there is a failure on a previous witness generation run. 

Mirrors the logic within the multi and single block executors, as well as the `op-succinct` proving server.