### PR TITLE
feat(proposer): Error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4321,6 +4321,7 @@ dependencies = [
  "op-succinct-host-utils",
  "serde",
  "serde_json",
+ "serde_repr",
  "sp1-sdk",
  "tokio",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,6 +4320,7 @@ dependencies = [
  "op-succinct-client-utils",
  "op-succinct-host-utils",
  "serde",
+ "serde_json",
  "sp1-sdk",
  "tokio",
  "tower-http",

--- a/configs/480/rollup.json
+++ b/configs/480/rollup.json
@@ -1,0 +1,48 @@
+{
+  "genesis": {
+    "l1": {
+      "number": 20170118,
+      "hash": "0x793daed4743301e00143be5533cd1dce0a741519e9e9c96588a9ad7dbb4d8db4"
+    },
+    "l2": {
+      "number": 0,
+      "hash": "0x70d316d2e0973b62332ba2e9768dd7854298d7ffe77f0409ffdb8d859f2d3fa3"
+    },
+    "l2_time": 1719335639,
+    "system_config": {
+      "batcherAddr": "0xdbbe3d8c2d2b22a2611c5a94a9a12c2fcd49eb29",
+      "overhead": "0xbc",
+      "scalar": "0xa6fe0",
+      "gasLimit": 100000000,
+      "baseFeeScalar": null,
+      "blobBaseFeeScalar": null,
+      "eip1559Denominator": null,
+      "eip1559Elasticity": null
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 1800,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "granite_channel_timeout": 50,
+  "l1_chain_id": 1,
+  "l2_chain_id": 480,
+  "base_fee_params": {
+    "max_change_denominator": "0x32",
+    "elasticity_multiplier": "0xa"
+  },
+  "canyon_base_fee_params": {
+    "max_change_denominator": "0xfa",
+    "elasticity_multiplier": "0xa"
+  },
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 1721826000,
+  "granite_time": 1727780400,
+  "batch_inbox_address": "0xff00000000000000000000000000000000000480",
+  "deposit_contract_address": "0xd5ec14a83b7d95be1e2ac12523e2dee12cbeea6c",
+  "l1_system_config_address": "0x6ab0777fd0e609ce58f939a7f70fe41f5aa6300a",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}

--- a/proposer/db-utils/query_proofs.py
+++ b/proposer/db-utils/query_proofs.py
@@ -96,8 +96,14 @@ if __name__ == "__main__":
     if L2OO_ADDRESS is None:
         raise ValueError("L2OO_ADDRESS not found in .env file")
 
+    # Get chain ID from command line args
+    if len(sys.argv) != 2:
+        print("Usage: python query_proofs.py <chain_id>")
+        sys.exit(1)
+    chain_id = sys.argv[1]
+
     print(f"L2OO_ADDRESS: {L2OO_ADDRESS}")
-    db_path = "../../db/808813/proofs.db"
+    db_path = f"../../db/{chain_id}/proofs.db"
 
     # Get all span proofs
     print("\nSpan Proofs:")

--- a/proposer/op/proposer/driver.go
+++ b/proposer/op/proposer/driver.go
@@ -169,7 +169,7 @@ func (l *L2OutputSubmitter) StartL2OutputSubmitting() error {
 		return fmt.Errorf("failed to get witness generation pending proofs: %w", err)
 	}
 	for _, req := range witnessGenReqs {
-		err = l.RetryRequest(req)
+		err = l.RetryRequest(req, ProofStatusResponse{})
 		if err != nil {
 			return fmt.Errorf("failed to retry request: %w", err)
 		}

--- a/proposer/op/proposer/driver.go
+++ b/proposer/op/proposer/driver.go
@@ -692,6 +692,8 @@ func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output *eth.Outpu
 	l.Metr.RecordL2BlocksProposed(output.BlockRef)
 }
 
+// checkpointBlockHash gets the current L1 head, and then sends a transaction to checkpoint the blockhash on
+// the L2OO contract for the aggregation proof.
 func (l *L2OutputSubmitter) checkpointBlockHash(ctx context.Context) (uint64, common.Hash, error) {
 	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()

--- a/proposer/op/proposer/metrics/metrics.go
+++ b/proposer/op/proposer/metrics/metrics.go
@@ -23,6 +23,7 @@ type OPSuccinctMetricer interface {
 	opproposermetrics.Metricer
 
 	RecordProposerStatus(metrics ProposerMetrics)
+	RecordError(label string, num uint64)
 }
 
 type OPSuccinctMetrics struct {
@@ -154,6 +155,20 @@ func (m *OPSuccinctMetrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {
 
 func (m *OPSuccinctMetrics) Document() []opmetrics.DocumentedMetric {
 	return m.factory.Document()
+}
+
+// RecordError increments the error counter for the given label
+func (m *OPSuccinctMetrics) RecordError(label string, num uint64) {
+	switch label {
+	case "witnessgen":
+		m.ErrorCount.WithLabelValues("witnessgen", "", "", "").Add(float64(num))
+	case "prove":
+		m.ErrorCount.WithLabelValues("", "prove", "", "").Add(float64(num))
+	case "get_proof_status":
+		m.ErrorCount.WithLabelValues("", "", "get_proof_status", "").Add(float64(num))
+	case "validate_config":
+		m.ErrorCount.WithLabelValues("", "", "", "validate_config").Add(float64(num))
+	}
 }
 
 // RecordProposerStatus sets the proposer Prometheus metrics to the given values.

--- a/proposer/op/proposer/metrics/metrics.go
+++ b/proposer/op/proposer/metrics/metrics.go
@@ -5,15 +5,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opproposermetrics "github.com/ethereum-optimism/optimism/op-proposer/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/prometheus/client_golang/prometheus"
-
-	
 )
 
 const Namespace = "op_succinct_proposer"
@@ -46,6 +44,8 @@ type OPSuccinctMetrics struct {
 	L2FinalizedBlock               prometheus.Gauge
 	LatestContractL2Block          prometheus.Gauge
 	HighestProvenContiguousL2Block prometheus.Gauge
+
+	ErrorCount *prometheus.CounterVec
 }
 
 var _ OPSuccinctMetricer = (*OPSuccinctMetrics)(nil)
@@ -109,6 +109,16 @@ func NewMetrics(procName string) *OPSuccinctMetrics {
 			Namespace: ns,
 			Name:      "highest_proven_contiguous_l2_block",
 			Help:      "Highest proven L2 block contiguous with contract's latest block",
+		}),
+		ErrorCount: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "error_count",
+			Help:      "Number of errors encountered",
+		}, []string{
+			"witnessgen",
+			"prove",
+			"get_proof_status",
+			"validate_config",
 		}),
 	}
 }

--- a/proposer/op/proposer/metrics/noop.go
+++ b/proposer/op/proposer/metrics/noop.go
@@ -22,6 +22,8 @@ var NoopMetrics OPSuccinctMetricer = new(noopMetrics)
 
 func (*noopMetrics) RecordProposerStatus(metrics ProposerMetrics) {}
 func (*noopMetrics) RecordError(label string, num uint64)         {}
+func (*noopMetrics) RecordProveFailure(reason string)             {}
+func (*noopMetrics) RecordWitnessGenFailure(reason string)        {}
 
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}

--- a/proposer/op/proposer/metrics/noop.go
+++ b/proposer/op/proposer/metrics/noop.go
@@ -21,6 +21,7 @@ type noopMetrics struct {
 var NoopMetrics OPSuccinctMetricer = new(noopMetrics)
 
 func (*noopMetrics) RecordProposerStatus(metrics ProposerMetrics) {}
+func (*noopMetrics) RecordError(label string, num uint64)         {}
 
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -388,6 +388,8 @@ func (l *L2OutputSubmitter) GetProofStatus(proofId string) (ProofStatusResponse,
 	// Create a variable of the Response type
 	var proofStatus ProofStatusResponse
 
+	fmt.Println(string(body))
+
 	// Unmarshal the JSON into the response variable
 	err = json.Unmarshal(body, &proofStatus)
 	if err != nil {

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -54,7 +54,7 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 			l.Log.Error("failed to get proof status for ID", "id", req.ProverRequestID, "err", err)
 			return err
 		}
-		if proofStatus.Status == "PROOF_FULFILLED" {
+		if proofStatus.Status == SP1ProofStatusFulfilled {
 			// Update the proof in the DB and update status to COMPLETE.
 			l.Log.Info("Fulfilled Proof", "id", req.ProverRequestID)
 			err = l.db.AddFulfilledProof(req.ID, proofStatus.Proof)
@@ -67,7 +67,7 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 
 		// TODO: Is this proof timeout logic necessary? Users should be able to count on the proof being fulfilled or unclaimed.
 		timeout := uint64(time.Now().Unix()) > req.ProofRequestTime+l.DriverSetup.Cfg.ProofTimeout
-		if timeout || proofStatus.Status == "PROOF_UNCLAIMED" {
+		if timeout || proofStatus.Status == SP1ProofStatusUnclaimed {
 			if timeout {
 				l.Log.Info("proof timed out", "id", req.ProverRequestID)
 			} else {

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -331,6 +331,11 @@ func (l *L2OutputSubmitter) RequestProofFromServer(proofType proofrequest.Type, 
 	}
 	defer resp.Body.Close()
 
+	// If there's an error, return it.
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
+	}
+
 	// Read the response body.
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -338,7 +343,7 @@ func (l *L2OutputSubmitter) RequestProofFromServer(proofType proofrequest.Type, 
 	}
 
 	// Create a variable of the Response type.
-	var response ProofResponse
+	var response WitnessGenerationResponse
 
 	// Unmarshal the JSON into the response variable.
 	err = json.Unmarshal(body, &response)
@@ -369,15 +374,15 @@ func (l *L2OutputSubmitter) GetProofStatus(proofId string) (ProofStatusResponse,
 	}
 	defer resp.Body.Close()
 
+	// If the response status code is not 200, return an error.
+	if resp.StatusCode != http.StatusOK {
+		return ProofStatusResponse{}, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
+	}
+
 	// Read the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return ProofStatusResponse{}, fmt.Errorf("error reading the response body: %v", err)
-	}
-
-	// If the response status code is not 200, return an error.
-	if resp.StatusCode != http.StatusOK {
-		return ProofStatusResponse{}, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
 	}
 
 	// Create a variable of the Response type

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -83,7 +83,6 @@ func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest, status ProofStat
 
 	// If the proof was unclaimed due to a program execution error, we should split the proof into two.
 	if status.UnclaimDescription == ProgramExecutionError {
-		l.Log.Info("proof unclaimed due to program execution error, splitting into two", "id", req.ID, "type", req.Type, "start", req.StartBlock, "end", req.EndBlock)
 		mid := (req.StartBlock + req.EndBlock) / 2
 		// Create two new proof requests, one from [start, mid] and one from [mid, end]. The requests
 		// are consecutive and overlapping.
@@ -98,7 +97,6 @@ func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest, status ProofStat
 			return err
 		}
 	} else {
-		l.Log.Info("proof unclaimed, retrying with same range", "id", req.ID, "type", req.Type, "start", req.StartBlock, "end", req.EndBlock)
 		// If the proof was unclaimed for any other reason, retry with the same range.
 		err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)
 		if err != nil {

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -37,7 +37,7 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 	}
 
 	for _, req := range failedReqs {
-		err = l.RetryRequest(req)
+		err = l.RetryRequest(req, ProofStatusResponse{})
 		if err != nil {
 			return fmt.Errorf("failed to retry request: %w", err)
 		}
@@ -49,15 +49,15 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 		return err
 	}
 	for _, req := range reqs {
-		status, proof, err := l.GetProofStatus(req.ProverRequestID)
+		proofStatus, err := l.GetProofStatus(req.ProverRequestID)
 		if err != nil {
 			l.Log.Error("failed to get proof status for ID", "id", req.ProverRequestID, "err", err)
 			return err
 		}
-		if status == "PROOF_FULFILLED" {
+		if proofStatus.Status == "PROOF_FULFILLED" {
 			// Update the proof in the DB and update status to COMPLETE.
 			l.Log.Info("Fulfilled Proof", "id", req.ProverRequestID)
-			err = l.db.AddFulfilledProof(req.ID, proof)
+			err = l.db.AddFulfilledProof(req.ID, proofStatus.Proof)
 			if err != nil {
 				l.Log.Error("failed to update completed proof status", "err", err)
 				return err
@@ -65,8 +65,9 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 			continue
 		}
 
+		// TODO: Is this proof timeout logic necessary? Users should be able to count on the proof being fulfilled or unclaimed.
 		timeout := uint64(time.Now().Unix()) > req.ProofRequestTime+l.DriverSetup.Cfg.ProofTimeout
-		if timeout || status == "PROOF_UNCLAIMED" {
+		if timeout || proofStatus.Status == "PROOF_UNCLAIMED" {
 			if timeout {
 				l.Log.Info("proof timed out", "id", req.ProverRequestID)
 			} else {
@@ -79,7 +80,7 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 				return err
 			}
 
-			err = l.RetryRequest(req)
+			err = l.RetryRequest(req, proofStatus)
 			if err != nil {
 				return fmt.Errorf("failed to retry request: %w", err)
 			}
@@ -89,7 +90,7 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 	return nil
 }
 
-func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest) error {
+func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest, status ProofStatusResponse) error {
 	err := l.db.UpdateProofStatus(req.ID, proofrequest.StatusFAILED)
 	if err != nil {
 		l.Log.Error("failed to update proof status", "err", err)
@@ -97,11 +98,29 @@ func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest) error {
 	}
 
 	l.Log.Info("Retrying proof", "id", req.ID, "type", req.Type, "start", req.StartBlock, "end", req.EndBlock)
-	// TODO: For range proofs, add custom logic to split the proof into two if the error is an execution error.
-	err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)
-	if err != nil {
-		l.Log.Error("failed to add new proof request", "err", err)
-		return err
+
+	// If the proof was unclaimed due to a program execution error, we should split the proof into two.
+	if status.UnclaimDescription == ProgramExecutionError {
+		mid := (req.StartBlock + req.EndBlock) / 2
+		// Create two new proof requests, one from [start, mid] and one from [mid, end]. The requests
+		// are consecutive and overlapping.
+		err = l.db.NewEntry(req.Type, req.StartBlock, mid)
+		if err != nil {
+			l.Log.Error("failed to add first proof request", "err", err)
+			return err
+		}
+		err = l.db.NewEntry(req.Type, mid, req.EndBlock)
+		if err != nil {
+			l.Log.Error("failed to add second proof request", "err", err)
+			return err
+		}
+	} else {
+		// If the proof was unclaimed for any other reason, retry with the same range.
+		err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)
+		if err != nil {
+			l.Log.Error("failed to add proof request", "err", err)
+			return err
+		}
 	}
 
 	return nil
@@ -173,7 +192,7 @@ func (l *L2OutputSubmitter) RequestQueuedProofs(ctx context.Context) error {
 			}
 
 			// If the proof fails to be requested, we should add it to the queue to be retried.
-			err = l.RetryRequest(nextProofToRequest)
+			err = l.RetryRequest(nextProofToRequest, ProofStatusResponse{})
 			if err != nil {
 				l.Log.Error("failed to retry request", "err", err)
 			}
@@ -336,10 +355,10 @@ func (l *L2OutputSubmitter) RequestProofFromServer(proofType proofrequest.Type, 
 }
 
 // Get the status of a proof given its ID.
-func (l *L2OutputSubmitter) GetProofStatus(proofId string) (string, []byte, error) {
+func (l *L2OutputSubmitter) GetProofStatus(proofId string) (ProofStatusResponse, error) {
 	req, err := http.NewRequest("GET", l.Cfg.OPSuccinctServerUrl+"/status/"+proofId, nil)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to create request: %w", err)
+		return ProofStatusResponse{}, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	client := &http.Client{
@@ -348,28 +367,33 @@ func (l *L2OutputSubmitter) GetProofStatus(proofId string) (string, []byte, erro
 	resp, err := client.Do(req)
 	if err != nil {
 		if err, ok := err.(net.Error); ok && err.Timeout() {
-			return "", nil, fmt.Errorf("request timed out after %s: %w", PROOF_STATUS_TIMEOUT, err)
+			return ProofStatusResponse{}, fmt.Errorf("request timed out after %s: %w", PROOF_STATUS_TIMEOUT, err)
 		}
-		return "", nil, fmt.Errorf("failed to send request: %w", err)
+		return ProofStatusResponse{}, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// Read the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", nil, fmt.Errorf("error reading the response body: %v", err)
+		return ProofStatusResponse{}, fmt.Errorf("error reading the response body: %v", err)
+	}
+
+	// If the response status code is not 200, return an error.
+	if resp.StatusCode != http.StatusOK {
+		return ProofStatusResponse{}, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
 	}
 
 	// Create a variable of the Response type
-	var response ProofStatus
+	var proofStatus ProofStatusResponse
 
 	// Unmarshal the JSON into the response variable
-	err = json.Unmarshal(body, &response)
+	err = json.Unmarshal(body, &proofStatus)
 	if err != nil {
-		return "", nil, fmt.Errorf("error decoding JSON response: %v", err)
+		return ProofStatusResponse{}, fmt.Errorf("error decoding JSON response: %v", err)
 	}
 
-	return response.Status, response.Proof, nil
+	return proofStatus, nil
 }
 
 // Validate the contract's configuration of the aggregation and range verification keys as well

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -73,12 +73,6 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 			} else {
 				l.Log.Info("proof unclaimed", "id", req.ProverRequestID)
 			}
-			// update status in db to "FAILED"
-			err = l.db.UpdateProofStatus(req.ID, proofrequest.StatusFAILED)
-			if err != nil {
-				l.Log.Error("failed to update failed proof status", "err", err)
-				return err
-			}
 
 			err = l.RetryRequest(req, proofStatus)
 			if err != nil {
@@ -90,6 +84,8 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 	return nil
 }
 
+// Retry a proof request. Sets the status of a proof to FAILED and retries the proof based on the optional proof status response.
+// If the response is a program execution error, the proof is split into two, which will avoid SP1 out of memory execution errors.
 func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest, status ProofStatusResponse) error {
 	err := l.db.UpdateProofStatus(req.ID, proofrequest.StatusFAILED)
 	if err != nil {

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -20,7 +20,9 @@ type ValidateConfigResponse struct {
 	RangeVkeyValid        bool `json:"range_vkey_valid"`
 }
 
-type ProofResponse struct {
+// WitnessGenerationResponse is the response type for the `request_span_proof` and `request_agg_proof`
+// RPCs from the op-succinct-server.
+type WitnessGenerationResponse struct {
 	ProofID string `json:"proof_id"`
 }
 

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -24,7 +24,18 @@ type ProofResponse struct {
 	ProofID string `json:"proof_id"`
 }
 
-type ProofStatus struct {
-	Status string `json:"status"`
-	Proof  []byte `json:"proof"`
+type UnclaimDescription int
+
+const (
+	UnexpectedProverError UnclaimDescription = iota
+	ProgramExecutionError
+	CycleLimitExceeded
+	Other
+)
+
+// ProofStatusResponse is the response type for the `GetProofStatus` RPC from the op-succinct-server.
+type ProofStatusResponse struct {
+	Status             string             `json:"status"`
+	Proof              []byte             `json:"proof"`
+	UnclaimDescription UnclaimDescription `json:"unclaim_description,omitempty"`
 }

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -24,6 +24,7 @@ type ProofResponse struct {
 	ProofID string `json:"proof_id"`
 }
 
+// UnclaimDescription is the description of why a proof was unclaimed.
 type UnclaimDescription int
 
 const (
@@ -33,9 +34,21 @@ const (
 	Other
 )
 
+// SP1ProofStatus represents the status of a proof in the SP1 network.
+type SP1ProofStatus int
+
+const (
+	SP1ProofStatusUnknown SP1ProofStatus = iota
+	SP1ProofStatusPending
+	SP1ProofStatusInProgress
+	SP1ProofStatusFulfilled
+	SP1ProofStatusUnclaimed
+	SP1ProofStatusInvalid
+)
+
 // ProofStatusResponse is the response type for the `GetProofStatus` RPC from the op-succinct-server.
 type ProofStatusResponse struct {
-	Status             string             `json:"status"`
+	Status             SP1ProofStatus     `json:"status"`
 	Proof              []byte             `json:"proof"`
 	UnclaimDescription UnclaimDescription `json:"unclaim_description,omitempty"`
 }

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -33,8 +33,25 @@ const (
 	UnexpectedProverError UnclaimDescription = iota
 	ProgramExecutionError
 	CycleLimitExceeded
+	// Other is a catch-all for any other unclaim description that doesn't fit into the above categories.
+	// Typically, this is used for proofs that are forcibly unclaimed by the cluster.
 	Other
 )
+
+func (d UnclaimDescription) String() string {
+	switch d {
+	case UnexpectedProverError:
+		return "UnexpectedProverError"
+	case ProgramExecutionError:
+		return "ProgramExecutionError" 
+	case CycleLimitExceeded:
+		return "CycleLimitExceeded"
+	case Other:
+		return "Other"
+	default:
+		return "Unknown"
+	}
+}
 
 // SP1ProofStatus represents the status of a proof in the SP1 network.
 type SP1ProofStatus int

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -40,15 +40,15 @@ const (
 type SP1ProofStatus int
 
 const (
-	SP1ProofStatusUnknown SP1ProofStatus = iota
-	SP1ProofStatusPending
-	SP1ProofStatusInProgress
-	SP1ProofStatusFulfilled
+	SP1ProofStatusUnspecified SP1ProofStatus = iota
+	SP1ProofStatusPreparing
+	SP1ProofStatusRequested
+	SP1ProofStatusClaimed
 	SP1ProofStatusUnclaimed
-	SP1ProofStatusInvalid
+	SP1ProofStatusFulfilled
 )
 
-// ProofStatusResponse is the response type for the `GetProofStatus` RPC from the op-succinct-server.
+// ProofStatusResponse is the response type for the `/status/:proof_id` RPC from the op-succinct-server.
 type ProofStatusResponse struct {
 	Status             SP1ProofStatus     `json:"status"`
 	Proof              []byte             `json:"proof"`

--- a/proposer/op/proposer/span_batches.go
+++ b/proposer/op/proposer/span_batches.go
@@ -14,6 +14,7 @@ type Span struct {
 	End   uint64
 }
 
+// CreateSpans creates a list of spans of size MaxBlockRangePerSpanProof from start to end. Note: The end of span i = start of span i+1.
 func (l *L2OutputSubmitter) CreateSpans(start, end uint64) []Span {
 	spans := []Span{}
 	// Create spans of size MaxBlockRangePerSpanProof from start to end.

--- a/proposer/succinct/Cargo.toml
+++ b/proposer/succinct/Cargo.toml
@@ -28,6 +28,7 @@ anyhow.workspace = true
 dotenv.workspace = true
 op-succinct-client-utils.workspace = true
 serde = { workspace = true }
+serde_json.workspace = true
 
 # server
 axum = "0.7.4"

--- a/proposer/succinct/Cargo.toml
+++ b/proposer/succinct/Cargo.toml
@@ -36,6 +36,7 @@ bincode.workspace = true
 log.workspace = true
 base64.workspace = true
 tower-http.workspace = true
+serde_repr = "0.1.19"
 
 [build-dependencies]
 op-succinct-build-utils.workspace = true

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -228,7 +228,7 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ProofStatus {
-                        status: SP1ProofStatus::ProofUnspecifiedStatus,
+                        status: SP1ProofStatus::ProofUnspecifiedStatus.into(),
                         proof: vec![],
                         unclaim_description: None,
                     }),
@@ -238,7 +238,7 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ProofStatus {
-                        status: SP1ProofStatus::ProofUnspecifiedStatus,
+                        status: SP1ProofStatus::ProofUnspecifiedStatus.into(),
                         proof: vec![],
                         unclaim_description: None,
                     }),

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -34,9 +34,12 @@ pub struct ProofResponse {
 }
 
 #[derive(Serialize)]
+/// The status of a proof request.
 pub struct ProofStatus {
+    // TODO: Modify this to return an i32 matching `SP1ProofStatus`
     pub status: String,
     pub proof: Vec<u8>,
+    pub unclaim_description: Option<i32>,
 }
 
 /// Configuration of the L2 Output Oracle contract. Created once at server start-up, monitors if there are any changes

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -60,7 +60,6 @@ impl From<String> for UnclaimDescription {
 #[derive(Serialize)]
 /// The status of a proof request.
 pub struct ProofStatus {
-    // TODO: Modify this to return an i32 matching `SP1ProofStatus`
     pub status: SP1ProofStatus,
     pub proof: Vec<u8>,
     pub unclaim_description: Option<UnclaimDescription>,

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::B256;
 use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Deserializer, Serialize};
-use sp1_sdk::{network::proto::network::ProofStatus as SP1ProofStatus, SP1VerifyingKey};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use sp1_sdk::SP1VerifyingKey;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidateConfigRequest {
@@ -33,7 +34,7 @@ pub struct ProofResponse {
     pub proof_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize_repr, Deserialize_repr)]
 #[repr(i32)]
 /// The type of error that occurred when unclaiming a proof. Based off of the `unclaim_description`
 /// field in the `ProofStatus` struct.
@@ -57,10 +58,12 @@ impl From<String> for UnclaimDescription {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 /// The status of a proof request.
 pub struct ProofStatus {
-    pub status: SP1ProofStatus,
+    // Note: Can't use `SP1ProofStatus` directly because `Serialize_repr` and `Deserialize_repr` aren't derived on it.
+    // serde_repr::Serialize_repr and Deserialize_repr are necessary to use `SP1ProofStatus` in this struct.
+    pub status: i32,
     pub proof: Vec<u8>,
     pub unclaim_description: Option<UnclaimDescription>,
 }


### PR DESCRIPTION
- Add error handling based on the `UnclaimDescription`. If a proof failed due to `program execution error`, split the proof in half.
- Add argument for `query_proofs.py`.
- Add metrics for errors + prove failures + witness gen failures.
- Backoff on `validateConfig` to avoid throwing unnecessary errors.
- Use `int`'s instead of strings for better type handling in the RPC.