### PR TITLE
feat: downgrade `kona`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecdsa"
 version = "0.16.8"
-source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.8#aad9626d51e830729969220eee44de082ff97d53"
+source = "git+https://github.com/sp1-patches/signatures?branch=ratan/secp256k1-add-fixes-v0.16.8#cdeab4f0ed0d715ceae3fc6d09d16ec3ae41ead7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2096,7 +2096,7 @@ dependencies = [
  "hex-literal",
  "rfc6979",
  "signature",
- "sp1-lib 3.0.0",
+ "sp1-lib 3.0.0-rc3",
  "spki",
 ]
 
@@ -5547,7 +5547,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.8#aad9626d51e830729969220eee44de082ff97d53"
+source = "git+https://github.com/sp1-patches/signatures?branch=ratan/secp256k1-add-fixes-v0.16.8#cdeab4f0ed0d715ceae3fc6d09d16ec3ae41ead7"
 dependencies = [
  "hmac",
  "subtle",
@@ -6432,6 +6432,15 @@ dependencies = [
  "hex",
  "serde",
  "snowbridge-amcl",
+]
+
+[[package]]
+name = "sp1-lib"
+version = "3.0.0-rc3"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=tamir/v1.3.0-rc2#d900b661e552c4cb87cd6dee56bee73d809fb426"
+dependencies = [
+ "bincode",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,6 +4320,7 @@ dependencies = [
  "op-succinct-client-utils",
  "op-succinct-host-utils",
  "rayon",
+ "reqwest 0.12.8",
  "serde",
  "serde_json",
  "sp1-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
  "op-succinct-client-utils",
  "serde_cbor",
  "sha2",
- "sp1-lib 3.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 3.0.0",
  "sp1-zkvm",
 ]
 
@@ -1194,6 +1194,24 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1202,7 +1220,6 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.79",
- "which",
 ]
 
 [[package]]
@@ -2069,7 +2086,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecdsa"
 version = "0.16.8"
-source = "git+https://github.com/sp1-patches/signatures?branch=ratan/secp256k1-add-fixes-v0.16.8#cdeab4f0ed0d715ceae3fc6d09d16ec3ae41ead7"
+source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.8#aad9626d51e830729969220eee44de082ff97d53"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2079,7 +2096,7 @@ dependencies = [
  "hex-literal",
  "rfc6979",
  "signature",
- "sp1-lib 3.0.0-rc3 (git+https://github.com/succinctlabs/sp1.git?branch=tamir/v1.3.0-rc2)",
+ "sp1-lib 3.0.0",
  "spki",
 ]
 
@@ -2969,15 +2986,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,7 +3716,7 @@ version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "bzip2-sys",
  "cc",
  "glob",
@@ -5537,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures?branch=ratan/secp256k1-add-fixes-v0.16.8#cdeab4f0ed0d715ceae3fc6d09d16ec3ae41ead7"
+source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.8#aad9626d51e830729969220eee44de082ff97d53"
 dependencies = [
  "hmac",
  "subtle",
@@ -6272,9 +6280,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385fe10d8952ca911d2e4f2a849b4e48f6039b758f3b8100a2c5e653b2d51ce4"
+checksum = "8929a4197b02537dbcd16a078e9424d40985438091df64a9373ebd10e5557083"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6285,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcf4d12fdcdb59632dbb8491e9f1ed5090de774b46cb5ef26ce5fcd4d024e3e"
+checksum = "1ff9718f87f207404aee3f447c4438e2a35791092dc24ce65ff95db699ed49c1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6319,9 +6327,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6f7b232d011a2db7a314d53ee37ef79e60c2e282e4c249c9b91041e4ff88ec"
+checksum = "7ac8b5f2cecb7b2174495fc7a3e004bdb78e1c7ea44577ac0acc0d1e90b817ea"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6367,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c2c7fb1a24a9dcd06ffc26c4377056163cba55d47b973b19eec81442217f57"
+checksum = "f1af9ff15e524ebe58286d7ee9bc345657b45b13091b5dc58fdce61542b65a47"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -6389,9 +6397,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c88b3e7ead9192679bf2ef5b0c28b6e7b9a56f929bd76851820e5e5b947bb"
+checksum = "5f1490c07bd283f59169eae6e67df355b5de8ba10cc75bf6dbfc05a28fdccfc6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6426,18 +6434,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5835b93e7be1840ac075bf16ddc9235a7be122e2209cf3ad3e1cb0f50353f8"
-dependencies = [
- "bincode",
- "serde",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "3.0.0-rc3"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=tamir/v1.3.0-rc2#d900b661e552c4cb87cd6dee56bee73d809fb426"
+checksum = "9c372b16988e765af85ccf958b18b26d89c05886f2592d313a285415dcc769cb"
 dependencies = [
  "bincode",
  "serde",
@@ -6445,9 +6444,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2567220b2d8170a0c42eba514dec66b76c5c87927c9a3232ee53a56310acee72"
+checksum = "025f06b633588e246308ad5f67b32f0f7d1cbeab38f7a842314699270bc706f5"
 dependencies = [
  "bincode",
  "hex",
@@ -6463,9 +6462,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb59f305b4768a441049f46bc52e0d1edfd2d3179d65a3440f7396baa74e1bda"
+checksum = "1bd16530cb12f1cecb1b6902142d8d0d87507f88de84bc714f10c29a7fd3769c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6505,9 +6504,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08f45e8fa3caf412251a730cdad04b36285e745a6c1b409d865bae3338a5196"
+checksum = "98d0a8ceee12600bd14d2e2d31b54db00b7985e30acedbfe8e1c1a9e41d7992f"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6539,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648941453ab9e8c69386df5cd660dedabe4d06c041450d8a2548ba6cefa6ed45"
+checksum = "591d60768948dcef34a1fc16c3c6cf457e32fdee83d55ec14dbb94cd4447c030"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6561,9 +6560,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf8c5dc0a2c33ef1dc7da7a137574e4f1783e45489681ca01aa3309abc6adee"
+checksum = "85c15a51b675accb41608f7bf7ef5f95c23b47ceac38a9a87833a2b12c3bc190"
 dependencies = [
  "backtrace",
  "ff 0.13.0",
@@ -6597,9 +6596,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7807dc1a72bb7b86f2e82c414cb58b9789d880ca459b2113f7406df814945ae"
+checksum = "c5b2aaa03093afb2b0f58379bb4f0d7898344ef1bb8dd326ec02db7125c1a590"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6607,13 +6606,13 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff667dda92cbe2f9382e36fe222641f60a4e794e0a3b6c7597cd6a74d79262d"
+checksum = "1a12889c662cf64870e72bb3ba8096f3465bf442f5f179c07b50c86f5c47ce80"
 dependencies = [
  "anyhow",
  "bincode",
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "cfg-if",
  "hex",
@@ -6633,9 +6632,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9a960e85019f30d96a2269bb2faa4982fbc0af784bc7c5998ae5d8ee2ea033"
+checksum = "39bab15e962d1218e8ad021b2e9904597d5506d12847ef8be182385d5f3d3a6c"
 dependencies = [
  "alloy-sol-types 0.7.7",
  "anyhow",
@@ -6674,9 +6673,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8706930d1d65aa645d194b175f6c4c0f47ac7833640b4f46cf4da5964d2d1d"
+checksum = "ec27b60e797a52eed7af54e032498edcaf8f1ab0649077cbaa6f146a740380dd"
 dependencies = [
  "arrayref",
  "getrandom",
@@ -6710,9 +6709,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "3.0.0-rc3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c61090e56fa9f05e38295d39cb74e49391da007a05cc2f92681d7179776f7d"
+checksum = "ce08dc324dade0709260b01c76c8eeb665f2ef7c652c2002e2edf5a492ded7f1"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -6722,7 +6721,7 @@ dependencies = [
  "p3-field",
  "rand",
  "sha2",
- "sp1-lib 3.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 3.0.0",
  "sp1-primitives",
 ]
 
@@ -7710,18 +7709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "kona-common"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "cfg-if",
  "linked_list_allocator",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "kona-common-proc"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3473,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.0.2"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.8",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-primitives 0.8.8",
  "async-trait",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "kona-primitives"
 version = "0.0.2"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.8",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "kona-providers"
 version = "0.0.1"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.8",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.0.1"
-source = "git+https://github.com/moongate-forks/kona?branch=ratan/native-client-command-bugged#4be3cb46d530b1637465167c6a6a661ff0b9466c"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,6 +4268,7 @@ dependencies = [
 name = "op-succinct-proposer"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-primitives 0.8.8",
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,10 @@ op-alloy-rpc-types = { version = "0.4.0", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.4.0", default-features = false }
 
 # sp1
-sp1-lib = { version = "3.0.0", features = ["verify"] }
-sp1-zkvm = { version = "3.0.0", features = ["verify"] }
-sp1-sdk = { version = "3.0.0" }
-sp1-build = { version = "3.0.0" }
+sp1-lib = { version = "3.0.0-rc3", features = ["verify"] }
+sp1-zkvm = { version = "3.0.0-rc3", features = ["verify"] }
+sp1-sdk = { version = "3.0.0-rc3" }
+sp1-build = { version = "3.0.0-rc3" }
 
 [profile.release-client-lto]
 inherits = "release"
@@ -93,6 +93,7 @@ lto = "fat"
 [patch.crates-io]
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
-ecdsa = { git = "https://github.com/sp1-patches/signatures", branch = "patch-ecdsa-v0.16.8" }
+# TODO: Update this to patch-ecdsa-v0.16.8 when updating SP1 to v3.0.0.
+ecdsa = { git = "https://github.com/sp1-patches/signatures", branch = "ratan/secp256k1-add-fixes-v0.16.8" }
 bn = { git = "https://github.com/0xWOLAND/bn.git", package = "substrate-bn" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", branch = "patch-sha3-v0.10.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,10 @@ op-alloy-rpc-types = { version = "0.4.0", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.4.0", default-features = false }
 
 # sp1
-sp1-lib = { version = "3.0.0-rc3", features = ["verify"] }
-sp1-zkvm = { version = "3.0.0-rc3", features = ["verify"] }
-sp1-sdk = { version = "3.0.0-rc3" }
-sp1-build = { version = "3.0.0-rc3" }
+sp1-lib = { version = "3.0.0", features = ["verify"] }
+sp1-zkvm = { version = "3.0.0", features = ["verify"] }
+sp1-sdk = { version = "3.0.0" }
+sp1-build = { version = "3.0.0" }
 
 [profile.release-client-lto]
 inherits = "release"
@@ -93,7 +93,6 @@ lto = "fat"
 [patch.crates-io]
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
-# TODO: Change this back to the original patch branch once the changes to sp1-lib to fix secp256k1 addition have been merged and a stable version tag is released.
-ecdsa = { git = "https://github.com/sp1-patches/signatures", branch = "ratan/secp256k1-add-fixes-v0.16.8" }
+ecdsa = { git = "https://github.com/sp1-patches/signatures", branch = "patch-ecdsa-v0.16.8" }
 bn = { git = "https://github.com/0xWOLAND/bn.git", package = "substrate-bn" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", branch = "patch-sha3-v0.10.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,17 +38,17 @@ kzg-rs = { version = "0.2.2" }
 
 # kona
 # Note: Switch to latest version of kona once the std::process::Command issue is resolved.
-kona-common = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
-kona-common-proc = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
-kona-preimage = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged", features = [
+kona-common = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-common-proc = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-preimage = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", features = [
     "rkyv",
 ] }
-kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
-kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
-kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged", default-features = false }
-kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
-kona-client = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
-kona-host = { git = "https://github.com/moongate-forks/kona", branch = "ratan/native-client-command-bugged" }
+kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", default-features = false }
+kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/book/getting-started/configuration.md
+++ b/book/getting-started/configuration.md
@@ -2,7 +2,7 @@
 
 The last step is to update your OP Stack configuration to use the new `OPSuccinctL2OutputOracle` contract managed by the `op-succinct-proposer` service.
 
-> ⚠️ **Warning**: All proposed, non-finalized output roots on the `L2OutputOracleProxy` will be automatically finalized after the upgrade to `op-succinct`, as the `finalizationPeriod` is set to 0 by default. For security, we recommend ensuring that all old proposer output roots are correct before upgrading.
+> ⚠️ **Caution**: When upgrading to the `OPSuccinctL2OutputOracle` contract, maintain the existing `finalizationPeriod` for a duration equal to at least one `finalizationPeriod`. Failure to do so will result in immediate finalization of all pending output roots upon upgrade, which is unsafe. Only after this waiting period has elapsed should you set the `finalizationPeriod` to 0.
 
 ## Self-Managed OP Stack Chains
 

--- a/configs/13269/rollup.json
+++ b/configs/13269/rollup.json
@@ -10,7 +10,7 @@
     },
     "l2_time": 1723487352,
     "system_config": {
-      "batcherAddr": "0x6322c47FEE60e15FC1B7ba65f1cfd66201E4c61d",
+      "batcherAddr": "0x6322c47fee60e15fc1b7ba65f1cfd66201e4c61d",
       "overhead": "0xbc",
       "scalar": "0xa6fe0",
       "gasLimit": 30000000,
@@ -41,8 +41,8 @@
   "ecotone_time": 0,
   "fjord_time": 0,
   "granite_time": 1725984001,
-  "batch_inbox_address": "0x136B12DB1FbaC1d6Aa6D0a1D2b724892c6FbA921",
-  "deposit_contract_address": "0x16839f9F6a11195A72B88744336EDFf036e7B3d5",
-  "l1_system_config_address": "0x19145e3aEe49C40D9f499F705F25ac1eA7409834",
+  "batch_inbox_address": "0x136b12db1fbac1d6aa6d0a1d2b724892c6fba921",
+  "deposit_contract_address": "0x16839f9f6a11195a72b88744336edff036e7b3d5",
+  "l1_system_config_address": "0x19145e3aee49c40d9f499f705f25ac1ea7409834",
   "protocol_versions_address": "0x0000000000000000000000000000000000000000"
 }

--- a/configs/15107/rollup.json
+++ b/configs/15107/rollup.json
@@ -1,0 +1,47 @@
+{
+  "genesis": {
+    "l1": {
+      "number": 6810323,
+      "hash": "0xe3d1b1463dc367692b66172f41b5afacfa83b3d74daad8d44d4f3b98026d9b08"
+    },
+    "l2": {
+      "number": 0,
+      "hash": "0x4103a20d40c65c102dbab5cc86b8f313d1467d4bc44a67730a68e88a001ed528"
+    },
+    "l2_time": 1728005724,
+    "system_config": {
+      "batcherAddr": "0x619989c355ae587f202c3d9a280526ab6dd8895a",
+      "overhead": "0xbc",
+      "scalar": "0x10b30",
+      "gasLimit": 30000000,
+      "baseFeeScalar": null,
+      "blobBaseFeeScalar": null,
+      "eip1559Denominator": null,
+      "eip1559Elasticity": null
+    }
+  },
+  "block_time": 10,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "granite_channel_timeout": 50,
+  "l1_chain_id": 11155111,
+  "l2_chain_id": 15107,
+  "base_fee_params": {
+    "max_change_denominator": "0x32",
+    "elasticity_multiplier": "0x6"
+  },
+  "canyon_base_fee_params": {
+    "max_change_denominator": "0xfa",
+    "elasticity_multiplier": "0x6"
+  },
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 0,
+  "batch_inbox_address": "0x49290eb79886449325c3647b9d29f59d0f03ab54",
+  "deposit_contract_address": "0xe57867e254bc69beb7614f0375be7dbd9a098974",
+  "l1_system_config_address": "0xd3207b99c3aa2d4fb455d4d81b37132008262672",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ run-multi start end use-cache="false" prove="false":
 # Runs the cost estimator for a given block range.
 cost-estimator start end:
   #!/usr/bin/env bash
-  cargo run --bin cost_estimator --release -- --start {{start}} --end {{end}}
+  cargo run --bin cost-estimator --release -- --start {{start}} --end {{end}}
 
 # Runs the client program in native execution mode. Modified version of Kona Native Client execution:
 # https://github.com/ethereum-optimism/kona/blob/ae71b9df103c941c06b0dc5400223c4f13fe5717/bin/client/justfile#L65-L108

--- a/proposer/op/proposer/driver.go
+++ b/proposer/op/proposer/driver.go
@@ -175,6 +175,13 @@ func (l *L2OutputSubmitter) StartL2OutputSubmitting() error {
 		}
 	}
 
+	// Validate the contract's configuration of the aggregation and range verification keys as well
+	// as the rollup config hash.
+	err = l.ValidateConfig(l.Cfg.L2OutputOracleAddr.Hex())
+	if err != nil {
+		return fmt.Errorf("failed to validate config: %w", err)
+	}
+
 	l.wg.Add(1)
 	go l.loop()
 

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -1,0 +1,30 @@
+package proposer
+
+type SpanProofRequest struct {
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+}
+
+type AggProofRequest struct {
+	Subproofs [][]byte `json:"subproofs"`
+	L1Head    string   `json:"head"`
+}
+
+type ValidateConfigRequest struct {
+	Address string `json:"address"`
+}
+
+type ValidateConfigResponse struct {
+	RollupConfigHashValid bool `json:"rollup_config_hash_valid"`
+	AggVkeyValid          bool `json:"agg_vkey_valid"`
+	RangeVkeyValid        bool `json:"range_vkey_valid"`
+}
+
+type ProofResponse struct {
+	ProofID string `json:"proof_id"`
+}
+
+type ProofStatus struct {
+	Status string `json:"status"`
+	Proof  []byte `json:"proof"`
+}

--- a/proposer/succinct/Cargo.toml
+++ b/proposer/succinct/Cargo.toml
@@ -16,6 +16,7 @@ path = "bin/server.rs"
 # workspace
 tokio = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy = { workspace = true }
 
 # local
 op-succinct-host-utils.workspace = true

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -1,0 +1,66 @@
+use alloy_primitives::B256;
+use base64::{engine::general_purpose, Engine as _};
+use serde::{Deserialize, Deserializer, Serialize};
+use sp1_sdk::SP1VerifyingKey;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidateConfigRequest {
+    pub address: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidateConfigResponse {
+    pub rollup_config_hash_valid: bool,
+    pub agg_vkey_valid: bool,
+    pub range_vkey_valid: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SpanProofRequest {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct AggProofRequest {
+    #[serde(deserialize_with = "deserialize_base64_vec")]
+    pub subproofs: Vec<Vec<u8>>,
+    pub head: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProofResponse {
+    pub proof_id: String,
+}
+
+#[derive(Serialize)]
+pub struct ProofStatus {
+    pub status: String,
+    pub proof: Vec<u8>,
+}
+
+/// Configuration of the L2 Output Oracle contract. Created once at server start-up, monitors if there are any changes
+/// to the contract's configuration.
+#[derive(Clone)]
+pub struct ContractConfig {
+    pub range_vk: SP1VerifyingKey,
+    pub agg_vkey_hash: B256,
+    pub range_vkey_commitment: B256,
+    pub rollup_config_hash: B256,
+}
+
+/// Deserialize a vector of base64 strings into a vector of vectors of bytes. Go serializes
+/// the subproofs as base64 strings.
+fn deserialize_base64_vec<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Vec<String> = Deserialize::deserialize(deserializer)?;
+    s.into_iter()
+        .map(|base64_str| {
+            general_purpose::STANDARD
+                .decode(base64_str)
+                .map_err(serde::de::Error::custom)
+        })
+        .collect()
+}

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -34,14 +34,21 @@ struct Args {
     /// Generate proof.
     #[arg(short, long)]
     prove: bool,
+
+    /// Env file.
+    #[arg(short, long, default_value = ".env")]
+    env_file: Option<String>,
 }
 
 /// Execute the OP Succinct program for multiple blocks.
 #[tokio::main]
 async fn main() -> Result<()> {
-    dotenv::dotenv().ok();
-    utils::setup_logger();
     let args = Args::parse();
+
+    if let Some(env_file) = args.env_file {
+        dotenv::from_filename(env_file).ok();
+    }
+    utils::setup_logger();
 
     let data_fetcher = OPSuccinctDataFetcher::default();
 

--- a/scripts/prove/build.rs
+++ b/scripts/prove/build.rs
@@ -59,7 +59,7 @@ fn build_zkvm_program(program: &str) {
         &format!("../../programs/{}", program),
         BuildArgs {
             elf_name: format!("{}-elf", program),
-            // docker: true,
+            docker: true,
             ..Default::default()
         },
     );

--- a/scripts/utils/Cargo.toml
+++ b/scripts/utils/Cargo.toml
@@ -8,15 +8,19 @@ repository.workspace = true
 homepage.workspace = true
 
 [[bin]]
-name = "fetch_and_save_proof"
+name = "fetch-and-save-proof"
 path = "bin/fetch_and_save_proof.rs"
+
+[[bin]]
+name = "update-vkeys"
+path = "bin/update_vkeys.rs"
 
 [[bin]]
 name = "vkey"
 path = "bin/vkey.rs"
 
 [[bin]]
-name = "cost_estimator"
+name = "cost-estimator"
 path = "bin/cost_estimator.rs"
 
 [[bin]]
@@ -36,6 +40,7 @@ dotenv.workspace = true
 log.workspace = true
 csv.workspace = true
 serde = { workspace = true }
+reqwest = { workspace = true }
 futures.workspace = true
 rayon = "1.10.0"
 serde_json.workspace = true

--- a/scripts/utils/bin/update_vkeys.rs
+++ b/scripts/utils/bin/update_vkeys.rs
@@ -5,11 +5,10 @@ use std::time::Duration;
 use alloy::network::EthereumWallet;
 use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
-use alloy::sol;
 use alloy_primitives::{Address, B256};
 use anyhow::Result;
 use op_succinct_client_utils::types::u32_to_u8;
-use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
+use op_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, L2OutputOracle};
 use reqwest::Url;
 use sp1_sdk::{utils, HashableKey, ProverClient};
 
@@ -24,19 +23,6 @@ struct Args {
     /// Contract address to check the vkey against.
     #[arg(short, long, required = false, value_delimiter = ',')]
     contract_addresses: Vec<String>,
-}
-
-sol! {
-    #[allow(missing_docs)]
-    #[sol(rpc)]
-    contract L2OutputOracle {
-        bytes32 public aggregationVkey;
-        bytes32 public rangeVkeyCommitment;
-
-        function updateAggregationVKey(bytes32 _aggregationVKey) external onlyOwner;
-
-        function updateRangeVkeyCommitment(bytes32 _rangeVkeyCommitment) external onlyOwner;
-    }
 }
 
 // Get the verification keys for the ELFs and check them against the contract.

--- a/scripts/utils/bin/update_vkeys.rs
+++ b/scripts/utils/bin/update_vkeys.rs
@@ -1,0 +1,116 @@
+use std::env;
+use std::str::FromStr;
+use std::time::Duration;
+
+use alloy::network::EthereumWallet;
+use alloy::providers::ProviderBuilder;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::sol;
+use alloy_primitives::{Address, B256};
+use anyhow::Result;
+use op_succinct_client_utils::types::u32_to_u8;
+use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
+use reqwest::Url;
+use sp1_sdk::{utils, HashableKey, ProverClient};
+
+pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
+pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Contract address to check the vkey against.
+    #[arg(short, long, required = false, value_delimiter = ',')]
+    contract_addresses: Vec<String>,
+}
+
+sol! {
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    contract L2OutputOracle {
+        bytes32 public aggregationVkey;
+        bytes32 public rangeVkeyCommitment;
+
+        function updateAggregationVKey(bytes32 _aggregationVKey) external onlyOwner;
+
+        function updateRangeVkeyCommitment(bytes32 _rangeVkeyCommitment) external onlyOwner;
+    }
+}
+
+// Get the verification keys for the ELFs and check them against the contract.
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+    utils::setup_logger();
+
+    let args = Args::parse();
+
+    let fetcher = OPSuccinctDataFetcher::default();
+
+    let prover = ProverClient::new();
+
+    let (_, range_vk) = prover.setup(MULTI_BLOCK_ELF);
+
+    // Get the 32 byte commitment to the vkey from vkey.vk.hash_u32()
+    let multi_block_vkey_u8 = u32_to_u8(range_vk.vk.hash_u32());
+    let multi_block_vkey_b256 = B256::from(multi_block_vkey_u8);
+    println!(
+        "Range ELF Verification Key Commitment: {}",
+        multi_block_vkey_b256
+    );
+
+    let (_, agg_vk) = prover.setup(AGG_ELF);
+    println!("Aggregation ELF Verification Key: {}", agg_vk.bytes32());
+    let agg_vkey_b256 = B256::from_str(&agg_vk.bytes32()).unwrap();
+
+    let private_key = env::var("PRIVATE_KEY").unwrap();
+    let signer: PrivateKeySigner = private_key.parse().expect("Failed to parse private key");
+    let wallet = EthereumWallet::from(signer);
+
+    let rpc_url = fetcher.rpc_config.l1_rpc;
+
+    // Wait for 3 required confirmations with a timeout of 60 seconds.
+    const NUM_CONFIRMATIONS: u64 = 3;
+    const TIMEOUT_SECONDS: u64 = 60;
+
+    for contract_address in args.contract_addresses {
+        let provider = ProviderBuilder::new()
+            .with_recommended_fillers()
+            .wallet(wallet.clone())
+            .on_http(Url::parse(&rpc_url).unwrap());
+
+        let contract_address = Address::from_str(&contract_address).unwrap();
+        let contract = L2OutputOracle::new(contract_address, provider);
+
+        let receipt = contract
+            .updateAggregationVKey(agg_vkey_b256)
+            .send()
+            .await?
+            .with_required_confirmations(NUM_CONFIRMATIONS)
+            .with_timeout(Some(Duration::from_secs(TIMEOUT_SECONDS)))
+            .get_receipt()
+            .await?;
+        println!(
+            "Updated Aggregation VKey on contract {}. Tx: {}",
+            contract_address, receipt.transaction_hash
+        );
+
+        let receipt = contract
+            .updateRangeVkeyCommitment(multi_block_vkey_b256)
+            .send()
+            .await?
+            .with_required_confirmations(NUM_CONFIRMATIONS)
+            .with_timeout(Some(Duration::from_secs(TIMEOUT_SECONDS)))
+            .get_receipt()
+            .await?;
+
+        println!(
+            "Updated Range VKey Commitment on contract {}. Tx: {}",
+            contract_address, receipt.transaction_hash
+        );
+    }
+
+    Ok(())
+}

--- a/scripts/utils/bin/update_vkeys.rs
+++ b/scripts/utils/bin/update_vkeys.rs
@@ -8,7 +8,7 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, B256};
 use anyhow::Result;
 use op_succinct_client_utils::types::u32_to_u8;
-use op_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, L2OutputOracle};
+use op_succinct_host_utils::L2OutputOracle;
 use reqwest::Url;
 use sp1_sdk::{utils, HashableKey, ProverClient};
 
@@ -33,8 +33,6 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    let fetcher = OPSuccinctDataFetcher::default();
-
     let prover = ProverClient::new();
 
     let (_, range_vk) = prover.setup(MULTI_BLOCK_ELF);
@@ -55,7 +53,7 @@ async fn main() -> Result<()> {
     let signer: PrivateKeySigner = private_key.parse().expect("Failed to parse private key");
     let wallet = EthereumWallet::from(signer);
 
-    let rpc_url = fetcher.rpc_config.l1_rpc;
+    let l1_rpc = env::var("L1_RPC").unwrap();
 
     // Wait for 3 required confirmations with a timeout of 60 seconds.
     const NUM_CONFIRMATIONS: u64 = 3;
@@ -65,7 +63,7 @@ async fn main() -> Result<()> {
         let provider = ProviderBuilder::new()
             .with_recommended_fillers()
             .wallet(wallet.clone())
-            .on_http(Url::parse(&rpc_url).unwrap());
+            .on_http(Url::parse(&l1_rpc).unwrap());
 
         let contract_address = Address::from_str(&contract_address).unwrap();
         let contract = L2OutputOracle::new(contract_address, provider);

--- a/scripts/utils/bin/vkey.rs
+++ b/scripts/utils/bin/vkey.rs
@@ -1,4 +1,3 @@
-use alloy::sol;
 use alloy_primitives::B256;
 use anyhow::Result;
 use op_succinct_client_utils::types::u32_to_u8;
@@ -6,28 +5,6 @@ use sp1_sdk::{utils, HashableKey, ProverClient};
 
 pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
 pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
-
-use clap::Parser;
-
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-struct Args {
-    /// Contract address to check the vkey against.
-    #[arg(short, long, required = false)]
-    contract_address: Option<String>,
-
-    /// RPC URL to use for the provider.
-    #[arg(short, long, required = false)]
-    rpc_url: Option<String>,
-}
-
-sol! {
-    #[allow(missing_docs)]
-    #[sol(rpc)]
-    contract L2OutputOracle {
-        bytes32 public vkey;
-    }
-}
 
 // Get the verification keys for the ELFs and check them against the contract.
 #[tokio::main]

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -7,7 +7,8 @@ edition.workspace = true
 [dependencies]
 
 # workspace
-alloy.workspace = true
+alloy = { workspace = true }
+
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -45,10 +45,10 @@ impl Default for OPSuccinctDataFetcher {
 
 #[derive(Debug, Clone)]
 pub struct RPCConfig {
-    l1_rpc: String,
-    l1_beacon_rpc: String,
-    l2_rpc: String,
-    l2_node_rpc: String,
+    pub l1_rpc: String,
+    pub l1_beacon_rpc: String,
+    pub l2_rpc: String,
+    pub l2_node_rpc: String,
 }
 
 /// The mode corresponding to the chain we are fetching data for.

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -4,6 +4,7 @@ pub mod rollup_config;
 pub mod stats;
 pub mod witnessgen;
 
+use alloy::sol;
 use alloy_consensus::Header;
 use alloy_primitives::B256;
 use kona_host::{
@@ -19,8 +20,6 @@ use std::{fs::File, io::Read};
 
 use anyhow::Result;
 
-use alloy_sol_types::sol;
-
 use rkyv::{
     ser::{
         serializers::{AlignedSerializer, CompositeSerializer, HeapScratch, SharedSerializeMap},
@@ -28,6 +27,20 @@ use rkyv::{
     },
     AlignedVec,
 };
+
+sol! {
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    contract L2OutputOracle {
+        bytes32 public aggregationVkey;
+        bytes32 public rangeVkeyCommitment;
+        bytes32 public rollupConfigHash;
+
+        function updateAggregationVKey(bytes32 _aggregationVKey) external onlyOwner;
+
+        function updateRangeVkeyCommitment(bytes32 _rangeVkeyCommitment) external onlyOwner;
+    }
+}
 
 pub enum ProgramType {
     Single,


### PR DESCRIPTION
The updated version of `kona` from https://github.com/succinctlabs/op-succinct/pull/174 doubled the derivation cycle counts. In a future PR, I'll add performance regression testing which will verify that changes pulled in from `kona` aren't dramatically alerting the proving cost.

For now, use this branch of kona (https://github.com/moongate-forks/kona/pull/28), which uses a version of `kona` from a few weeks ago in addition to the bug fixes for https://github.com/anton-rs/kona/pull/573 and https://github.com/anton-rs/kona/pull/705

This PR also cherry-picks the changes from #175 , #176, #177 