### PR TITLE
feat: Load OP Stack Rollup Config

### DIFF
--- a/programs/range/src/main.rs
+++ b/programs/range/src/main.rs
@@ -171,8 +171,10 @@ fn main() {
                 Sealed::new_unchecked(new_block_header.clone(), new_block_header.hash_slow()),
             );
 
-            // Produce the next payload.
+            println!("cycle-tracker-report-start: payload-derivation");
+            // Produce the next payload. If a span batch boundary is passed, the driver will step until the next batch.
             payload = driver.produce_payloads().await.unwrap();
+            println!("cycle-tracker-report-end: payload-derivation");
         }
 
         println!("cycle-tracker-start: output-root");

--- a/proposer/op/Dockerfile.op_proposer
+++ b/proposer/op/Dockerfile.op_proposer
@@ -25,6 +25,9 @@ COPY --from=optimism-builder /optimism/op-proposer/proposer/bin/op-proposer /usr
 # Set the entrypoint to run op-proposer with environment variables
 COPY ./proposer/op/op_proposer.sh /usr/local/bin/op_proposer.sh
 
+# Copy the rollup configs
+COPY ./rollup-configs /app/rollup-configs
+
 # Make the binary and entrypoint executable.
 RUN ls -l /usr/local/bin/
 RUN chmod +x /usr/local/bin/op-proposer

--- a/proposer/op/Dockerfile.op_proposer
+++ b/proposer/op/Dockerfile.op_proposer
@@ -26,7 +26,7 @@ COPY --from=optimism-builder /optimism/op-proposer/proposer/bin/op-proposer /usr
 COPY ./proposer/op/op_proposer.sh /usr/local/bin/op_proposer.sh
 
 # Copy the rollup configs
-COPY ./rollup-configs /app/rollup-configs
+COPY ../rollup-configs /rollup-configs
 
 # Make the binary and entrypoint executable.
 RUN ls -l /usr/local/bin/

--- a/proposer/op/Dockerfile.span_batch_server
+++ b/proposer/op/Dockerfile.span_batch_server
@@ -26,7 +26,7 @@ WORKDIR /app
 COPY ./proposer/op /app/op-proposer-go
 
 # Copy the rollup configs
-COPY ./rollup-configs /app/rollup-configs
+COPY ../rollup-configs /rollup-configs
 
 # Change to the server directory and build the application
 WORKDIR /app/op-proposer-go/server

--- a/proposer/op/Dockerfile.span_batch_server
+++ b/proposer/op/Dockerfile.span_batch_server
@@ -25,6 +25,9 @@ WORKDIR /app
 # Copy the local proposer/op directory
 COPY ./proposer/op /app/op-proposer-go
 
+# Copy the rollup configs
+COPY ./rollup-configs /app/rollup-configs
+
 # Change to the server directory and build the application
 WORKDIR /app/op-proposer-go/server
 

--- a/proposer/op/cmd/main.go
+++ b/proposer/op/cmd/main.go
@@ -61,7 +61,7 @@ func main() {
 			},
 		},
 		Action: func(cliCtx *cli.Context) error {
-			// Get the chain ID from the L2 RPC
+			// Get the chain ID from the L2 RPC.
 			l2Client, err := ethclient.Dial(cliCtx.String("l2"))
 			if err != nil {
 				log.Fatal(err)
@@ -71,7 +71,7 @@ func main() {
 				log.Fatal(err)
 			}
 
-			// Load the rollup config for the given L2 chain ID
+			// Load the rollup config for the given L2 chain ID.
 			rollupCfg, err := utils.LoadOPStackRollupConfigFromChainID(chainID.Uint64())
 			if err != nil {
 				log.Fatal(err)

--- a/proposer/op/cmd/main.go
+++ b/proposer/op/cmd/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/joho/godotenv"
 	"github.com/succinctlabs/op-succinct-go/proposer/utils"
 	"github.com/urfave/cli/v2"
@@ -60,7 +61,18 @@ func main() {
 			},
 		},
 		Action: func(cliCtx *cli.Context) error {
-			rollupCfg, err := utils.GetRollupConfigFromL2Rpc(cliCtx.String("l2"))
+			// Get the chain ID from the L2 RPC
+			l2Client, err := ethclient.Dial(cliCtx.String("l2"))
+			if err != nil {
+				log.Fatal(err)
+			}
+			chainID, err := l2Client.ChainID(context.Background())
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// Load the rollup config for the given L2 chain ID
+			rollupCfg, err := utils.LoadOPStackRollupConfigFromChainID(chainID.Uint64())
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/proposer/op/proposer/span_batches.go
+++ b/proposer/op/proposer/span_batches.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/succinctlabs/op-succinct-go/proposer/db/ent"
 	"github.com/succinctlabs/op-succinct-go/proposer/utils"
@@ -51,7 +50,7 @@ func (l *L2OutputSubmitter) DeriveNewSpanBatches(ctx context.Context) error {
 	}
 
 	// Get the rollup config for the chain to fetch the batcher address.
-	rollupCfg, err := rollup.LoadOPStackRollupConfig(l.Cfg.L2ChainID)
+	rollupCfg, err := utils.LoadOPStackRollupConfigFromChainID(l.Cfg.L2ChainID)
 	if err != nil {
 		return fmt.Errorf("failed to load rollup config: %w", err)
 	}

--- a/proposer/op/proposer/utils/utils.go
+++ b/proposer/op/proposer/utils/utils.go
@@ -56,19 +56,20 @@ type BatchDecoderConfig struct {
 // full-length and minimal hex strings.
 type CustomBytes32 eth.Bytes32
 
+// Unmarshal some data into a CustomBytes32.
 func (b *CustomBytes32) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
 
-	// Remove "0x" prefix if present
+	// Remove "0x" prefix if present.
 	s = strings.TrimPrefix(s, "0x")
 
-	// Pad the string to 64 characters (32 bytes) with leading zeros
+	// Pad the string to 64 characters (32 bytes) with leading zeros.
 	s = fmt.Sprintf("%064s", s)
 
-	// Add back the "0x" prefix
+	// Add back the "0x" prefix.
 	s = "0x" + s
 
 	bytes, err := common.ParseHexOrString(s)
@@ -86,19 +87,18 @@ func (b *CustomBytes32) UnmarshalJSON(data []byte) error {
 
 // LoadOPStackRollupConfigFromChainID loads and parses the rollup config for the given L2 chain ID.
 func LoadOPStackRollupConfigFromChainID(l2ChainId uint64) (*rollup.Config, error) {
-	// Determine the path to the rollup config file
+	// Determine the path to the rollup config file.
 	_, currentFile, _, _ := runtime.Caller(0)
 	currentDir := filepath.Dir(currentFile)
 	path := filepath.Join(currentDir, "..", "..", "..", "..", "rollup-configs", fmt.Sprintf("%d.json", l2ChainId))
-	fmt.Printf("Path: %v\n", path)
 
-	// Read the rollup config file
+	// Read the rollup config file.
 	rollupCfg, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read rollup config: %w", err)
 	}
 
-	// Parse the JSON config
+	// Parse the JSON config.
 	var rawConfig map[string]interface{}
 	if err := json.Unmarshal(rollupCfg, &rawConfig); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal rollup config: %w", err)
@@ -110,13 +110,13 @@ func LoadOPStackRollupConfigFromChainID(l2ChainId uint64) (*rollup.Config, error
 		return nil, fmt.Errorf("failed to convert config types: %w", err)
 	}
 
-	// Marshal the converted config back to JSON
+	// Marshal the converted config back to JSON.
 	modifiedConfig, err := json.Marshal(convertedConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to re-marshal modified config: %w", err)
 	}
 
-	// Unmarshal into the actual rollup.Config struct
+	// Unmarshal into the actual rollup.Config struct.
 	var config rollup.Config
 	if err := json.Unmarshal(modifiedConfig, &config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal modified rollup config: %w", err)
@@ -128,14 +128,14 @@ func LoadOPStackRollupConfigFromChainID(l2ChainId uint64) (*rollup.Config, error
 // The JSON serialization of the Rust superchain-primitives types differ from the Go types (ex. U256 instead of Bytes32, U64 instead of uint64, etc.)
 // This function converts the Rust types in the rollup config JSON to the Go types.
 func convertConfigTypes(rawConfig map[string]interface{}) (map[string]interface{}, error) {
-	// Convert genesis block numbers
+	// Convert genesis block numbers.
 	if genesis, ok := rawConfig["genesis"].(map[string]interface{}); ok {
 		convertBlockNumber(genesis, "l1")
 		convertBlockNumber(genesis, "l2")
 		convertSystemConfig(genesis)
 	}
 
-	// Convert base fee parameters
+	// Convert base fee parameters.
 	convertBaseFeeParams(rawConfig, "base_fee_params")
 	convertBaseFeeParams(rawConfig, "canyon_base_fee_params")
 
@@ -245,7 +245,7 @@ func GetSpanBatchRanges(config reassemble.Config, rollupCfg *rollup.Config, star
 			batchStartBlock := TimestampToBlock(rollupCfg, b.GetTimestamp())
 			spanBatch, success := b.AsSpanBatch()
 			if !success {
-				// If AsSpanBatch fails, return the entire range
+				// If AsSpanBatch fails, return the entire range.
 				log.Printf("couldn't convert batch %v to span batch\n", idx)
 				ranges = append(ranges, SpanBatchRange{Start: startBlock, End: endBlock})
 				return ranges, nil

--- a/proposer/op/proposer/utils/utils.go
+++ b/proposer/op/proposer/utils/utils.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"math/big"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -83,7 +85,10 @@ func (b *CustomBytes32) UnmarshalJSON(data []byte) error {
 }
 
 func LoadOPStackRollupConfigFromChainID(l2ChainId uint64) (*rollup.Config, error) {
-	path := fmt.Sprintf("../../../rollup-configs/%d.json", l2ChainId)
+	_, currentFile, _, _ := runtime.Caller(0)
+	currentDir := filepath.Dir(currentFile)
+	path := filepath.Join(currentDir, "..", "..", "..", "..", "rollup-configs", fmt.Sprintf("%d.json", l2ChainId))
+	fmt.Printf("Path: %v\n", path)
 	rollupCfg, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read rollup config: %w", err)
@@ -157,23 +162,6 @@ func LoadOPStackRollupConfigFromChainID(l2ChainId uint64) (*rollup.Config, error
 
 	return &config, nil
 }
-
-// // / Load the rollup config for the given L2 chain ID from the rollup-configs directory.
-// func LoadOPStackRollupConfigFromChainID(l2ChainId uint64) (*rollup.Config, error) {
-// 	path := fmt.Sprintf("../../../rollup-configs/%d.json", l2ChainId)
-// 	rollupCfg, err := os.ReadFile(path)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to read rollup config for chain ID %d: %w", l2ChainId, err)
-// 	}
-
-// 	var config rollup.Config
-// 	err = json.Unmarshal(rollupCfg, &config)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to unmarshal rollup config for chain ID %d: %w", l2ChainId, err)
-// 	}
-
-// 	return &config, nil
-// }
 
 // GetAllSpanBatchesInBlockRange fetches span batches within a range of L2 blocks.
 func GetAllSpanBatchesInL2BlockRange(config BatchDecoderConfig) ([]SpanBatchRange, error) {

--- a/proposer/op/server/main_test.go
+++ b/proposer/op/server/main_test.go
@@ -28,7 +28,7 @@ func TestHandleSpanBatchRanges(t *testing.T) {
 		t.Fatalf("Required environment variables are not set")
 	}
 
-	// Get the L2 chain ID from the L2 RPC
+	// Get the L2 chain ID from the L2 RPC.
 	l2Client, err := ethclient.Dial(l2Rpc)
 	if err != nil {
 		t.Fatalf("Failed to connect to L2 RPC: %v", err)
@@ -37,7 +37,7 @@ func TestHandleSpanBatchRanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get chain ID: %v", err)
 	}
-	// Rollup config
+	// Load the rollup config for the given L2 chain ID.
 	rollupCfg, err := utils.LoadOPStackRollupConfigFromChainID(chainID.Uint64())
 	if err != nil {
 		t.Fatalf("Failed to get rollup config: %v", err)

--- a/proposer/op/server/main_test.go
+++ b/proposer/op/server/main_test.go
@@ -28,8 +28,17 @@ func TestHandleSpanBatchRanges(t *testing.T) {
 		t.Fatalf("Required environment variables are not set")
 	}
 
+	// Get the L2 chain ID from the L2 RPC
+	l2Client, err := ethclient.Dial(l2Rpc)
+	if err != nil {
+		t.Fatalf("Failed to connect to L2 RPC: %v", err)
+	}
+	chainID, err := l2Client.ChainID(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get chain ID: %v", err)
+	}
 	// Rollup config
-	rollupCfg, err := utils.GetRollupConfigFromL2Rpc(l2Rpc)
+	rollupCfg, err := utils.LoadOPStackRollupConfigFromChainID(chainID.Uint64())
 	if err != nil {
 		t.Fatalf("Failed to get rollup config: %v", err)
 	}

--- a/scripts/prove/bin/cost_estimator.rs
+++ b/scripts/prove/bin/cost_estimator.rs
@@ -357,8 +357,6 @@ fn manage_span_batch_server_container() -> Result<()> {
     // Start the Docker container.
     let run_status = Command::new("docker")
         .args(["run", "-p", "8089:8089", "-d", "span_batch_server"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .status()?;
     if !run_status.success() {
         return Err(anyhow::anyhow!("Failed to start Docker container"));

--- a/scripts/prove/bin/cost_estimator.rs
+++ b/scripts/prove/bin/cost_estimator.rs
@@ -97,8 +97,22 @@ async fn get_span_batch_ranges_from_server(
         env::var("SPAN_BATCH_SERVER_URL").unwrap_or("http://localhost:8089".to_string());
     let query_url = format!("{}/span-batch-ranges", span_batch_server_url);
 
-    let response: SpanBatchResponse =
-        client.post(&query_url).json(&request).send().await?.json().await?;
+    let response = match client.post(&query_url).json(&request).send().await {
+        Ok(result) => {
+            let text = result.text().await.unwrap();
+            match serde_json::from_str::<SpanBatchResponse>(&text) {
+                Ok(json) => json,
+                Err(e) => {
+                    eprintln!("Error parsing JSON: {}. Response: {}", e, text);
+                    return Err(e.into());
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Error sending request: {}", e);
+            return Err(e.into());
+        }
+    };
 
     // If the response is empty, return one range with the start and end blocks.
     if response.ranges.is_none() {

--- a/utils/host/src/rollup_config.rs
+++ b/utils/host/src/rollup_config.rs
@@ -131,8 +131,7 @@ pub fn save_rollup_config(rollup_config: &RollupConfig) -> Result<()> {
 /// Read rollup config from rollup-configs/{l2_chain_id}.json in the workspace root.
 pub fn read_rollup_config(l2_chain_id: u64) -> Result<RollupConfig> {
     let workspace_root = cargo_metadata::MetadataCommand::new().exec()?.workspace_root;
-    let rollup_config_path =
-        workspace_root.join(format!("rollup-configs/{}.json", l2_chain_id));
+    let rollup_config_path = workspace_root.join(format!("rollup-configs/{}.json", l2_chain_id));
     let rollup_config_str = fs::read_to_string(rollup_config_path)?;
     let rollup_config: RollupConfig = serde_json::from_str(&rollup_config_str)?;
     Ok(rollup_config)

--- a/utils/host/src/witnessgen.rs
+++ b/utils/host/src/witnessgen.rs
@@ -14,6 +14,11 @@ pub fn convert_host_cli_to_args(host_cli: &HostCli) -> Vec<String> {
         format!("--l2-block-number={}", host_cli.l2_block_number),
         format!("--l2-chain-id={}", host_cli.l2_chain_id),
     ];
+    // The verbosity should be passed as -v, -vv, -vvv, etc.
+    if host_cli.v > 0 {
+        args.push(format!("-{}", "v".repeat(host_cli.v as usize)));
+    }
+
     if let Some(addr) = &host_cli.l2_node_address {
         args.push("--l2-node-address".to_string());
         args.push(addr.to_string());
@@ -45,7 +50,7 @@ pub fn convert_host_cli_to_args(host_cli: &HostCli) -> Vec<String> {
 }
 
 /// Default timeout for witness generation.
-pub const WITNESSGEN_TIMEOUT: Duration = Duration::from_secs(120);
+pub const WITNESSGEN_TIMEOUT: Duration = Duration::from_secs(1000);
 
 struct WitnessGenProcess {
     child: tokio::process::Child,


### PR DESCRIPTION
## Overview
Load the OP Stack rollup config in the batch decoder. If the span batch decoding fails, just return a single range.

## Misc
- Add cycle tracking for repeated block derivation. Occurs when processing multiple span batches in the same proof.
- Parse the Rust rollup config from Go.
- Pass in the verbosity flag to the `native-host-runner`.