### PR TITLE
chore: `cost_estimator`

### DIFF
--- a/configs/11155420/rollup.json
+++ b/configs/11155420/rollup.json
@@ -10,7 +10,7 @@
     },
     "l2_time": 1691802540,
     "system_config": {
-      "batcherAddr": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
+      "batcherAddr": "0x8f23bb38f531600e5d8fddaaec41f13fab46e98c",
       "overhead": "0xbc",
       "scalar": "0xa6fe0",
       "gasLimit": 30000000,
@@ -42,7 +42,7 @@
   "fjord_time": 1716998400,
   "granite_time": 1723478400,
   "batch_inbox_address": "0xff00000000000000000000000000000011155420",
-  "deposit_contract_address": "0x16Fc5058F25648194471939df75CF27A2fdC48BC",
-  "l1_system_config_address": "0x034edD2A225f7f429A63E0f1D2084B9E0A93b538",
-  "protocol_versions_address": "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
+  "deposit_contract_address": "0x16fc5058f25648194471939df75cf27a2fdc48bc",
+  "l1_system_config_address": "0x034edd2a225f7f429a63e0f1d2084b9e0a93b538",
+  "protocol_versions_address": "0x79add5713b383daa0a138d3c4780c7a1804a8090"
 }

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -121,6 +121,7 @@ async fn main() -> Result<()> {
         }
 
         let mut stats = ExecutionStats::default();
+        stats.chain_id = l2_chain_id;
         stats
             .add_block_data(&data_fetcher, args.start, args.end)
             .await;

--- a/scripts/prove/bin/single.rs
+++ b/scripts/prove/bin/single.rs
@@ -99,6 +99,7 @@ async fn main() -> Result<()> {
         }
 
         let mut stats = ExecutionStats::default();
+        stats.chain_id = l2_chain_id;
         stats
             .add_block_data(&data_fetcher, args.l2_block, args.l2_block)
             .await;

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -163,6 +163,7 @@ async fn execute_blocks_parallel(
             // Create a new data fetcher. This avoids the runtime dropping the provider dispatch task.
             let data_fetcher = OPSuccinctDataFetcher::default();
             let mut exec_stats = ExecutionStats::default();
+            exec_stats.chain_id = data_fetcher.get_chain_id(RPCMode::L2).await.unwrap();
             exec_stats.add_block_data(&data_fetcher, start, end).await;
             let mut execution_stats_map = execution_stats_map.lock().unwrap();
             execution_stats_map.insert((start, end), exec_stats);
@@ -238,6 +239,7 @@ fn aggregate_execution_stats(
     witness_generation_time_sec: u64,
 ) -> ExecutionStats {
     let mut aggregate_stats = ExecutionStats::default();
+    aggregate_stats.chain_id = execution_stats[0].chain_id;
     let mut batch_start = u64::MAX;
     let mut batch_end = u64::MIN;
     for stats in execution_stats {

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -8,6 +8,7 @@ use sp1_sdk::{CostEstimator, ExecutionReport};
 /// Statistics for the range execution.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ExecutionStats {
+    pub chain_id: u64,
     pub batch_start: u64,
     pub batch_end: u64,
     /// The wall clock time to generate the witness.


### PR DESCRIPTION
- Modify the cost estimator to take in a configurable environment.
- Add the `chain_id` to the outputted data.

TODO: Turn loading the file from a custom environment into a shared utility.
TODO: The way we add data to the `cost_estimator` is quite manual and can lead to issues. The ExecutionStats struct should always expect some formatted data, and separately we can handle the data temporarily before we load it into the `ExecutionStats` struct.