### PR TITLE
docs: fix typo

### DIFF
--- a/book/advanced/verify-binaries.md
+++ b/book/advanced/verify-binaries.md
@@ -37,11 +37,11 @@ Then build the binaries:
 ```bash
 cd programs/range
 # Build the range-elf
-cargo prove build --elf range-elf --docker
+cargo prove build --elf-name range-elf --docker
 
 cd ../aggregation
 # Build the aggregation-elf
-cargo prove build --elf aggregation-elf --docker
+cargo prove build --elf-name aggregation-elf --docker
 ```
 
 Now, verify the binaries by confirming the output of `vkey` matches the vkeys on the contract. The `vkey` program outputs the verification keys


### PR DESCRIPTION
### Description
Encountered an error when running the command:

```bash
error: unexpected argument '--elf' found
```
It seems that the correct argument might be `--elf-name` instead.

see: https://github.com/succinctlabs/sp1/blob/dev/crates/build/src/lib.rs#L70