### PR TITLE
feat: simplify cost estimator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data
 
 # Execution Report
 execution-reports/
+block-data/
 
 # Rollup Config
 **/rollup-config.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4332,6 +4332,7 @@ dependencies = [
  "clap",
  "csv",
  "dotenv",
+ "kona-host",
  "num-format",
  "op-alloy-genesis",
  "op-succinct-build-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4482,12 +4482,25 @@ dependencies = [
 
 [[package]]
 name = "p3-air"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066f571b2e645505ed5972dd0e1e252ba03352150830c9566769ca711c0f1e9b"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
- "p3-field",
- "p3-matrix",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -4497,66 +4510,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff00f571044d299310d9659c6e51c98422de3bf94b8577f7f30cf59cf2043e40"
 dependencies = [
  "num-bigint 0.4.6",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.4-succinct",
+ "p3-mds 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
  "rand",
  "serde",
 ]
 
 [[package]]
 name = "p3-blake3"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4cb69ae54a279bbbd477566d1bdb71aa879b528fd658d0fcfc36f54b00217c"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "blake3",
- "p3-symmetric",
+ "p3-symmetric 0.1.0",
 ]
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf19917f986d45e9abb6d177e875824ced6eed096480d574fce16f2c45c721ea"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "ff 0.13.0",
  "num-bigint 0.4.6",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand",
  "serde",
 ]
 
 [[package]]
 name = "p3-challenger"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be7e4fbce4566a93091107eadfafa0b5374bd1ffd3e0f6b850da3ff72eb183f"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-commit"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a03eb0f99d68a712c41e658e9a7782a0705d4ffcfb6232a43bd3f1ef9591002"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-util 0.1.0",
  "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
+ "tracing",
 ]
 
 [[package]]
@@ -4565,11 +4585,24 @@ version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1556de968523fbe5d804ab50600ea306fcceea3500cfd7601e40882480524664"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-util 0.1.0",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -4581,52 +4614,63 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util",
+ "p3-util 0.1.4-succinct",
  "rand",
  "serde",
 ]
 
 [[package]]
 name = "p3-fri"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f351ee9f9d4256455164565cd91e3e6d2487cc2a5355515fa2b6d479269188dd"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
  "p3-commit",
- "p3-dft",
- "p3-field",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
  "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-interpolation"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24d0f2907a374ebe4545fcff3120d6376d9630cf0bef30feedcfc5908ea2c37"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-util 0.1.0",
 ]
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66badd47cedf6570e91a0cabc389b80dfd53ba1a6e9a45a3923fd54b86122ff"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
+ "rand",
+ "serde",
  "tracing",
 ]
 
@@ -4637,9 +4681,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa272f3ae77ed8d73478aa7c89e712efb15bda3ff4aff10fadfe11a012cd5389"
 dependencies = [
  "itertools 0.12.1",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "rand",
  "serde",
  "tracing",
@@ -4647,11 +4691,30 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
 version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eecad6292021858f282d643d9d1284ab112a200494d589863a9c4080e578ef0"
+
+[[package]]
+name = "p3-mds"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
- "rayon",
+ "itertools 0.12.1",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
+ "rand",
 ]
 
 [[package]]
@@ -4661,29 +4724,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "716c4dbe68a02f1541eb09149d07b8663a3a5951b1864a31cd67ff3bb0826e57"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "rand",
 ]
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7ebab52a03c26025988663a135aed62f5084a2e2ea262176dc8748efb593e5"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "gcd",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-symmetric 0.1.0",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -4693,10 +4768,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39c042efa15beab7a8c4d0ca9b9e4cbda7582be0c08e121e830fec45f082935b"
 dependencies = [
  "gcd",
- "p3-field",
- "p3-mds",
- "p3-symmetric",
+ "p3-field 0.1.4-succinct",
+ "p3-mds 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
  "rand",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field 0.1.0",
  "serde",
 ]
 
@@ -4707,27 +4792,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9896a831f5b688adc13f6fbe1dcf66ecfaa4622a500f81aa745610e777acb72"
 dependencies = [
  "itertools 0.12.1",
- "p3-field",
+ "p3-field 0.1.4-succinct",
  "serde",
 ]
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.1.4-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437ebcd060c8a5479898030b114a93da8a86eb4c2e5f313d9eeaaf40c6e6f61"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
  "p3-challenger",
  "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3?branch=sp1-v4#db3d45d4ec899efaf8f7234a8573f285fbdda5db"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6334,8 +6426,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff9718f87f207404aee3f447c4438e2a35791092dc24ce65ff95db699ed49c1"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6348,13 +6439,13 @@ dependencies = [
  "log",
  "nohash-hasher",
  "num",
- "p3-field",
- "p3-maybe-rayon",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
  "rand",
  "rrs-succinct",
  "serde",
  "sp1-curves",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-stark",
  "strum",
  "strum_macros",
@@ -6368,8 +6459,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac8b5f2cecb7b2174495fc7a3e004bdb78e1c7ea44577ac0acc0d1e90b817ea"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6383,15 +6473,15 @@ dependencies = [
  "num",
  "num_cpus",
  "p3-air",
- "p3-baby-bear",
+ "p3-baby-bear 0.1.0",
  "p3-blake3",
  "p3-challenger",
- "p3-field",
+ "p3-field 0.1.0",
  "p3-keccak-air",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
  "p3-uni-stark",
- "p3-util",
+ "p3-util 0.1.0",
  "rand",
  "serde",
  "size",
@@ -6399,7 +6489,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-stark",
  "static_assertions",
  "strum",
@@ -6410,14 +6500,14 @@ dependencies = [
  "tracing-forest",
  "tracing-subscriber",
  "typenum",
+ "vec_map",
  "web-time",
 ]
 
 [[package]]
 name = "sp1-curves"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1af9ff15e524ebe58286d7ee9bc345657b45b13091b5dc58fdce61542b65a47"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -6427,10 +6517,10 @@ dependencies = [
  "itertools 0.13.0",
  "k256",
  "num",
- "p3-field",
+ "p3-field 0.1.0",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-stark",
  "typenum",
 ]
@@ -6438,8 +6528,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1490c07bd283f59169eae6e67df355b5de8ba10cc75bf6dbfc05a28fdccfc6"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6492,10 +6581,27 @@ dependencies = [
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "sp1-primitives"
+version = "3.0.0"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
+dependencies = [
+ "bincode",
+ "hex",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "p3-baby-bear 0.1.0",
+ "p3-field 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "serde",
  "sha2",
 ]
@@ -6503,8 +6609,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd16530cb12f1cecb1b6902142d8d0d87507f88de84bc714f10c29a7fd3769c"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6515,13 +6620,13 @@ dependencies = [
  "lazy_static",
  "lru",
  "num-bigint 0.4.6",
- "p3-baby-bear",
+ "p3-baby-bear 0.1.0",
  "p3-bn254-fr",
  "p3-challenger",
  "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-symmetric 0.1.0",
  "rayon",
  "reqwest 0.11.27",
  "serde",
@@ -6529,7 +6634,7 @@ dependencies = [
  "serial_test",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -6545,30 +6650,29 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0a8ceee12600bd14d2e2d31b54db00b7985e30acedbfe8e1c1a9e41d7992f"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-traits",
  "p3-air",
- "p3-baby-bear",
+ "p3-baby-bear 0.1.0",
  "p3-bn254-fr",
  "p3-challenger",
  "p3-commit",
- "p3-dft",
- "p3-field",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
  "p3-fri",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-matrix 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "rand",
  "rayon",
  "serde",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -6579,18 +6683,17 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591d60768948dcef34a1fc16c3c6cf457e32fdee83d55ec14dbb94cd4447c030"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
- "p3-baby-bear",
+ "p3-baby-bear 0.1.0",
  "p3-bn254-fr",
- "p3-field",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-symmetric 0.1.0",
  "serde",
  "sp1-core-machine",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -6601,31 +6704,30 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-core"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c15a51b675accb41608f7bf7ef5f95c23b47ceac38a9a87833a2b12c3bc190"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "backtrace",
  "ff 0.13.0",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "p3-air",
- "p3-baby-bear",
+ "p3-baby-bear 0.1.0",
  "p3-bn254-fr",
  "p3-challenger",
  "p3-commit",
- "p3-dft",
- "p3-field",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
  "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
  "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "serde",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6637,8 +6739,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-derive"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b2aaa03093afb2b0f58379bb4f0d7898344ef1bb8dd326ec02db7125c1a590"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6647,8 +6748,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a12889c662cf64870e72bb3ba8096f3465bf442f5f179c07b50c86f5c47ce80"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6658,9 +6758,9 @@ dependencies = [
  "hex",
  "log",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-symmetric",
+ "p3-baby-bear 0.1.0",
+ "p3-field 0.1.0",
+ "p3-symmetric 0.1.0",
  "serde",
  "serde_json",
  "sha2",
@@ -6673,8 +6773,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bab15e962d1218e8ad021b2e9904597d5506d12847ef8be182385d5f3d3a6c"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "alloy-sol-types 0.7.7",
  "anyhow",
@@ -6689,8 +6788,8 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "log",
- "p3-baby-bear",
- "p3-field",
+ "p3-baby-bear 0.1.0",
+ "p3-field 0.1.0",
  "p3-fri",
  "prost",
  "reqwest 0.12.8",
@@ -6698,7 +6797,7 @@ dependencies = [
  "serde",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -6714,8 +6813,7 @@ dependencies = [
 [[package]]
 name = "sp1-stark"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec27b60e797a52eed7af54e032498edcaf8f1ab0649077cbaa6f146a740380dd"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#5a57be728165fdb5954a86dd326a8f752b83e3c4"
 dependencies = [
  "arrayref",
  "getrandom",
@@ -6723,23 +6821,23 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "p3-air",
- "p3-baby-bear",
+ "p3-baby-bear 0.1.0",
  "p3-challenger",
  "p3-commit",
- "p3-dft",
- "p3-field",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
  "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
  "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "p3-uni-stark",
- "p3-util",
+ "p3-util 0.1.0",
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -6757,12 +6855,12 @@ dependencies = [
  "getrandom",
  "lazy_static",
  "libm",
- "p3-baby-bear",
- "p3-field",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
  "rand",
  "sha2",
  "sp1-lib 3.0.0",
- "sp1-primitives",
+ "sp1-primitives 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,6 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3458,7 +3457,6 @@ dependencies = [
 [[package]]
 name = "kona-common"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "cfg-if",
  "linked_list_allocator",
@@ -3468,7 +3466,6 @@ dependencies = [
 [[package]]
 name = "kona-common-proc"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3481,7 +3478,6 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3507,7 +3503,6 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.0.2"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3524,7 +3519,6 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3561,7 +3555,6 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.8",
@@ -3576,7 +3569,6 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-primitives 0.8.8",
  "async-trait",
@@ -3589,7 +3581,6 @@ dependencies = [
 [[package]]
 name = "kona-primitives"
 version = "0.0.2"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.8",
@@ -3605,7 +3596,6 @@ dependencies = [
 [[package]]
 name = "kona-providers"
 version = "0.0.1"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.8",
@@ -3618,7 +3608,6 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.0.1"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3458,6 +3459,7 @@ dependencies = [
 [[package]]
 name = "kona-common"
 version = "0.0.3"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "cfg-if",
  "linked_list_allocator",
@@ -3467,6 +3469,7 @@ dependencies = [
 [[package]]
 name = "kona-common-proc"
 version = "0.0.3"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3479,6 +3482,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.0.3"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3504,6 +3508,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.0.2"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3520,6 +3525,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3556,6 +3562,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.0.3"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.8",
@@ -3570,6 +3577,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.0.3"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-primitives 0.8.8",
  "async-trait",
@@ -3582,6 +3590,7 @@ dependencies = [
 [[package]]
 name = "kona-primitives"
 version = "0.0.2"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.8",
@@ -3597,6 +3606,7 @@ dependencies = [
 [[package]]
 name = "kona-providers"
 version = "0.0.1"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.8",
@@ -3609,6 +3619,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.0.1"
+source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "rayon",
 ]
 
 [[package]]
@@ -4341,6 +4342,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "csv",
+ "dashmap",
  "dotenv",
  "futures",
  "kona-host",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,6 +5372,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "anyhow",
  "cfg-if",
  "kona-client",
  "kona-derive",
@@ -5383,6 +5384,8 @@ dependencies = [
  "op-succinct-client-utils",
  "serde_json",
  "sp1-zkvm",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,28 +42,28 @@ tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 
 # kona
 # Note: Switch to latest version of kona once the std::process::Command issue is resolved.
-# kona-common = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-common-proc = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-preimage = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", features = [
-#     "rkyv",
-# ] }
-# kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", default-features = false }
-# kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-common = { path = "../kona/crates/common" }
-kona-common-proc = { path = "../kona/crates/common-proc" }
-kona-preimage = { path = "../kona/crates/preimage", features = [
+kona-common = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-common-proc = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-preimage = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", features = [
     "rkyv",
 ] }
-kona-primitives = { path = "../kona/crates/primitives" }
-kona-mpt = { path = "../kona/crates/mpt" }
-kona-derive = { path = "../kona/crates/derive", default-features = false }
-kona-executor = { path = "../kona/crates/executor" }
-kona-client = { path = "../kona/bin/client" }
-kona-host = { path = "../kona/bin/host" }
+kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", default-features = false }
+kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-common = { path = "../kona/crates/common" }
+# kona-common-proc = { path = "../kona/crates/common-proc" }
+# kona-preimage = { path = "../kona/crates/preimage", features = [
+#     "rkyv",
+# ] }
+# kona-primitives = { path = "../kona/crates/primitives" }
+# kona-mpt = { path = "../kona/crates/mpt" }
+# kona-derive = { path = "../kona/crates/derive", default-features = false }
+# kona-executor = { path = "../kona/crates/executor" }
+# kona-client = { path = "../kona/bin/client" }
+# kona-host = { path = "../kona/bin/host" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ base64 = "0.22.1"
 tower-http = { version = "0.5.2", features = ["limit"] }
 kzg-rs = { version = "0.2.2" }
 
+# program tracing
+tracing = { version = "0.1.40", default-features = false }
+tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
+
 # kona
 # Note: Switch to latest version of kona once the std::process::Command issue is resolved.
 kona-common = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ op-alloy-network = { version = "0.4.0", default-features = false }
 # sp1
 sp1-lib = { version = "3.0.0", features = ["verify"] }
 sp1-zkvm = { version = "3.0.0", features = ["verify"] }
-sp1-sdk = { version = "3.0.0" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", branch = "dev" }
 sp1-build = { version = "3.0.0" }
 
 [profile.release-client-lto]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,17 +53,6 @@ kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-
 kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
 kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
 kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-# kona-common = { path = "../kona/crates/common" }
-# kona-common-proc = { path = "../kona/crates/common-proc" }
-# kona-preimage = { path = "../kona/crates/preimage", features = [
-#     "rkyv",
-# ] }
-# kona-primitives = { path = "../kona/crates/primitives" }
-# kona-mpt = { path = "../kona/crates/mpt" }
-# kona-derive = { path = "../kona/crates/derive", default-features = false }
-# kona-executor = { path = "../kona/crates/executor" }
-# kona-client = { path = "../kona/bin/client" }
-# kona-host = { path = "../kona/bin/host" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,28 @@ tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 
 # kona
 # Note: Switch to latest version of kona once the std::process::Command issue is resolved.
-kona-common = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-common-proc = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-preimage = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", features = [
+# kona-common = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-common-proc = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-preimage = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", features = [
+#     "rkyv",
+# ] }
+# kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", default-features = false }
+# kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+# kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-common = { path = "../kona/crates/common" }
+kona-common-proc = { path = "../kona/crates/common-proc" }
+kona-preimage = { path = "../kona/crates/preimage", features = [
     "rkyv",
 ] }
-kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona", default-features = false }
-kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-primitives = { path = "../kona/crates/primitives" }
+kona-mpt = { path = "../kona/crates/mpt" }
+kona-derive = { path = "../kona/crates/derive", default-features = false }
+kona-executor = { path = "../kona/crates/executor" }
+kona-client = { path = "../kona/bin/client" }
+kona-host = { path = "../kona/bin/host" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/configs/60808/rollup.json
+++ b/configs/60808/rollup.json
@@ -1,0 +1,48 @@
+{
+  "genesis": {
+    "l1": {
+      "number": 19634321,
+      "hash": "0x218132178d65c4bc490aadd93c31535326043fe1fe8fea2d87f26c1da83d45c2"
+    },
+    "l2": {
+      "number": 0,
+      "hash": "0x8ed4903b7f9c3f7bb7a09374d63ae9c9852cd9aab1784b433c41dbeb47b4dba2"
+    },
+    "l2_time": 1712861987,
+    "system_config": {
+      "batcherAddr": "0x08f9f14ff43e112b18c96f0986f28cb1878f1d11",
+      "overhead": "0xbc",
+      "scalar": "0xa6fe0",
+      "gasLimit": 30000000,
+      "baseFeeScalar": null,
+      "blobBaseFeeScalar": null,
+      "eip1559Denominator": null,
+      "eip1559Elasticity": null
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "granite_channel_timeout": 50,
+  "l1_chain_id": 1,
+  "l2_chain_id": 60808,
+  "base_fee_params": {
+    "max_change_denominator": "0x32",
+    "elasticity_multiplier": "0x6"
+  },
+  "canyon_base_fee_params": {
+    "max_change_denominator": "0xfa",
+    "elasticity_multiplier": "0x6"
+  },
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 1720627201,
+  "granite_time": 1726070401,
+  "batch_inbox_address": "0x3a75346f81302aac0333fb5dcdd407e12a6cfa83",
+  "deposit_contract_address": "0x8adee124447435fe03e3cd24df3f4cae32e65a3e",
+  "l1_system_config_address": "0xacb886b75d76d1c8d9248cfddfa09b70c71c5393",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}

--- a/configs/70028/rollup.json
+++ b/configs/70028/rollup.json
@@ -1,0 +1,47 @@
+{
+  "genesis": {
+    "l1": {
+      "number": 6953197,
+      "hash": "0xdd6907c2d97a0ce642cee05bebffa692a7e1acd6a377b553dd5903710584ffd3"
+    },
+    "l2": {
+      "number": 0,
+      "hash": "0x6234f965019ffae2d60c1242e1643249d8253761b0ccc5a0b2d06be571907904"
+    },
+    "l2_time": 1729993596,
+    "system_config": {
+      "batcherAddr": "0x4a1ff7b3f2ce0654ada0503ac0c47cbd4b011e1d",
+      "overhead": "0xbc",
+      "scalar": "0xa6fe0",
+      "gasLimit": 30000000,
+      "baseFeeScalar": null,
+      "blobBaseFeeScalar": null,
+      "eip1559Denominator": null,
+      "eip1559Elasticity": null
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "granite_channel_timeout": 50,
+  "l1_chain_id": 11155111,
+  "l2_chain_id": 70028,
+  "base_fee_params": {
+    "max_change_denominator": "0x32",
+    "elasticity_multiplier": "0x6"
+  },
+  "canyon_base_fee_params": {
+    "max_change_denominator": "0xfa",
+    "elasticity_multiplier": "0x6"
+  },
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 0,
+  "batch_inbox_address": "0x64179d2df0f0a24ae1d8c5623f23176da244b37e",
+  "deposit_contract_address": "0xa5cd423b6a03a11d493badf127a866098d331a4a",
+  "l1_system_config_address": "0xded428a20c07f1bfe8dd7d7d37ebdd0bbfb670ab",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}

--- a/programs/range/Cargo.toml
+++ b/programs/range/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 cfg-if.workspace = true
 serde_json.workspace = true
 log.workspace = true
+tracing.workspace = true
+anyhow.workspace = true
 
 # workspace (ethereum)
 op-alloy-consensus.workspace = true
@@ -29,3 +31,9 @@ kona-derive.workspace = true
 
 # op-succinct
 op-succinct-client-utils.workspace = true
+
+# `tracing-subscriber` feature dependencies
+tracing-subscriber = { workspace = true, optional = true }
+
+[features]
+tracing-subscriber = ["dep:tracing-subscriber"]

--- a/programs/range/src/main.rs
+++ b/programs/range/src/main.rs
@@ -45,6 +45,15 @@ cfg_if! {
 }
 
 fn main() {
+    #[cfg(feature = "tracing-subscriber")]
+    {
+        use anyhow::anyhow;
+        use tracing::Level;
+
+        let subscriber = tracing_subscriber::fmt().with_max_level(Level::DEBUG).finish();
+        tracing::subscriber::set_global_default(subscriber).map_err(|e| anyhow!(e)).unwrap();
+    }
+
     op_succinct_client_utils::block_on(async move {
         ////////////////////////////////////////////////////////////////
         //                          PROLOGUE                          //

--- a/scripts/fees/src/lib.rs
+++ b/scripts/fees/src/lib.rs
@@ -9,6 +9,7 @@ pub struct AggregateFeeData {
     pub end: u64,
     pub num_transactions: u64,
     pub total_l1_fee: U256,
+    pub total_tx_fees: u128,
 }
 
 impl fmt::Display for AggregateFeeData {
@@ -30,11 +31,13 @@ pub fn aggregate_fee_data(fee_data: Vec<FeeData>) -> Result<AggregateFeeData> {
         end: fee_data[fee_data.len() - 1].block_number,
         num_transactions: 0,
         total_l1_fee: U256::ZERO,
+        total_tx_fees: 0,
     };
 
     for data in fee_data {
         aggregate_fee_data.num_transactions += 1;
         aggregate_fee_data.total_l1_fee += data.l1_gas_cost;
+        aggregate_fee_data.total_tx_fees += data.tx_fee;
     }
 
     Ok(aggregate_fee_data)

--- a/scripts/prove/Cargo.toml
+++ b/scripts/prove/Cargo.toml
@@ -30,6 +30,9 @@ dotenv.workspace = true
 num-format.workspace = true
 csv.workspace = true
 
+# kona
+kona-host = { workspace = true }
+
 # local
 op-succinct-host-utils.workspace = true
 op-succinct-client-utils.workspace = true

--- a/scripts/prove/bin/agg.rs
+++ b/scripts/prove/bin/agg.rs
@@ -68,10 +68,10 @@ async fn main() -> Result<()> {
     let (proofs, boot_infos) = load_aggregation_proof_data(args.proofs, l2_chain_id);
     let latest_checkpoint_head = fetcher
         .get_l1_header(args.latest_checkpoint_head_nb.into())
-        .await?
-        .hash_slow();
+        .await?;
+    let latest_checkpoint_head_hash = latest_checkpoint_head.hash_slow();
     let headers = fetcher
-        .get_header_preimages(&boot_infos, latest_checkpoint_head)
+        .get_header_preimages(&boot_infos, latest_checkpoint_head_hash)
         .await?;
 
     let (_, vkey) = prover.setup(MULTI_BLOCK_ELF);
@@ -81,8 +81,14 @@ async fn main() -> Result<()> {
         vkey.vk.hash_u32()
     );
 
-    let stdin =
-        get_agg_proof_stdin(proofs, boot_infos, headers, &vkey, latest_checkpoint_head).unwrap();
+    let stdin = get_agg_proof_stdin(
+        proofs,
+        boot_infos,
+        headers,
+        &vkey,
+        latest_checkpoint_head_hash,
+    )
+    .unwrap();
 
     let (agg_pk, agg_vk) = prover.setup(AGG_ELF);
     println!("Aggregate ELF Verification Key: {:?}", agg_vk.vk.bytes32());

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -62,8 +62,6 @@ async fn main() -> Result<()> {
         .get_host_cli_args(args.start, args.end, ProgramType::Multi, cache_mode)
         .await?;
 
-    println!("Host CLI: {:?}", host_cli);
-
     // By default, re-run the native execution unless the user passes `--use-cache`.
     let start_time = Instant::now();
     if !args.use_cache {

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -62,6 +62,8 @@ async fn main() -> Result<()> {
         .get_host_cli_args(args.start, args.end, ProgramType::Multi, cache_mode)
         .await?;
 
+    println!("Host CLI: {:?}", host_cli);
+
     // By default, re-run the native execution unless the user passes `--use-cache`.
     let start_time = Instant::now();
     if !args.use_cache {

--- a/scripts/utils/Cargo.toml
+++ b/scripts/utils/Cargo.toml
@@ -51,6 +51,7 @@ op-succinct-client-utils.workspace = true
 
 # sp1
 sp1-sdk = { workspace = true }
+dashmap = { version = "6.1.0", features = ["rayon"] }
 
 [build-dependencies]
 op-succinct-build-utils.workspace = true

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -405,6 +405,22 @@ async fn main() -> Result<()> {
         total_execution_time_sec,
         witness_generation_time_sec,
     );
+
+    // Read the execution stats from the CSV file.
+    let cargo_metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
+    let root_dir = PathBuf::from(cargo_metadata.workspace_root);
+    let report_path = root_dir.join(format!(
+        "execution-reports/{}/{}-{}-report.csv",
+        l2_chain_id, args.start, args.end
+    ));
+
+    let mut final_execution_stats = Vec::new();
+    let mut csv_reader = csv::Reader::from_path(report_path)?;
+    for result in csv_reader.deserialize() {
+        let stats: ExecutionStats = result?;
+        final_execution_stats.push(stats);
+    }
+
     println!(
         "Aggregate Execution Stats for Chain {}: \n {}",
         l2_chain_id, aggregate_execution_stats

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
+use futures::StreamExt;
 use kona_host::HostCli;
 use log::info;
 use op_succinct_host_utils::{
@@ -9,7 +10,7 @@ use op_succinct_host_utils::{
     witnessgen::WitnessGenExecutor,
     ProgramType,
 };
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use sp1_sdk::{utils, ProverClient};
 use std::{
@@ -43,6 +44,12 @@ struct HostArgs {
     /// The path to the CSV file containing the execution data.
     #[clap(long, default_value = "report.csv")]
     report_path: PathBuf,
+    /// Use cached witness generation.
+    #[clap(long)]
+    use_cache: bool,
+    /// The environment file to use.
+    #[clap(long, default_value = ".env")]
+    env_file: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,15 +58,9 @@ struct SpanBatchRange {
     end: u64,
 }
 
-struct BatchHostCli {
-    host_cli: HostCli,
-    start: u64,
-    end: u64,
-}
-
 fn get_max_span_batch_range_size(l2_chain_id: u64, supplied_range_size: Option<u64>) -> u64 {
     // TODO: The default size/batch size should be dynamic based on the L2 chain. Specifically, look at the gas used across the block range (should be fast to compute) and then set the batch size accordingly.
-    const DEFAULT_SIZE: u64 = 1000;
+    const DEFAULT_SIZE: u64 = 300;
     let default_size = supplied_range_size.unwrap_or(DEFAULT_SIZE);
     match l2_chain_id {
         8453 => 5,      // Base
@@ -93,49 +94,23 @@ fn split_range(
 }
 
 /// Concurrently run the native data generation process for each split range.
-async fn run_native_data_generation(
-    data_fetcher: &OPSuccinctDataFetcher,
-    split_ranges: &[SpanBatchRange],
-) -> Vec<BatchHostCli> {
+async fn run_native_data_generation(host_clis: &[HostCli]) {
     const CONCURRENT_NATIVE_HOST_RUNNERS: usize = 5;
 
     // Split the entire range into chunks of size CONCURRENT_NATIVE_HOST_RUNNERS and process chunks
     // serially. Generate witnesses within each chunk in parallel. This prevents the RPC from
     // being overloaded with too many concurrent requests, while also improving witness generation
     // throughput.
-    let batch_host_clis = split_ranges
-        .chunks(CONCURRENT_NATIVE_HOST_RUNNERS)
-        .map(|chunk| {
-            let mut witnessgen_executor = WitnessGenExecutor::default();
+    for chunk in host_clis.chunks(CONCURRENT_NATIVE_HOST_RUNNERS) {
+        let mut witnessgen_executor = WitnessGenExecutor::default();
 
-            let mut batch_host_clis = Vec::new();
-            for range in chunk.iter() {
-                let host_cli = block_on(data_fetcher.get_host_cli_args(
-                    range.start,
-                    range.end,
-                    ProgramType::Multi,
-                    CacheMode::DeleteCache,
-                ))
-                .expect("Failed to get host CLI args");
+        for host_cli in chunk {
+            block_on(witnessgen_executor.spawn_witnessgen(host_cli))
+                .expect("Failed to spawn witness generation process");
+        }
 
-                batch_host_clis.push(BatchHostCli {
-                    host_cli: host_cli.clone(),
-                    start: range.start,
-                    end: range.end,
-                });
-                block_on(witnessgen_executor.spawn_witnessgen(&host_cli))
-                    .expect("Failed to spawn witness generation process.");
-            }
-
-            let res = block_on(witnessgen_executor.flush());
-            if res.is_err() {
-                panic!("Failed to generate witnesses: {:?}", res.err().unwrap());
-            }
-
-            batch_host_clis
-        });
-
-    batch_host_clis.into_iter().flatten().collect()
+        block_on(witnessgen_executor.flush()).expect("Failed to generate witnesses");
+    }
 }
 
 /// Utility method for blocking on an async function.
@@ -155,7 +130,8 @@ pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
 
 /// Run the zkVM execution process for each split range in parallel.
 async fn execute_blocks_parallel(
-    host_clis: Vec<BatchHostCli>,
+    host_clis: &[HostCli],
+    ranges: Vec<SpanBatchRange>,
     prover: &ProverClient,
 ) -> Vec<ExecutionStats> {
     // Create a new execution stats map between the start and end block and the default ExecutionStats.
@@ -163,41 +139,53 @@ async fn execute_blocks_parallel(
 
     // Fetch all of the execution stats block ranges in parallel.
     let mut handles = Vec::new();
-    for (start, end) in host_clis.iter().map(|r| (r.start, r.end)) {
+    for range in ranges.clone() {
         let execution_stats_map = Arc::clone(&execution_stats_map);
         let handle = tokio::spawn(async move {
             // Create a new data fetcher. This avoids the runtime dropping the provider dispatch task.
             let data_fetcher = OPSuccinctDataFetcher::default();
             let mut exec_stats = ExecutionStats::default();
-            exec_stats.add_block_data(&data_fetcher, start, end).await;
+            exec_stats
+                .add_block_data(&data_fetcher, range.start, range.end)
+                .await;
             let mut execution_stats_map = execution_stats_map.lock().unwrap();
-            execution_stats_map.insert((start, end), exec_stats);
+            execution_stats_map.insert((range.start, range.end), exec_stats);
         });
         handles.push(handle);
     }
     futures::future::join_all(handles).await;
 
     // Run the zkVM execution process for each split range in parallel and fill in the execution stats.
-    host_clis.par_iter().for_each(|r| {
-        let sp1_stdin = get_proof_stdin(&r.host_cli).unwrap();
+    host_clis
+        .chunks(5)
+        .zip(ranges.chunks(5))
+        .for_each(|(cli_batch, range_batch)| {
+            cli_batch
+                .par_iter()
+                .zip(range_batch.par_iter())
+                .for_each(|(host_cli, range)| {
+                    let sp1_stdin = get_proof_stdin(&host_cli).unwrap();
 
-        // TODO: Implement retries with a smaller block range if this fails.
-        let (_, report) = prover
-            .execute(MULTI_BLOCK_ELF, sp1_stdin)
-            .run()
-            .unwrap_or_else(|e| {
-                panic!(
-                    "Failed to execute blocks {:?} - {:?}: {:?}",
-                    r.start, r.end, e
-                )
-            });
+                    // TODO: Implement retries with a smaller block range if this fails.
+                    let (_, report) = prover
+                        .execute(MULTI_BLOCK_ELF, sp1_stdin)
+                        .run()
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "Failed to execute blocks {:?} - {:?}: {:?}",
+                                range.start, range.end, e
+                            )
+                        });
 
-        // Get the existing execution stats and modify it in place.
-        let mut execution_stats_map = execution_stats_map.lock().unwrap();
-        let exec_stats = execution_stats_map.get_mut(&(r.start, r.end)).unwrap();
-        exec_stats.add_report_data(&report);
-        exec_stats.add_aggregate_data();
-    });
+                    // Get the existing execution stats and modify it in place.
+                    let mut execution_stats_map = execution_stats_map.lock().unwrap();
+                    let exec_stats = execution_stats_map
+                        .get_mut(&(range.start, range.end))
+                        .unwrap();
+                    exec_stats.add_report_data(&report);
+                    exec_stats.add_aggregate_data();
+                });
+        });
 
     info!("Execution is complete.");
 
@@ -294,10 +282,11 @@ fn aggregate_execution_stats(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    dotenv::dotenv().ok();
+    let args = HostArgs::parse();
+
+    dotenv::from_path(&args.env_file).ok();
     utils::setup_logger();
 
-    let args = HostArgs::parse();
     let data_fetcher = OPSuccinctDataFetcher::default();
 
     let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
@@ -311,12 +300,33 @@ async fn main() -> Result<()> {
 
     let prover = ProverClient::new();
 
+    let cache_mode = if args.use_cache {
+        CacheMode::KeepCache
+    } else {
+        CacheMode::DeleteCache
+    };
+
+    // Get the host CLIs in order, in parallel.
+    let host_clis = futures::stream::iter(split_ranges.iter())
+        .map(|range| async {
+            data_fetcher
+                .get_host_cli_args(range.start, range.end, ProgramType::Multi, cache_mode)
+                .await
+                .expect("Failed to get host CLI args")
+        })
+        .buffered(15)
+        .collect::<Vec<_>>()
+        .await;
+
     let start_time = Instant::now();
-    let host_clis = run_native_data_generation(&data_fetcher, &split_ranges).await;
+    if !args.use_cache {
+        // Get the host CLI args
+        run_native_data_generation(&host_clis).await;
+    }
     let witness_generation_time_sec = start_time.elapsed().as_secs();
 
     let start_time = Instant::now();
-    let execution_stats = execute_blocks_parallel(host_clis, &prover).await;
+    let execution_stats = execute_blocks_parallel(&host_clis, split_ranges, &prover).await;
     let total_execution_time_sec = start_time.elapsed().as_secs();
 
     // Sort the execution stats by batch start block.

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -166,7 +166,9 @@ async fn execute_blocks_parallel(
         l2_chain_id, args.start, args.end
     ));
     if let Some(parent) = report_path.parent() {
-        fs::create_dir_all(parent).unwrap();
+        if !parent.exists() {
+            fs::create_dir_all(parent).unwrap();
+        }
     }
 
     // Run the zkVM execution process for each split range in parallel and fill in the execution stats.

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -4,6 +4,7 @@ use sp1_build::{build_program_with_args, BuildArgs};
 
 /// Build a native program.
 fn build_native_program(program: &str) {
+    // Build with tracing-subscriber feature enabled for `kona-client` logging.
     let status = Command::new("cargo")
         .args([
             "build",

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -12,6 +12,8 @@ fn build_native_program(program: &str) {
             program,
             "--profile",
             "release-client-lto",
+            "--features",
+            "tracing-subscriber",
         ])
         .status()
         .expect("Failed to execute cargo build command");

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -5,7 +5,7 @@ use sp1_build::{build_program_with_args, BuildArgs};
 /// Build a native program.
 fn build_native_program(program: &str) {
     // Build with tracing-subscriber feature enabled for `kona-client` logging.
-    let status = Command::new("cargo")
+    let status = Command::new("cargo") 
         .args([
             "build",
             "--workspace",

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -65,8 +65,8 @@ fn build_zkvm_program(program: &str) {
         &format!("{}/{}", metadata.workspace_root.join("programs"), program),
         BuildArgs {
             elf_name: format!("{}-elf", program),
-            // docker: true,
-            // tag: "v3.0.0".to_string(),
+            docker: true,
+            tag: "v3.0.0".to_string(),
             ..Default::default()
         },
     );
@@ -81,7 +81,7 @@ pub fn build_all() {
         // Note: Don't comment this out, because the Docker program depends on the native program
         // for range being built.
         build_native_program(program);
-        build_zkvm_program(program);
+        // build_zkvm_program(program);
     }
 
     // build_zkvm_program("aggregation");

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -65,8 +65,8 @@ fn build_zkvm_program(program: &str) {
         &format!("{}/{}", metadata.workspace_root.join("programs"), program),
         BuildArgs {
             elf_name: format!("{}-elf", program),
-            docker: true,
-            tag: "v3.0.0".to_string(),
+            // docker: true,
+            // tag: "v3.0.0".to_string(),
             ..Default::default()
         },
     );
@@ -81,7 +81,7 @@ pub fn build_all() {
         // Note: Don't comment this out, because the Docker program depends on the native program
         // for range being built.
         build_native_program(program);
-        // build_zkvm_program(program);
+        build_zkvm_program(program);
     }
 
     // build_zkvm_program("aggregation");

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -10,7 +10,7 @@ use anyhow::anyhow;
 use anyhow::Result;
 use cargo_metadata::MetadataCommand;
 use kona_host::HostCli;
-use log::{debug, info};
+use log::info;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_network::{
     primitives::{BlockTransactions, BlockTransactionsKind},

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -718,10 +718,6 @@ impl OPSuccinctDataFetcher {
                 vec![l2_start_block_hex.into()],
             )
             .await?;
-        println!(
-            "L1 Origin of L2 Start Block: {:?}",
-            optimism_output_data.block_ref.l1_origin.number
-        );
 
         let latest_l1_header = self.get_l1_header(BlockId::latest()).await?;
 
@@ -742,9 +738,6 @@ impl OPSuccinctDataFetcher {
         loop {
             // If the current L1 block number is greater than the latest L1 header number, then return an error.
             if current_l1_block_number > latest_l1_header.number {
-                println!(
-                    "Could not find an L1 block with an L2 safe head greater than the L2 end block."
-                );
                 return Err(anyhow::anyhow!(
                     "Could not find an L1 block with an L2 safe head greater than the L2 end block."
                 ));
@@ -760,7 +753,6 @@ impl OPSuccinctDataFetcher {
                 .await?;
             let l2_safe_head = result.safe_head.number;
             if l2_safe_head > l2_end_block {
-                println!("The L1 Head chosen is {:?}", result.l1_block.number);
                 return Ok((result.l1_block.hash, result.l1_block.number));
             }
 

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -10,6 +10,7 @@ use anyhow::anyhow;
 use anyhow::Result;
 use cargo_metadata::MetadataCommand;
 use kona_host::HostCli;
+use log::{debug, info};
 use op_alloy_genesis::RollupConfig;
 use op_alloy_network::{
     primitives::{BlockTransactions, BlockTransactionsKind},
@@ -335,6 +336,9 @@ impl OPSuccinctDataFetcher {
             .map(|block_number| {
                 let l2_provider = l2_provider.clone();
                 async move {
+                    if block_number % 1000 == 0 {
+                        info!("Fetching block: {}", block_number);
+                    }
                     let block = l2_provider
                         .get_block_by_number(block_number.into(), false)
                         .await?
@@ -366,7 +370,7 @@ impl OPSuccinctDataFetcher {
                     })
                 }
             })
-            .buffered(100)
+            .buffered(300)
             .collect::<Vec<Result<BlockInfo>>>()
             .await;
 

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -741,7 +741,6 @@ impl OPSuccinctDataFetcher {
         // Search forward from the l1Origin, skipping forward in 5 minute increments until an L1 block with an L2 safe head greater than the l2_end_block is found.
         let mut current_l1_block_number = l1_origin.number;
         loop {
-            println!("loop");
             // If the current L1 block number is greater than the latest L1 header number, then return an error.
             if current_l1_block_number > latest_l1_header.number {
                 println!(

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -25,6 +25,7 @@ pub struct ExecutionStats {
     pub nb_transactions: u64,
     pub eth_gas_used: u64,
     pub l1_fees: U256,
+    pub total_tx_fees: u128,
     pub cycles_per_block: u64,
     pub cycles_per_transaction: u64,
     pub transactions_per_block: u64,
@@ -125,7 +126,8 @@ impl ExecutionStats {
         self.batch_end = end;
         self.nb_transactions = block_data.iter().map(|b| b.transaction_count).sum();
         self.eth_gas_used = block_data.iter().map(|b| b.gas_used).sum();
-        self.l1_fees = block_data.iter().map(|b| b.l1_gas_cost).sum();
+        self.l1_fees = block_data.iter().map(|b| b.total_l1_fees).sum();
+        self.total_tx_fees = block_data.iter().map(|b| b.total_tx_fees).sum();
         self.nb_blocks = end - start + 1;
     }
 

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use crate::fetcher::OPSuccinctDataFetcher;
-use alloy_primitives::U256;
 use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Serialize};
 use sp1_sdk::{CostEstimator, ExecutionReport};
@@ -24,7 +23,7 @@ pub struct ExecutionStats {
     pub nb_blocks: u64,
     pub nb_transactions: u64,
     pub eth_gas_used: u64,
-    pub l1_fees: U256,
+    pub l1_fees: u128,
     pub total_tx_fees: u128,
     pub cycles_per_block: u64,
     pub cycles_per_transaction: u64,

--- a/utils/host/src/witnessgen.rs
+++ b/utils/host/src/witnessgen.rs
@@ -98,8 +98,6 @@ impl WitnessGenExecutor {
         let child = tokio::process::Command::new(target_dir)
             .args(&args)
             .env("RUST_LOG", "info")
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
             .spawn()?;
         self.ongoing_processes.push(WitnessGenProcess {
             child,

--- a/utils/host/src/witnessgen.rs
+++ b/utils/host/src/witnessgen.rs
@@ -98,6 +98,8 @@ impl WitnessGenExecutor {
         let child = tokio::process::Command::new(target_dir)
             .args(&args)
             .env("RUST_LOG", "info")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
             .spawn()?;
         self.ongoing_processes.push(WitnessGenProcess {
             child,


### PR DESCRIPTION
- Add `total_tx_fees` to the `BlockInfo`. Useful for determining the total fees collected by the rollup.
- Simplify the `cost_estimator`. Write to the CSV progressively.
- Add `client` logs by adding a `tracing_subscriber` feature, mimicking the `kona-client`.