### PR TITLE
feat(cycle-tracking): `secp256r1`

### DIFF
--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -261,6 +261,7 @@ fn aggregate_execution_stats(
         aggregate_stats.bn_mul_cycles += stats.bn_mul_cycles;
         aggregate_stats.kzg_eval_cycles += stats.kzg_eval_cycles;
         aggregate_stats.ec_recover_cycles += stats.ec_recover_cycles;
+        aggregate_stats.secp256r1_verify_cycles += stats.secp256r1_verify_cycles;
     }
 
     // For statistics that are per-block or per-transaction, we take the average over the entire

--- a/utils/client/src/precompiles/mod.rs
+++ b/utils/client/src/precompiles/mod.rs
@@ -44,6 +44,8 @@ pub(crate) const ANNOTATED_KZG_EVAL: PrecompileWithAddress = create_annotated_pr
 );
 pub(crate) const ANNOTATED_EC_RECOVER: PrecompileWithAddress =
     create_annotated_precompile!(revm::precompile::secp256k1::ECRECOVER, "ec-recover");
+pub(crate) const ANNOTATED_SECP256R1_VERIFY: PrecompileWithAddress =
+    create_annotated_precompile!(secp256r1::P256VERIFY, "secp256r1-verify");
 
 // Source: https://github.com/anton-rs/kona/blob/main/bin/client/src/fault/handler/mod.rs#L20-L42
 pub fn zkvm_handle_register<F, H>(handler: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>)
@@ -69,6 +71,7 @@ where
             ANNOTATED_BN_PAIR,
             ANNOTATED_KZG_EVAL,
             ANNOTATED_EC_RECOVER,
+            ANNOTATED_SECP256R1_VERIFY,
         ];
         ctx_precompiles.extend(override_precompiles);
 

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -33,6 +33,7 @@ pub struct ExecutionStats {
     pub bn_mul_cycles: u64,
     pub kzg_eval_cycles: u64,
     pub ec_recover_cycles: u64,
+    pub secp256r1_verify_cycles: u64,
 }
 
 /// Write a statistic to the formatter.
@@ -99,6 +100,7 @@ impl fmt::Display for ExecutionStats {
         write_stat(f, "BN Mul Cycles", self.bn_mul_cycles)?;
         write_stat(f, "KZG Eval Cycles", self.kzg_eval_cycles)?;
         write_stat(f, "EC Recover Cycles", self.ec_recover_cycles)?;
+        write_stat(f, "Secp256r1 Verify Cycles", self.secp256r1_verify_cycles)?;
         writeln!(
             f,
             "+--------------------------------+---------------------------+"
@@ -141,6 +143,7 @@ impl ExecutionStats {
         self.bn_pair_cycles = get_cycles("precompile-bn-pair");
         self.kzg_eval_cycles = get_cycles("precompile-kzg-eval");
         self.ec_recover_cycles = get_cycles("precompile-ec-recover");
+        self.secp256r1_verify_cycles = get_cycles("precompile-secp256r1-verify");
         self.total_sp1_gas = report.estimate_gas();
     }
 
@@ -185,6 +188,7 @@ pub struct SpanBatchStats {
     pub bn_pair_cycles: u64,
     pub kzg_eval_cycles: u64,
     pub ec_recover_cycles: u64,
+    pub secp256r1_verify_cycles: u64,
 }
 
 impl fmt::Display for SpanBatchStats {
@@ -221,6 +225,7 @@ impl fmt::Display for SpanBatchStats {
         write_stat(f, "BN Pair Cycles", self.bn_pair_cycles)?;
         write_stat(f, "KZG Eval Cycles", self.kzg_eval_cycles)?;
         write_stat(f, "EC Recover Cycles", self.ec_recover_cycles)?;
+        write_stat(f, "Secp256r1 Verify Cycles", self.secp256r1_verify_cycles)?;
         writeln!(
             f,
             "+-------------------------------+---------------------------+"


### PR DESCRIPTION
Add support for tracking the performance of `secp256r1` precompiles.

TODO: Update `signatures` patch to point to @umadayal's `secp256r1` branch here: https://github.com/sp1-patches/signatures/tree/umadayal/secp256r1