### PR TITLE
refactor(witnessgen): error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -4300,6 +4300,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sp1-sdk",
+ "sysinfo 0.32.0",
  "tokio",
 ]
 
@@ -6845,7 +6846,7 @@ dependencies = [
  "sp1-primitives 3.0.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
  "strum",
  "strum_macros",
- "sysinfo",
+ "sysinfo 0.30.13",
  "thiserror 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
@@ -7054,7 +7055,21 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "windows",
+ "windows 0.52.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ae3f4f7d64646c46c4cae4e3f01d1c5d255c7406fdd7c7f999a94e488791"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -7897,7 +7912,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7911,13 +7936,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -7936,7 +8004,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -6,26 +6,6 @@ edition.workspace = true
 
 [dependencies]
 
-# workspace
-alloy = { workspace = true }
-alloy-rlp.workspace = true
-
-alloy-primitives.workspace = true
-alloy-consensus.workspace = true
-alloy-sol-types.workspace = true
-rkyv.workspace = true
-serde_json.workspace = true
-anyhow.workspace = true
-cargo_metadata.workspace = true
-serde_cbor.workspace = true
-dotenv.workspace = true
-tokio.workspace = true
-futures.workspace = true
-num-format.workspace = true
-serde.workspace = true
-reqwest.workspace = true
-log.workspace = true
-
 # sp1
 sp1-sdk.workspace = true
 
@@ -39,6 +19,29 @@ op-alloy-network.workspace = true
 op-alloy-protocol.workspace = true
 op-alloy-consensus.workspace = true
 
+# alloy
+alloy = { workspace = true }
+alloy-rlp.workspace = true
+alloy-primitives.workspace = true
+alloy-consensus.workspace = true
+alloy-sol-types.workspace = true
+
 # kona
 kona-host.workspace = true
 kona-primitives.workspace = true
+
+# general
+rkyv.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+cargo_metadata.workspace = true
+serde_cbor.workspace = true
+dotenv.workspace = true
+tokio.workspace = true
+futures.workspace = true
+num-format.workspace = true
+serde.workspace = true
+reqwest.workspace = true
+log.workspace = true
+sysinfo = "0.32.0"
+


### PR DESCRIPTION
Kill the spawned native programs using the `sysinfo` crate, by killing all of the processes that have a `native_host_runner` parent process in the witness generation list.

The previous methodology of killing all native programs with a specified name (e.g. `range`) on the machine caused issues, because a single failed witness generation process would inadvertently kill all other ongoing witness generation processes. This made it difficult to discover which witness generation process had an issue.

Reorganize the `Cargo.toml` inside of `op-succinct-host-utils` to be more straightforward.