### PR TITLE
feat: data fetcher fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,6 +4376,8 @@ dependencies = [
  "futures",
  "kona-host",
  "log",
+ "op-alloy-consensus",
+ "op-alloy-network",
  "op-succinct-build-utils",
  "op-succinct-client-utils",
  "op-succinct-host-utils",

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -49,8 +49,9 @@ async fn main() {
     let range_vkey_commitment = B256::from(multi_block_vkey_u8);
     let agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
 
-    let mut fetcher = OPSuccinctDataFetcher::default();
-    fetcher.fetch_and_save_rollup_config().await.unwrap();
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
     // Note: The rollup config hash never changes for a given chain, so we can just hash it once at
     // server start-up. The only time a rollup config changes is typically when a new version of the
     // [`RollupConfig`] is released from `op-alloy`.
@@ -116,8 +117,9 @@ async fn request_span_proof(
     Json(payload): Json<SpanProofRequest>,
 ) -> Result<(StatusCode, Json<ProofResponse>), AppError> {
     info!("Received span proof request: {:?}", payload);
-    let mut fetcher = OPSuccinctDataFetcher::default();
-    fetcher.fetch_and_save_rollup_config().await.unwrap();
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
 
     let host_cli = fetcher
         .get_host_cli_args(
@@ -192,8 +194,9 @@ async fn request_agg_proof(
     )?;
     let l1_head: [u8; 32] = l1_head_bytes.try_into().unwrap();
 
-    let mut fetcher = OPSuccinctDataFetcher::default();
-    fetcher.fetch_and_save_rollup_config().await.unwrap();
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
     let headers = fetcher
         .get_header_preimages(&boot_infos, l1_head.into())
         .await?;

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -49,11 +49,12 @@ async fn main() {
     let range_vkey_commitment = B256::from(multi_block_vkey_u8);
     let agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
 
-    let fetcher = OPSuccinctDataFetcher::default();
+    let mut fetcher = OPSuccinctDataFetcher::default();
+    fetcher.fetch_and_save_rollup_config().await.unwrap();
     // Note: The rollup config hash never changes for a given chain, so we can just hash it once at
     // server start-up. The only time a rollup config changes is typically when a new version of the
     // [`RollupConfig`] is released from `op-alloy`.
-    let rollup_config_hash = hash_rollup_config(&fetcher.rollup_config);
+    let rollup_config_hash = hash_rollup_config(&fetcher.rollup_config.as_ref().unwrap());
 
     // Initialize global hashes.
     let global_hashes = ContractConfig {
@@ -115,9 +116,10 @@ async fn request_span_proof(
     Json(payload): Json<SpanProofRequest>,
 ) -> Result<(StatusCode, Json<ProofResponse>), AppError> {
     info!("Received span proof request: {:?}", payload);
-    let data_fetcher = OPSuccinctDataFetcher::default();
+    let mut fetcher = OPSuccinctDataFetcher::default();
+    fetcher.fetch_and_save_rollup_config().await.unwrap();
 
-    let host_cli = data_fetcher
+    let host_cli = fetcher
         .get_host_cli_args(
             payload.start,
             payload.end,
@@ -190,7 +192,8 @@ async fn request_agg_proof(
     )?;
     let l1_head: [u8; 32] = l1_head_bytes.try_into().unwrap();
 
-    let fetcher = OPSuccinctDataFetcher::default();
+    let mut fetcher = OPSuccinctDataFetcher::default();
+    fetcher.fetch_and_save_rollup_config().await.unwrap();
     let headers = fetcher
         .get_header_preimages(&boot_infos, l1_head.into())
         .await?;

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -55,7 +55,7 @@ async fn main() {
     // Note: The rollup config hash never changes for a given chain, so we can just hash it once at
     // server start-up. The only time a rollup config changes is typically when a new version of the
     // [`RollupConfig`] is released from `op-alloy`.
-    let rollup_config_hash = hash_rollup_config(&fetcher.rollup_config.as_ref().unwrap());
+    let rollup_config_hash = hash_rollup_config(fetcher.rollup_config.as_ref().unwrap());
 
     // Initialize global hashes.
     let global_hashes = ContractConfig {

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -50,7 +50,8 @@ async fn main() -> Result<()> {
     }
     utils::setup_logger();
 
-    let data_fetcher = OPSuccinctDataFetcher::default();
+    let mut data_fetcher = OPSuccinctDataFetcher::default();
+    data_fetcher.fetch_and_save_rollup_config().await?;
 
     let cache_mode = if args.use_cache {
         CacheMode::KeepCache

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -50,8 +50,9 @@ async fn main() -> Result<()> {
     }
     utils::setup_logger();
 
-    let mut data_fetcher = OPSuccinctDataFetcher::default();
-    data_fetcher.fetch_and_save_rollup_config().await?;
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
 
     let cache_mode = if args.use_cache {
         CacheMode::KeepCache

--- a/scripts/prove/bin/single.rs
+++ b/scripts/prove/bin/single.rs
@@ -35,8 +35,9 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     utils::setup_logger();
 
-    let mut data_fetcher = OPSuccinctDataFetcher::default();
-    data_fetcher.fetch_and_save_rollup_config().await?;
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
 
     let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 

--- a/scripts/prove/bin/single.rs
+++ b/scripts/prove/bin/single.rs
@@ -35,7 +35,9 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     utils::setup_logger();
 
-    let data_fetcher = OPSuccinctDataFetcher::default();
+    let mut data_fetcher = OPSuccinctDataFetcher::default();
+    data_fetcher.fetch_and_save_rollup_config().await?;
+
     let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 
     let l2_safe_head = args.l2_block - 1;

--- a/scripts/utils/Cargo.toml
+++ b/scripts/utils/Cargo.toml
@@ -53,6 +53,10 @@ kona-host = { workspace = true }
 op-succinct-host-utils.workspace = true
 op-succinct-client-utils.workspace = true
 
+# op-alloy
+op-alloy-consensus.workspace = true
+op-alloy-network.workspace = true
+
 # sp1
 sp1-sdk = { workspace = true }
 dashmap = { version = "6.1.0", features = ["rayon"] }

--- a/scripts/utils/bin/block_data.rs
+++ b/scripts/utils/bin/block_data.rs
@@ -1,29 +1,21 @@
+use alloy::{
+    providers::{Provider, ProviderBuilder, RootProvider},
+    transports::http::Http,
+};
 use anyhow::Result;
 use clap::Parser;
-use op_succinct_host_utils::fetcher::{BlockInfo, OPSuccinctDataFetcher};
+use futures::{stream, StreamExt};
+use log::info;
+use op_alloy_network::Optimism;
+use op_succinct_host_utils::fetcher::BlockInfo;
+use reqwest::{Client, Url};
 use sp1_sdk::utils;
 use std::{
     fs::{self},
     path::PathBuf,
+    str::FromStr,
+    sync::Arc,
 };
-
-/// Write the block data to a CSV file.
-fn write_block_data_to_csv(report_path: &PathBuf, block_data: &[BlockInfo]) -> Result<()> {
-    if let Some(parent) = report_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let mut csv_writer = csv::Writer::from_path(report_path)?;
-
-    for block in block_data {
-        csv_writer
-            .serialize(block)
-            .expect("Failed to write execution stats to CSV.");
-    }
-    csv_writer.flush().expect("Failed to flush CSV writer.");
-
-    Ok(())
-}
 
 /// The arguments for the host executable.
 #[derive(Debug, Clone, Parser)]
@@ -39,6 +31,160 @@ struct BlockDataArgs {
     env_file: PathBuf,
 }
 
+#[derive(Debug, Clone, Default, serde::Serialize)]
+struct AggregatedBlockData {
+    transaction_count: u64,
+    gas_used: u64,
+    total_l1_fees: u128,
+    total_tx_fees: u128,
+    nb_blocks: u64,
+    avg_txns_per_block: f64,
+    avg_gas_per_block: f64,
+    avg_l1_fees_per_block: f64,
+    avg_tx_fees_per_block: f64,
+}
+
+impl AggregatedBlockData {
+    fn new(block_data: &[BlockInfo]) -> Self {
+        let total_txns: u64 = block_data.iter().map(|b| b.transaction_count).sum();
+        let total_gas: u64 = block_data.iter().map(|b| b.gas_used).sum();
+        let total_l1_fees: u128 = block_data.iter().map(|b| b.total_l1_fees).sum();
+        let total_tx_fees: u128 = block_data.iter().map(|b| b.total_tx_fees).sum();
+        let num_blocks = block_data.len() as u64;
+
+        Self {
+            transaction_count: total_txns,
+            gas_used: total_gas,
+            total_l1_fees,
+            total_tx_fees,
+            nb_blocks: num_blocks,
+            avg_txns_per_block: ((total_txns - num_blocks) as f64 / num_blocks as f64),
+            avg_gas_per_block: total_gas as f64 / num_blocks as f64,
+            avg_l1_fees_per_block: total_l1_fees as f64 / num_blocks as f64,
+            avg_tx_fees_per_block: total_tx_fees as f64 / num_blocks as f64,
+        }
+    }
+}
+
+impl std::fmt::Display for AggregatedBlockData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "\nAggregate Block Data:")?;
+        writeln!(f, "Total Blocks: {}", self.nb_blocks)?;
+        writeln!(
+            f,
+            "Total Transactions (excluding system txns): {}",
+            self.transaction_count - self.nb_blocks
+        )?;
+        writeln!(f, "Total Gas Used: {}", self.gas_used)?;
+        writeln!(
+            f,
+            "Total L1 Fees: {:.6} ETH",
+            self.total_l1_fees as f64 / 1e18
+        )?;
+        writeln!(
+            f,
+            "Total TX Fees: {:.6} ETH",
+            self.total_tx_fees as f64 / 1e18
+        )?;
+        writeln!(
+            f,
+            "Avg Txns/Block (excluding system txns): {:.5}",
+            self.avg_txns_per_block
+        )?;
+        writeln!(f, "Avg Gas/Block: {:.2}", self.avg_gas_per_block)?;
+        writeln!(
+            f,
+            "Avg L1 Fees/Block: {:.6} ETH",
+            self.avg_l1_fees_per_block / 1e18
+        )?;
+        writeln!(
+            f,
+            "Avg TX Fees/Block: {:.6} ETH",
+            self.avg_tx_fees_per_block / 1e18
+        )
+    }
+}
+
+/// Write the block data to a CSV file. Returns the block data.
+async fn write_block_data_to_csv(
+    args: &BlockDataArgs,
+    l2_provider: Arc<RootProvider<Http<Client>, Optimism>>,
+    report_path: PathBuf,
+) -> Result<Vec<BlockInfo>> {
+    // Create CSV writer with headers
+    let mut csv_writer = csv::Writer::from_path(&report_path)?;
+
+    // Process blocks in chunks and write incrementally.
+    const CHUNK_SIZE: u64 = 1000;
+    let mut current_start = args.start;
+
+    let mut all_data: Vec<BlockInfo> = Vec::new();
+    while current_start <= args.end {
+        let chunk_end = (current_start + CHUNK_SIZE - 1).min(args.end);
+
+        let chunk_data = stream::iter(current_start..=chunk_end)
+            .map(|block_number| {
+                let l2_provider = l2_provider.clone();
+                async move {
+                    let block = match l2_provider
+                        .get_block_by_number(block_number.into(), false)
+                        .await?
+                    {
+                        Some(block) => block,
+                        None => return Err(anyhow::anyhow!("Block {} not found", block_number)),
+                    };
+
+                    let receipts = match l2_provider.get_block_receipts(block_number.into()).await?
+                    {
+                        Some(receipts) => receipts,
+                        None => {
+                            return Err(anyhow::anyhow!(
+                                "Receipts for block {} not found",
+                                block_number
+                            ))
+                        }
+                    };
+                    let total_l1_fees: u128 = receipts
+                        .iter()
+                        .map(|tx| tx.l1_block_info.l1_fee.unwrap_or(0))
+                        .sum();
+                    let total_tx_fees: u128 = receipts
+                        .iter()
+                        .map(|tx| {
+                            tx.inner.effective_gas_price * tx.inner.gas_used
+                                + tx.l1_block_info.l1_fee.unwrap_or(0)
+                        })
+                        .sum();
+
+                    Ok(BlockInfo {
+                        block_number,
+                        transaction_count: block.transactions.len() as u64,
+                        gas_used: block.header.gas_used,
+                        total_l1_fees,
+                        total_tx_fees,
+                    })
+                }
+            })
+            .buffered(100)
+            .collect::<Vec<Result<BlockInfo>>>()
+            .await;
+
+        // Write the data for each block in the chunk to the CSV file.
+        for block_result in chunk_data {
+            if let Ok(block) = block_result {
+                csv_writer.serialize(&block)?;
+                all_data.push(block);
+            }
+        }
+        csv_writer.flush()?;
+
+        info!("Processed blocks {} to {}", current_start, chunk_end);
+        current_start = chunk_end + 1;
+    }
+
+    Ok(all_data)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = BlockDataArgs::parse();
@@ -46,50 +192,36 @@ async fn main() -> Result<()> {
     dotenv::from_path(&args.env_file).ok();
     utils::setup_logger();
 
-    let data_fetcher = OPSuccinctDataFetcher::default();
+    let l2_provider: Arc<RootProvider<Http<Client>, Optimism>> = Arc::new(
+        ProviderBuilder::default()
+            .on_http(Url::from_str(&std::env::var("L2_RPC").unwrap()).unwrap()),
+    );
+    let l2_chain_id = l2_provider.get_chain_id().await?;
 
-    let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
-
-    let l2_block_data = data_fetcher
-        .get_l2_block_data_range(args.start, args.end)
+    // Confirm that the start and end blocks are valid.
+    let start_block = l2_provider
+        .get_block_by_number(args.start.into(), false)
         .await?;
+    let end_block = l2_provider
+        .get_block_by_number(args.end.into(), false)
+        .await?;
+    if start_block.is_none() || end_block.is_none() {
+        return Err(anyhow::anyhow!("Invalid start or end block"));
+    }
 
-    // Calculate aggregates
-    let total_txns: u64 = l2_block_data.iter().map(|b| b.transaction_count).sum();
-    let total_gas: u64 = l2_block_data.iter().map(|b| b.gas_used).sum();
-    let total_l1_fees: u128 = l2_block_data.iter().map(|b| b.total_l1_fees).sum();
-    let total_tx_fees: u128 = l2_block_data.iter().map(|b| b.total_tx_fees).sum();
-    let num_blocks = l2_block_data.len() as u64;
-
+    // Create the file at the report path.
     let report_path = PathBuf::from(format!(
         "block-data/{}/{}-{}-block-data.csv",
         l2_chain_id, args.start, args.end
     ));
+    if let Some(parent) = report_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
 
-    write_block_data_to_csv(&report_path, &l2_block_data)?;
-    println!("Wrote block data to {}", report_path.display());
+    let l2_block_data = write_block_data_to_csv(&args, l2_provider, report_path).await?;
 
-    println!(
-        "\nAggregate Block Data for blocks {} to {}:",
-        args.start, args.end
-    );
-    println!("Total Blocks: {}", num_blocks);
-    println!("Total Transactions: {}", total_txns);
-    println!("Total Gas Used: {}", total_gas);
-    println!("Total L1 Fees: {:.6} ETH", total_l1_fees as f64 / 1e18);
-    println!("Total TX Fees: {:.6} ETH", total_tx_fees as f64 / 1e18);
-    println!(
-        "Avg Txns/Block: {:.2}",
-        total_txns as f64 / num_blocks as f64
-    );
-    println!("Avg Gas/Block: {:.2}", total_gas as f64 / num_blocks as f64);
-    println!(
-        "Avg L1 Fees/Block: {:.6} ETH",
-        (total_l1_fees as f64 / num_blocks as f64) / 1e18
-    );
-    println!(
-        "Avg TX Fees/Block: {:.6} ETH",
-        (total_tx_fees as f64 / num_blocks as f64) / 1e18
-    );
+    // Calculate aggregate statistics.
+    let aggregated_data = AggregatedBlockData::new(&l2_block_data);
+    println!("{}", aggregated_data);
     Ok(())
 }

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -133,11 +133,12 @@ async fn execute_blocks_parallel(
     l2_chain_id: u64,
     args: &CostEstimatorArgs,
 ) {
+    let mut data_fetcher = OPSuccinctDataFetcher::default();
+    data_fetcher.fetch_and_save_rollup_config().await.unwrap();
+
     // Fetch all of the execution stats block ranges in parallel.
     let block_data = futures::stream::iter(ranges.clone())
-        .map(|range| async move {
-            // Create a new data fetcher. This avoids the runtime dropping the provider dispatch task.
-            let data_fetcher = OPSuccinctDataFetcher::default();
+        .map(|range| async {
             let block_data = data_fetcher
                 .get_l2_block_data_range(range.start, range.end)
                 .await

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -133,8 +133,9 @@ async fn execute_blocks_parallel(
     l2_chain_id: u64,
     args: &CostEstimatorArgs,
 ) {
-    let mut data_fetcher = OPSuccinctDataFetcher::default();
-    data_fetcher.fetch_and_save_rollup_config().await.unwrap();
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
 
     // Fetch all of the execution stats block ranges in parallel.
     let block_data = futures::stream::iter(ranges.clone())

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -45,8 +45,9 @@ struct L2OOConfig {
 /// - vkey: Get the vkey from the aggregation program ELF.
 /// - owner: Set to the address associated with the private key.
 async fn update_l2oo_config() -> Result<()> {
-    let mut data_fetcher = OPSuccinctDataFetcher::default();
-    data_fetcher.fetch_and_save_rollup_config().await.unwrap();
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
+        .await
+        .unwrap();
     // Get the workspace root with cargo metadata to make the paths.
     let workspace_root = PathBuf::from(
         cargo_metadata::MetadataCommand::new()
@@ -67,7 +68,7 @@ async fn update_l2oo_config() -> Result<()> {
     // Convert the starting block number to a hex string for the optimism_outputAtBlock RPC call.
     let starting_block_number_hex = format!("0x{:x}", l2oo_config.starting_block_number);
     let optimism_output_data: Value = data_fetcher
-        .fetch_rpc_data(
+        .fetch_rpc_data_with_mode(
             RPCMode::L2Node,
             "optimism_outputAtBlock",
             vec![starting_block_number_hex.into()],

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -45,8 +45,8 @@ struct L2OOConfig {
 /// - vkey: Get the vkey from the aggregation program ELF.
 /// - owner: Set to the address associated with the private key.
 async fn update_l2oo_config() -> Result<()> {
-    let data_fetcher = OPSuccinctDataFetcher::default();
-
+    let mut data_fetcher = OPSuccinctDataFetcher::default();
+    data_fetcher.fetch_and_save_rollup_config().await.unwrap();
     // Get the workspace root with cargo metadata to make the paths.
     let workspace_root = PathBuf::from(
         cargo_metadata::MetadataCommand::new()
@@ -75,13 +75,13 @@ async fn update_l2oo_config() -> Result<()> {
         .await?;
 
     // Hash the rollup config.
-    let hash: B256 = hash_rollup_config(&data_fetcher.rollup_config);
+    let hash: B256 = hash_rollup_config(&data_fetcher.rollup_config.as_ref().unwrap());
     // Set the rollup config hash.
     let hash_str = format!("0x{:x}", hash);
     l2oo_config.rollup_config_hash = hash_str;
 
     // Set the L2 block time from the rollup config.
-    l2oo_config.l2_block_time = data_fetcher.rollup_config.block_time;
+    l2oo_config.l2_block_time = data_fetcher.rollup_config.as_ref().unwrap().block_time;
 
     // Set the starting output root and starting timestamp.
     l2oo_config.starting_output_root = optimism_output_data["outputRoot"]

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -76,7 +76,7 @@ async fn update_l2oo_config() -> Result<()> {
         .await?;
 
     // Hash the rollup config.
-    let hash: B256 = hash_rollup_config(&data_fetcher.rollup_config.as_ref().unwrap());
+    let hash: B256 = hash_rollup_config(data_fetcher.rollup_config.as_ref().unwrap());
     // Set the rollup config hash.
     let hash_str = format!("0x{:x}", hash);
     l2oo_config.rollup_config_hash = hash_str;

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -584,7 +584,7 @@ impl OPSuccinctDataFetcher {
         cache_mode: CacheMode,
     ) -> Result<HostCli> {
         // If the rollup config is not already loaded, fetch and save it.
-        if let None = self.rollup_config {
+        if self.rollup_config.is_none() {
             return Err(anyhow::anyhow!("Rollup config not loaded."));
         }
         let l2_chain_id = self.rollup_config.as_ref().unwrap().l2_chain_id;
@@ -779,7 +779,7 @@ impl OPSuccinctDataFetcher {
     /// E.g. Origin Advance Error: BlockInfoFetch(Block number past L1 head.).
     async fn get_l1_head(&self, l2_end_block: u64) -> Result<(B256, u64)> {
         // If the rollup config is not already loaded, fetch and save it.
-        if let None = self.rollup_config {
+        if self.rollup_config.is_none() {
             return Err(anyhow::anyhow!("Rollup config not loaded."));
         }
         let l2_chain_id = self.rollup_config.as_ref().unwrap().l2_chain_id;
@@ -819,7 +819,7 @@ impl OPSuccinctDataFetcher {
 
     pub async fn l2_block_info_by_number(&self, block_number: u64) -> Result<L2BlockInfo> {
         // If the rollup config is not already loaded, fetch and save it.
-        if let None = self.rollup_config {
+        if self.rollup_config.is_none() {
             return Err(anyhow::anyhow!("Rollup config not loaded."));
         }
         let genesis = self.rollup_config.as_ref().unwrap().genesis;

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -12,7 +12,6 @@ use anyhow::Result;
 use cargo_metadata::MetadataCommand;
 use futures::{stream, StreamExt};
 use kona_host::HostCli;
-use log::info;
 use op_alloy_consensus::OpBlock;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_network::{
@@ -27,13 +26,12 @@ use op_alloy_rpc_types::{
 use op_succinct_client_utils::boot::BootInfoStruct;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use sp1_sdk::block_on;
 use std::{cmp::Ordering, collections::HashMap, env, fs, path::Path, str::FromStr, sync::Arc};
 
 use alloy_primitives::{keccak256, Bytes, U256, U64};
 
 use crate::{
-    rollup_config::{get_rollup_config_path, merge_rollup_config, save_rollup_config},
+    rollup_config::{get_rollup_config_path, merge_rollup_config},
     L2Output, ProgramType,
 };
 
@@ -46,13 +44,12 @@ pub struct OPSuccinctDataFetcher {
     pub rpc_config: RPCConfig,
     pub l1_provider: Arc<RootProvider<Http<Client>>>,
     pub l2_provider: Arc<RootProvider<Http<Client>, Optimism>>,
-    pub rollup_config: RollupConfig,
-    pub l1_block_time_secs: u64,
+    pub rollup_config: Option<RollupConfig>,
 }
 
 impl Default for OPSuccinctDataFetcher {
     fn default() -> Self {
-        block_on(OPSuccinctDataFetcher::new())
+        OPSuccinctDataFetcher::new()
     }
 }
 
@@ -112,7 +109,7 @@ pub struct FeeData {
 
 impl OPSuccinctDataFetcher {
     /// Gets the RPC URL's and saves the rollup config for the chain to the rollup config file.
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         let rpc_config = get_rpcs();
 
         let l1_provider = Arc::new(
@@ -122,31 +119,31 @@ impl OPSuccinctDataFetcher {
             ProviderBuilder::default().on_http(Url::from_str(&rpc_config.l2_rpc).unwrap()),
         );
 
-        let mut fetcher = OPSuccinctDataFetcher {
+        OPSuccinctDataFetcher {
             rpc_config,
             l1_provider,
             l2_provider,
-            rollup_config: RollupConfig::default(),
-            // Default L1 block time for most Ethereum chains.
-            l1_block_time_secs: 12,
-        };
+            rollup_config: None,
+        }
+    }
 
-        // Get the L1 block time.
-        let l1_block_time_secs = fetcher
-            .get_l1_block_time()
-            .await
-            .expect("Failed to get L1 block time. Make sure that the L1 RPC is active.");
-        fetcher.l1_block_time_secs = l1_block_time_secs;
+    /// Initialize the fetcher with a rollup config.
+    pub fn new_with_rollup_config(rollup_config: RollupConfig) -> Self {
+        let rpc_config = get_rpcs();
 
-        // Load and save the rollup config.
-        let rollup_config = fetcher
-            .fetch_rollup_config()
-            .await
-            .expect("Failed to fetch rollup config");
-        save_rollup_config(&rollup_config).expect("Failed to save rollup config");
-        fetcher.rollup_config = rollup_config;
+        let l1_provider = Arc::new(
+            ProviderBuilder::default().on_http(Url::from_str(&rpc_config.l1_rpc).unwrap()),
+        );
+        let l2_provider = Arc::new(
+            ProviderBuilder::default().on_http(Url::from_str(&rpc_config.l2_rpc).unwrap()),
+        );
 
-        fetcher
+        OPSuccinctDataFetcher {
+            rpc_config,
+            l1_provider,
+            l2_provider,
+            rollup_config: Some(rollup_config),
+        }
     }
 
     pub async fn get_l2_chain_id(&self) -> Result<u64> {
@@ -331,44 +328,39 @@ impl OPSuccinctDataFetcher {
     pub async fn get_l2_block_data_range(&self, start: u64, end: u64) -> Result<Vec<BlockInfo>> {
         use futures::stream::{self, StreamExt};
 
-        let l2_provider = self.l2_provider.clone();
         let block_data = stream::iter(start..=end)
-            .map(|block_number| {
-                let l2_provider = l2_provider.clone();
-                async move {
-                    if block_number % 1000 == 0 {
-                        info!("Fetching block: {}", block_number);
-                    }
-                    let block = l2_provider
-                        .get_block_by_number(block_number.into(), false)
-                        .await?
-                        .unwrap();
-                    let receipts = l2_provider
-                        .get_block_receipts(block_number.into())
-                        .await?
-                        .unwrap();
-                    let total_l1_fees: u128 = receipts
-                        .iter()
-                        .map(|tx| tx.l1_block_info.l1_fee.unwrap_or(0))
-                        .sum();
-                    let total_tx_fees: u128 = receipts
-                        .iter()
-                        .map(|tx| {
-                            // tx.inner.effective_gas_price * tx.inner.gas_used + tx.l1_block_info.l1_fee is the total fee for the transaction.
-                            // tx.inner.effective_gas_price * tx.inner.gas_used is the tx fee on L2.
-                            tx.inner.effective_gas_price * tx.inner.gas_used
-                                + tx.l1_block_info.l1_fee.unwrap_or(0)
-                        })
-                        .sum();
-
-                    Ok(BlockInfo {
-                        block_number,
-                        transaction_count: block.transactions.len() as u64,
-                        gas_used: block.header.gas_used,
-                        total_l1_fees,
-                        total_tx_fees,
+            .map(|block_number| async move {
+                let block = self
+                    .l2_provider
+                    .get_block_by_number(block_number.into(), false)
+                    .await?
+                    .unwrap();
+                let receipts = self
+                    .l2_provider
+                    .get_block_receipts(block_number.into())
+                    .await?
+                    .unwrap();
+                let total_l1_fees: u128 = receipts
+                    .iter()
+                    .map(|tx| tx.l1_block_info.l1_fee.unwrap_or(0))
+                    .sum();
+                let total_tx_fees: u128 = receipts
+                    .iter()
+                    .map(|tx| {
+                        // tx.inner.effective_gas_price * tx.inner.gas_used + tx.l1_block_info.l1_fee is the total fee for the transaction.
+                        // tx.inner.effective_gas_price * tx.inner.gas_used is the tx fee on L2.
+                        tx.inner.effective_gas_price * tx.inner.gas_used
+                            + tx.l1_block_info.l1_fee.unwrap_or(0)
                     })
-                }
+                    .sum();
+
+                Ok(BlockInfo {
+                    block_number,
+                    transaction_count: block.transactions.len() as u64,
+                    gas_used: block.header.gas_used,
+                    total_l1_fees,
+                    total_tx_fees,
+                })
             })
             .buffered(100)
             .collect::<Vec<Result<BlockInfo>>>()
@@ -446,15 +438,33 @@ impl OPSuccinctDataFetcher {
     }
 
     /// Fetch the rollup config. Combines the rollup config from `optimism_rollupConfig` and the
-    /// chain config from `debug_chainConfig`.
-    pub async fn fetch_rollup_config(&self) -> Result<RollupConfig> {
+    /// chain config from `debug_chainConfig`. Saves the rollup config to the rollup config file and
+    /// in memory.
+    pub async fn fetch_and_save_rollup_config(&mut self) -> Result<()> {
         let rollup_config = self
             .fetch_rpc_data(RPCMode::L2Node, "optimism_rollupConfig", vec![])
             .await?;
         let chain_config = self
             .fetch_rpc_data(RPCMode::L2, "debug_chainConfig", vec![])
             .await?;
-        merge_rollup_config(&rollup_config, &chain_config)
+        let rollup_config = merge_rollup_config(&rollup_config, &chain_config)?;
+
+        // Save rollup config to the rollup config file.
+        let rollup_config_path = get_rollup_config_path(rollup_config.l2_chain_id)?;
+
+        // Create the directory for the rollup config if it doesn't exist.
+        let rollup_configs_dir = rollup_config_path.parent().unwrap();
+        if !rollup_configs_dir.exists() {
+            fs::create_dir_all(rollup_configs_dir)?;
+        }
+
+        // Write the rollup config to the file.
+        let rollup_config_str = serde_json::to_string_pretty(&rollup_config)?;
+        fs::write(rollup_config_path, rollup_config_str)?;
+
+        // Save the rollup config in memory.
+        self.rollup_config = Some(rollup_config);
+        Ok(())
     }
 
     /// Fetch arbitrary data from the RPC.
@@ -573,6 +583,12 @@ impl OPSuccinctDataFetcher {
         multi_block: ProgramType,
         cache_mode: CacheMode,
     ) -> Result<HostCli> {
+        // If the rollup config is not already loaded, fetch and save it.
+        if let None = self.rollup_config {
+            return Err(anyhow::anyhow!("Rollup config not loaded."));
+        }
+        let l2_chain_id = self.rollup_config.as_ref().unwrap().l2_chain_id;
+
         if l2_start_block >= l2_end_block {
             return Err(anyhow::anyhow!(
                 "L2 start block is greater than or equal to L2 end block. Start: {}, End: {}",
@@ -642,14 +658,14 @@ impl OPSuccinctDataFetcher {
             ProgramType::Single => {
                 let proof_dir = format!(
                     "{}/data/{}/single/{}",
-                    workspace_root, self.rollup_config.l2_chain_id, l2_end_block
+                    workspace_root, l2_chain_id, l2_end_block
                 );
                 proof_dir
             }
             ProgramType::Multi => {
                 let proof_dir = format!(
                     "{}/data/{}/multi/{}-{}",
-                    workspace_root, self.rollup_config.l2_chain_id, l2_start_block, l2_end_block
+                    workspace_root, l2_chain_id, l2_start_block, l2_end_block
                 );
                 proof_dir
             }
@@ -674,7 +690,7 @@ impl OPSuccinctDataFetcher {
         }
 
         // Create the path to the rollup config file.
-        let rollup_config_path = get_rollup_config_path(self.rollup_config.l2_chain_id)?;
+        let rollup_config_path = get_rollup_config_path(l2_chain_id)?;
 
         // Creates the data directory if it doesn't exist, or no-ops if it does. Used to store the
         // witness data.
@@ -712,6 +728,8 @@ impl OPSuccinctDataFetcher {
 
     /// Get the L1 block from which the `l2_end_block` can be derived.
     async fn get_l1_head_with_safe_head(&self, l2_end_block: u64) -> Result<(B256, u64)> {
+        let l1_block_time_secs = self.get_l1_block_time().await?;
+
         let latest_l1_header = self.get_l1_header(BlockId::latest()).await?;
 
         // Get the l1 origin of the l2 end block.
@@ -751,7 +769,7 @@ impl OPSuccinctDataFetcher {
 
             // Move forward in 5 minute increments.
             const SKIP_MINS: u64 = 5;
-            current_l1_block_number += SKIP_MINS * (60 / self.l1_block_time_secs);
+            current_l1_block_number += SKIP_MINS * (60 / l1_block_time_secs);
         }
     }
 
@@ -760,6 +778,12 @@ impl OPSuccinctDataFetcher {
     /// relevant L2 block data can be derived.
     /// E.g. Origin Advance Error: BlockInfoFetch(Block number past L1 head.).
     async fn get_l1_head(&self, l2_end_block: u64) -> Result<(B256, u64)> {
+        // If the rollup config is not already loaded, fetch and save it.
+        if let None = self.rollup_config {
+            return Err(anyhow::anyhow!("Rollup config not loaded."));
+        }
+        let l2_chain_id = self.rollup_config.as_ref().unwrap().l2_chain_id;
+
         // See if optimism_safeHeadAtL1Block is available. If there's an error, then estimate the L1 block necessary based on the chain config.
         let result = self.get_l1_head_with_safe_head(l2_end_block).await;
 
@@ -768,7 +792,7 @@ impl OPSuccinctDataFetcher {
         } else {
             // Estimate the L1 block necessary based on the chain config. This is based on the maximum
             // delay between batches being posted on the L2 chain.
-            let max_batch_post_delay_minutes = match self.rollup_config.l2_chain_id {
+            let max_batch_post_delay_minutes = match l2_chain_id {
                 11155420 => 10,
                 10 => 10,
                 8453 => 10,
@@ -794,11 +818,13 @@ impl OPSuccinctDataFetcher {
     }
 
     pub async fn l2_block_info_by_number(&self, block_number: u64) -> Result<L2BlockInfo> {
+        // If the rollup config is not already loaded, fetch and save it.
+        if let None = self.rollup_config {
+            return Err(anyhow::anyhow!("Rollup config not loaded."));
+        }
+        let genesis = self.rollup_config.as_ref().unwrap().genesis;
         let block = self.get_l2_block_by_number(block_number).await?;
-        Ok(L2BlockInfo::from_block_and_genesis(
-            &block,
-            &self.rollup_config.genesis,
-        )?)
+        Ok(L2BlockInfo::from_block_and_genesis(&block, &genesis)?)
     }
 
     /// Get the L2 safe head corresponding to the L1 block number using optimism_safeHeadAtBlock.
@@ -849,11 +875,13 @@ mod tests {
         use alloy::eips::BlockId;
 
         dotenv::dotenv().ok();
-        let fetcher = OPSuccinctDataFetcher::new().await;
+        let mut fetcher = OPSuccinctDataFetcher::new();
+        fetcher.fetch_and_save_rollup_config().await.unwrap();
         let latest_l2_block = fetcher.get_l2_header(BlockId::latest()).await.unwrap();
 
         // Get the L2 block number from 1 hour ago.
-        let l2_end_block = latest_l2_block.number - ((60 * 60) / fetcher.rollup_config.block_time);
+        let l2_end_block = latest_l2_block.number
+            - ((60 * 60) / fetcher.rollup_config.as_ref().unwrap().block_time);
 
         let _ = fetcher.get_l1_head(l2_end_block).await.unwrap();
     }
@@ -868,7 +896,7 @@ mod tests {
         use crate::fetcher::RPCMode;
 
         dotenv::dotenv().ok();
-        let fetcher = OPSuccinctDataFetcher::new().await;
+        let fetcher = OPSuccinctDataFetcher::new();
         let mut l2_safe_heads = Vec::new();
 
         let latest_l1_block = fetcher.get_l1_header(BlockId::latest()).await.unwrap();

--- a/utils/host/src/rollup_config.rs
+++ b/utils/host/src/rollup_config.rs
@@ -114,22 +114,6 @@ pub(crate) fn merge_rollup_config(
     Ok(rollup_config)
 }
 
-/// Save rollup config to the rollup config file.
-pub fn save_rollup_config(rollup_config: &RollupConfig) -> Result<()> {
-    let rollup_config_path = get_rollup_config_path(rollup_config.l2_chain_id)?;
-
-    // Create the directory for the rollup config if it doesn't exist.
-    let rollup_configs_dir = rollup_config_path.parent().unwrap();
-    if !rollup_configs_dir.exists() {
-        fs::create_dir_all(rollup_configs_dir)?;
-    }
-
-    // Write the rollup config to the file.
-    let rollup_config_str = serde_json::to_string_pretty(rollup_config)?;
-    fs::write(rollup_config_path, rollup_config_str)?;
-    Ok(())
-}
-
 /// Get the path to the rollup config file for the given chain id.
 pub fn get_rollup_config_path(l2_chain_id: u64) -> Result<PathBuf> {
     let workspace_root = cargo_metadata::MetadataCommand::new()


### PR DESCRIPTION
- Create a `DataFetcher::new_with_rollup_config` method that loads and saves the rollup config. This enables initializing the data fetcher without a valid `L2_NODE_RPC` (or one with the specified endpoints for `op-succinct` enabled), which is useful for fetching the L2 block/fee data.
- Incrementally write the block data in the `block-data` script, so at least a partial amount of the data will be written.