### PR TITLE
wip: throw error if no blobs

### DIFF
--- a/scripts/prove/build.rs
+++ b/scripts/prove/build.rs
@@ -61,7 +61,7 @@ fn main() {
         // Note: Don't comment this out, because the Docker program depends on the native program
         // for range being built.
         build_native_program(program);
-        build_zkvm_program(program);
+        // build_zkvm_program(program);
     }
 
     // build_zkvm_program("aggregation");

--- a/scripts/prove/build.rs
+++ b/scripts/prove/build.rs
@@ -61,7 +61,7 @@ fn main() {
         // Note: Don't comment this out, because the Docker program depends on the native program
         // for range being built.
         build_native_program(program);
-        // build_zkvm_program(program);
+        build_zkvm_program(program);
     }
 
     // build_zkvm_program("aggregation");

--- a/utils/client/src/oracle/mod.rs
+++ b/utils/client/src/oracle/mod.rs
@@ -140,6 +140,12 @@ impl InMemoryOracle {
         }
 
         println!("cycle-tracker-report-start: blob-verification");
+        // If there are no blobs, throw an error. Indicates that the blobs were not passed in, this occurs if the block is too recent.
+        // TODO: Look into why blobs are not being fetched for recent blocks.
+        if blobs.is_empty() {
+            return Err(anyhow!("No blobs found in oracle. This may be because the block is too recent."));
+        }
+
         let commitments: Vec<Bytes48> =
             blobs.keys().cloned().map(|blob| Bytes48::from_slice(&blob.0).unwrap()).collect_vec();
         let kzg_proofs: Vec<Bytes48> = blobs


### PR DESCRIPTION
For recent blocks, the `L1BlobProvider` won't have blobs.

Figure out how to retrieve the blobs.