### PR TITLE
fix: cost estimator

### DIFF
--- a/scripts/prove/bin/cost_estimator.rs
+++ b/scripts/prove/bin/cost_estimator.rs
@@ -134,7 +134,8 @@ fn split_ranges(span_batch_ranges: Vec<SpanBatchRange>, l2_chain_id: u64) -> Vec
             while start < range.end {
                 let end = min(start + batch_size, range.end);
                 split_ranges.push(SpanBatchRange { start, end });
-                start = end;
+                // The start of the next range should be the end of the current range + 1.
+                start = end + 1;
             }
         } else {
             split_ranges.push(range);


### PR DESCRIPTION
Fix how the `cost-estimator` splits the span batch ranges `span-batch-server` according to the configuration per chain. There should be no overlap between ranges, otherwise there will be double execution of the same block.