### PR TITLE
feat: Add `useCachedDB` flag

### DIFF
--- a/contracts/zkconfig.json
+++ b/contracts/zkconfig.json
@@ -1,5 +1,5 @@
 {
-    "startingBlockNumber": 17047300,
+    "startingBlockNumber": 17048966,
     "l2RollupNode": "",
     "submissionInterval": 150,
     "l2BlockTime": 2,

--- a/proposer/op/proposer/db/db.go
+++ b/proposer/op/proposer/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/succinctlabs/op-succinct-go/proposer/db/ent"
@@ -15,8 +16,11 @@ type ProofDB struct {
 	client *ent.Client
 }
 
-// Initialize the database and return a handle to it.
-func InitDB(dbPath string) (*ProofDB, error) {
+// Initialize the database and return a handle to it. If useCachedDb is false, the existing DB at the path will be deleted (if it exists).
+func InitDB(dbPath string, useCachedDb bool) (*ProofDB, error) {
+	if !useCachedDb {
+		os.Remove(dbPath)
+	}
 	connectionString := fmt.Sprintf("file:%s?_fk=1", dbPath)
 	client, err := ent.Open("sqlite3", connectionString)
 	if err != nil {

--- a/proposer/op/proposer/driver.go
+++ b/proposer/op/proposer/driver.go
@@ -137,7 +137,7 @@ func newL2OOSubmitter(ctx context.Context, cancel context.CancelFunc, setup Driv
 		return nil, err
 	}
 
-	db, err := db.InitDB(setup.Cfg.DbPath)
+	db, err := db.InitDB(setup.Cfg.DbPath, setup.Cfg.UseCachedDb)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/proposer/op/proposer/flags/flags.go
+++ b/proposer/op/proposer/flags/flags.go
@@ -101,6 +101,12 @@ var (
 		Value:   "./op-proposer/proofs.db",
 		EnvVars: prefixEnvVars("DB_PATH"),
 	}
+	UseCachedDbFlag = &cli.BoolFlag{
+		Name:    "use-cached-db",
+		Usage:   "Use a cached database instead of creating a new one",
+		Value:   false,
+		EnvVars: prefixEnvVars("USE_CACHED_DB"),
+	}
 	MaxSpanBatchDeviationFlag = &cli.Uint64Flag{
 		Name:    "max-span-batch-deviation",
 		Usage:   "If we find a span batch this far ahead of our target, we assume an error and fill in the gap",

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -45,7 +45,7 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 			return err
 		}
 		if status == "PROOF_FULFILLED" {
-			// update the proof to the DB and update status to "COMPLETE"
+			// Update the proof in the DB and update status to COMPLETE.
 			l.Log.Info("proof fulfilled", "id", req.ProverRequestID)
 			err = l.db.AddProof(req.ID, proof)
 			if err != nil {

--- a/proposer/op/proposer/service.go
+++ b/proposer/op/proposer/service.go
@@ -52,6 +52,7 @@ type ProposerConfig struct {
 
 	// Additional fields required for ZK Proposer
 	DbPath                     string
+	UseCachedDb                bool
 	BeaconRpc                  string
 	TxCacheOutDir              string
 	BatchDecoderConcurrentReqs uint64


### PR DESCRIPTION
Add a flag to use the cached DB at the `dbPath` in the proposer. Removes the need to delete the DB manually.

This flag can be activated with `USE_CACHED_DB`.