### PR TITLE
fix(scripts): Load rollup config

### DIFF
--- a/scripts/prove/bin/agg.rs
+++ b/scripts/prove/bin/agg.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
     let prover = ProverClient::new();
-    let fetcher = OPSuccinctDataFetcher::default();
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
 
     let (_, vkey) = prover.setup(MULTI_BLOCK_ELF);
 

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -276,7 +276,7 @@ async fn main() -> Result<()> {
     dotenv::from_path(&args.env_file).ok();
     utils::setup_logger();
 
-    let data_fetcher = OPSuccinctDataFetcher::default();
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
 
     let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 


### PR DESCRIPTION
Load the rollup config in the data fetcher for the `agg` and `cost_estimator` scripts.