### PR TITLE
chore: error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,10 @@ execution-reports/
 **/rollup-config.json
 
 # DB
-db/*
+db
+
+# Stdins
+stdins
 
 **/bin/op-proposer
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,7 @@ dependencies = [
  "futures",
  "kona-host",
  "kona-primitives",
+ "log",
  "num-format",
  "op-alloy-genesis",
  "op-alloy-rpc-types",

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -22,6 +22,7 @@ futures.workspace = true
 num-format.workspace = true
 serde.workspace = true
 reqwest.workspace = true
+log.workspace = true
 
 # sp1
 sp1-sdk.workspace = true


### PR DESCRIPTION
Include the end block when a witness generation process fails.