### PR TITLE
feat: db path indexed by chain id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
     depends_on:
       - op-succinct-server
     volumes:
-      - ./db:/usr/local/bin/dbdata/
+      - ./db:/usr/local/bin/dbdata

--- a/proposer/op/op_proposer.sh
+++ b/proposer/op/op_proposer.sh
@@ -13,7 +13,7 @@
     --l1-eth-rpc=${L1_RPC} \
     --beacon-rpc=${L1_BEACON_RPC} \
     --max-concurrent-proof-requests=${MAX_CONCURRENT_PROOF_REQUESTS:-10} \
-    --db-path=${DB_PATH:-/usr/local/bin/dbdata/proofs.db} \
+    --db-path=${DB_PATH:-/usr/local/bin/dbdata} \
     --op-succinct-server-url=${OP_SUCCINCT_SERVER_URL:-http://op-succinct-server:3000} \
     --max-block-range-per-span-proof=${MAX_BLOCK_RANGE_PER_SPAN_PROOF:-20} \
     --use-cached-db=${USE_CACHED_DB:-false}

--- a/proposer/op/proposer/config.go
+++ b/proposer/op/proposer/config.go
@@ -2,7 +2,9 @@ package proposer
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"path/filepath"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -142,6 +144,9 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		log.Fatal(err)
 	}
 
+	dbPath := ctx.String(flags.DbPathFlag.Name)
+	dbPath = filepath.Join(dbPath, fmt.Sprintf("%d", rollupConfig.L2ChainID.Uint64()), "proofs.db")
+
 	return &CLIConfig{
 		// Required Flags
 		L1EthRpc:     ctx.String(flags.L1EthRpcFlag.Name),
@@ -164,7 +169,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		DisputeGameType:              uint32(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
 		ActiveSequencerCheckDuration: ctx.Duration(flags.ActiveSequencerCheckDurationFlag.Name),
 		WaitNodeSync:                 ctx.Bool(flags.WaitNodeSyncFlag.Name),
-		DbPath:                       ctx.String(flags.DbPathFlag.Name),
+		DbPath:                       dbPath,
 		UseCachedDb:                  ctx.Bool(flags.UseCachedDbFlag.Name),
 		MaxSpanBatchDeviation:        ctx.Uint64(flags.MaxSpanBatchDeviationFlag.Name),
 		MaxBlockRangePerSpanProof:    ctx.Uint64(flags.MaxBlockRangePerSpanProofFlag.Name),

--- a/proposer/op/proposer/flags/flags.go
+++ b/proposer/op/proposer/flags/flags.go
@@ -92,8 +92,8 @@ var (
 	}
 	DbPathFlag = &cli.StringFlag{
 		Name:    "db-path",
-		Usage:   "Path to the database used to track OP Succinct proof generation",
-		Value:   "./op-proposer/proofs.db",
+		Usage:   "Path to the database folder used to track OP Succinct proof generation. The DB file is always stored at DbPathFlag/{chain_id}/proofs.db",
+		Value:   "./op-proposer",
 		EnvVars: prefixEnvVars("DB_PATH"),
 	}
 	UseCachedDbFlag = &cli.BoolFlag{


### PR DESCRIPTION
Configure the DB path to be indexed by chain ID so multiple proposers can be run on the same machine.

Changes `dbPathFlag` to point to a directory rather than a file.