### PR TITLE
chore: `CacheMode`

### DIFF
--- a/proposer/succinct/bin/cost_estimator.rs
+++ b/proposer/succinct/bin/cost_estimator.rs
@@ -4,7 +4,7 @@ use kona_host::HostCli;
 use kona_primitives::RollupConfig;
 use log::info;
 use op_succinct_host_utils::{
-    fetcher::{ChainMode, OPSuccinctDataFetcher},
+    fetcher::{CacheMode, ChainMode, OPSuccinctDataFetcher},
     get_proof_stdin,
     stats::{get_execution_stats, ExecutionStats},
     witnessgen::WitnessGenExecutor,
@@ -164,11 +164,9 @@ async fn run_native_data_generation(
                 range.start,
                 range.end,
                 ProgramType::Multi,
+                CacheMode::DeleteCache,
             ))
             .expect("Failed to get host CLI args.");
-
-            // Overwrite existing data directory.
-            fs::create_dir_all(&host_cli.data_dir.clone().unwrap()).unwrap();
 
             batch_host_clis.push(BatchHostCli {
                 host_cli: host_cli.clone(),

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -10,8 +10,10 @@ use base64::{engine::general_purpose, Engine as _};
 use log::info;
 use op_succinct_client_utils::{RawBootInfo, BOOT_INFO_SIZE};
 use op_succinct_host_utils::{
-    fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, get_proof_stdin,
-    witnessgen::WitnessGenExecutor, ProgramType,
+    fetcher::{CacheMode, OPSuccinctDataFetcher},
+    get_agg_proof_stdin, get_proof_stdin,
+    witnessgen::WitnessGenExecutor,
+    ProgramType,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use sp1_sdk::{
@@ -76,13 +78,9 @@ async fn request_span_proof(
     // and access via Store.
     let data_fetcher = OPSuccinctDataFetcher::new();
 
-    let host_cli =
-        data_fetcher.get_host_cli_args(payload.start, payload.end, ProgramType::Multi).await?;
-
-    let data_dir = host_cli.data_dir.clone().unwrap();
-
-    // Overwrite existing data directory.
-    fs::create_dir_all(&data_dir)?;
+    let host_cli = data_fetcher
+        .get_host_cli_args(payload.start, payload.end, ProgramType::Multi, CacheMode::DeleteCache)
+        .await?;
 
     // Start the server and native client with a timeout.
     // Note: Ideally, the server should call out to a separate process that executes the native

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -3,7 +3,7 @@ use std::{fs, time::Instant};
 use anyhow::Result;
 use clap::Parser;
 use op_succinct_host_utils::{
-    fetcher::{ChainMode, OPSuccinctDataFetcher},
+    fetcher::{CacheMode, ChainMode, OPSuccinctDataFetcher},
     get_proof_stdin,
     stats::get_execution_stats,
     witnessgen::WitnessGenExecutor,
@@ -46,16 +46,15 @@ async fn main() -> Result<()> {
 
     let data_fetcher = OPSuccinctDataFetcher::new();
 
-    let host_cli = data_fetcher.get_host_cli_args(args.start, args.end, ProgramType::Multi).await?;
+    let cache_mode = if args.use_cache { CacheMode::KeepCache } else { CacheMode::DeleteCache };
 
-    let data_dir = host_cli.data_dir.clone().expect("Data directory is not set.");
+    let host_cli = data_fetcher
+        .get_host_cli_args(args.start, args.end, ProgramType::Multi, cache_mode)
+        .await?;
 
     // By default, re-run the native execution unless the user passes `--use-cache`.
     let start_time = Instant::now();
     if !args.use_cache {
-        // Overwrite existing data directory.
-        fs::create_dir_all(&data_dir).unwrap();
-
         // Start the server and native client.
         let mut witnessgen_executor = WitnessGenExecutor::default();
         witnessgen_executor.spawn_witnessgen(&host_cli).await?;

--- a/utils/host/src/witnessgen.rs
+++ b/utils/host/src/witnessgen.rs
@@ -41,7 +41,7 @@ pub fn convert_host_cli_to_args(host_cli: &HostCli) -> Vec<String> {
 }
 
 /// Default timeout for witness generation.
-pub const WITNESSGEN_TIMEOUT: Duration = Duration::from_secs(300);
+pub const WITNESSGEN_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct WitnessGenProcess {
     child: tokio::process::Child,


### PR DESCRIPTION
Centralize logic for adding/deleting witness generation files into `get_host_cli_args`.

Reduce witness generation timeout to 1 minute, as most `witnessgen` takes less than that.