### PR TITLE
fix(multi): execution stats

### DIFF
--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<()> {
 
         let mut stats = ExecutionStats::default();
         stats
-            .add_block_data(&data_fetcher, args.start, args.end)
+            .add_block_data(&data_fetcher, args.start + 1, args.end)
             .await;
         stats.add_report_data(&report);
         stats.add_aggregate_data();


### PR DESCRIPTION
`args.start` means the agreed l2 block, The agreed l2 block doesn't need to be derived and executed. So in the output execute stats, to avoid misinterpretation of the output, the start block should be `args.start + 1`.