### PR TITLE
feat: Use `optimism_safeHeadAtL1Block` if available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,6 +4213,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-rpc-types"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547d29c5ab957ff32e14edddb93652dad748d2ef6cbe4b0fe8615ce06b0a3ddb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives 0.8.5",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "op-alloy-consensus",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4273,6 +4290,7 @@ dependencies = [
  "kona-primitives",
  "num-format",
  "op-alloy-genesis",
+ "op-alloy-rpc-types",
  "op-succinct-client-utils",
  "reqwest 0.12.8",
  "rkyv 0.7.45",
@@ -6526,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=tamir/v1.3.0-rc2#a8db6b19673ed7f5bf7007faff1d2ef177713e3b"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=tamir/v1.3.0-rc2#dcd99a39ddc33bc8d2867a6d4c59bf5a22080dbd"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ alloy-sol-types = { version = "0.8" }
 op-alloy-consensus = { version = "0.3.3", default-features = false }
 op-alloy-genesis = { version = "0.3.3", default-features = false }
 op-alloy-protocol = { version = "0.3.3", default-features = false }
+op-alloy-rpc-types = { version = "0.3.3", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.3.3", default-features = false }
 
 # sp1

--- a/book/getting-started/prerequisites.md
+++ b/book/getting-started/prerequisites.md
@@ -20,7 +20,7 @@ The following RPC endpoints must be accessible:
 - L2 Execution Node (`op-geth`): Archive node with hash state scheme.
   - `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_getExecutionWitness`, `debug_dbGet`
 - L2 Optimism Node (`op-node`)
-  - `optimism_outputAtBlock`, `optimism_rollupConfig`, `optimism_syncStatus`
+  - `optimism_outputAtBlock`, `optimism_rollupConfig`, `optimism_syncStatus`, `optimism_safeHeadAtL1Block`.
 
 If you do not have access to an L2 OP Geth node + rollup node for your OP Stack chain, you can follow the [L2 node setup instructions](../node-setup.md) to spin them up.
 

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -31,6 +31,7 @@ op-succinct-client-utils.workspace = true
 
 # op-alloy
 op-alloy-genesis.workspace = true
+op-alloy-rpc-types.workspace = true
 
 # kona
 kona-host.workspace = true

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -576,7 +576,7 @@ impl OPSuccinctDataFetcher {
         let result = self.get_l1_head_with_safe_head(l2_end_block).await;
 
         if let Ok(safe_head_at_l1_block) = result {
-            return Ok(safe_head_at_l1_block);
+            Ok(safe_head_at_l1_block)
         } else {
             // Estimate the L1 block necessary based on the chain config. This is based on the maximum
             // delay between batches being posted on the L2 chain.
@@ -594,17 +594,19 @@ impl OPSuccinctDataFetcher {
                 .timestamp;
 
             let target_timestamp = l2_block_timestamp + (max_batch_post_delay_minutes * 60);
-            return Ok(self
+            Ok(self
                 .find_block_hash_by_timestamp(RPCMode::L1, target_timestamp)
-                .await?);
+                .await?)
         }
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::fetcher::{OPSuccinctDataFetcher, RPCMode};
 
     #[tokio::test]
+    #[cfg(test)]
     async fn test_get_l1_head() {
         dotenv::dotenv().ok();
         let fetcher = OPSuccinctDataFetcher::new().await;


### PR DESCRIPTION
If the `optimism_safeHeadAtL1Block` method is available, use it to fetch the `l1Head`. If it's not available, or it can't be used to find the `l1Head`, default to the max delay from which a batcher can post.