### PR TITLE
feat: display cycle count on CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,9 +48,13 @@ jobs:
 
       - name: Run multi script
         run: |
-          cargo run --bin multi --release
+          cargo test --test "multi" --release
         env:
           L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_RPC }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: OP Sepolia cost estimator on recent block range
         run: |
-          RUST_LOG=info cargo run --bin cost-estimator --release
+          RUST_LOG=info cargo run --bin cost-estimator --release -- --rolling
         env:
           L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
           L1_RPC: ${{ secrets.L1_RPC }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: OP Sepolia cost estimator om recent block range
+      - name: OP Sepolia cost estimator on recent block range
         run: |
           RUST_LOG=info cargo run --bin cost-estimator --release
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,9 +37,9 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: OP Sepolia Blocks 19000000 to 19000030
+      - name: OP Sepolia cost estimator om recent block range
         run: |
-          RUST_LOG=info cargo run --bin cost-estimator --release -- --start 19000000 --end 19000030
+          RUST_LOG=info cargo run --bin cost-estimator --release
         env:
           L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
           L1_RPC: ${{ secrets.L1_RPC }}

--- a/scripts/prove/Cargo.toml
+++ b/scripts/prove/Cargo.toml
@@ -47,5 +47,9 @@ alloy-eips = { workspace = true }
 # sp1
 sp1-sdk = { workspace = true }
 
+[dev-dependencies]
+reqwest = { version = "0.12.4", features = ["json"] }
+serde_json = { workspace = true }
+
 [build-dependencies]
 op-succinct-build-utils.workspace = true

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -106,7 +106,6 @@ async fn main() -> Result<()> {
             &prover,
             &data_fetcher,
             sp1_stdin,
-            l2_chain_id,
             l2_start_block,
             l2_end_block,
         )
@@ -120,6 +119,12 @@ async fn main() -> Result<()> {
         );
 
         println!("Execution Stats: \n{:?}", stats);
+
+        // Create the report directory if it doesn't exist.
+        let report_dir = format!("execution-reports/multi/{}", l2_chain_id);
+        if !std::path::Path::new(&report_dir).exists() {
+            fs::create_dir_all(&report_dir)?;
+        }
 
         let report_path = format!(
             "execution-reports/multi/{}/{}-{}.csv",

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -7,7 +7,7 @@ use op_succinct_host_utils::{
     stats::ExecutionStats,
     ProgramType,
 };
-use op_succinct_prove::{execute_proof, generate_witness, DEFAULT_RANGE, MULTI_BLOCK_ELF};
+use op_succinct_prove::{execute_multi, generate_witness, DEFAULT_RANGE, MULTI_BLOCK_ELF};
 use sp1_sdk::{utils, ProverClient};
 use std::{fs, time::Duration};
 
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
     } else {
         let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 
-        let (block_data, report, execution_duration) = execute_proof(
+        let (block_data, report, execution_duration) = execute_multi(
             &prover,
             &data_fetcher,
             sp1_stdin,

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -37,7 +37,7 @@ struct Args {
     prove: bool,
 
     /// Env file.
-    #[arg(short, long, default_value = ".env")]
+    #[arg(long, default_value = ".env")]
     env_file: Option<String>,
 }
 

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -5,13 +5,11 @@ use op_succinct_host_utils::{
     fetcher::{CacheMode, OPSuccinctDataFetcher},
     get_proof_stdin,
     stats::ExecutionStats,
-    witnessgen::WitnessGenExecutor,
     ProgramType,
 };
+use op_succinct_prove::{execute_proof, generate_witness, DEFAULT_RANGE, MULTI_BLOCK_ELF};
 use sp1_sdk::{utils, ProverClient};
-use std::{fs, time::Instant};
-
-pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
+use std::{fs, time::Duration};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -51,17 +49,13 @@ async fn main() -> Result<()> {
     }
     utils::setup_logger();
 
-    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config()
-        .await
-        .unwrap();
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
 
     let cache_mode = if args.use_cache {
         CacheMode::KeepCache
     } else {
         CacheMode::DeleteCache
     };
-
-    const DEFAULT_RANGE: u64 = 5;
 
     // If the end block is provided, check that it is less than the latest finalized block. If the end block is not provided, use the latest finalized block.
     let (l2_start_block, l2_end_block) =
@@ -72,18 +66,11 @@ async fn main() -> Result<()> {
         .await?;
 
     // By default, re-run the native execution unless the user passes `--use-cache`.
-    let start_time = Instant::now();
-    if !args.use_cache {
-        // Start the server and native client.
-        let mut witnessgen_executor = WitnessGenExecutor::default();
-        witnessgen_executor.spawn_witnessgen(&host_cli).await?;
-        witnessgen_executor.flush().await?;
-    }
-    let witness_generation_time_sec = start_time.elapsed();
-    println!(
-        "Witness Generation Duration: {:?}",
-        witness_generation_time_sec.as_secs()
-    );
+    let witness_generation_time_sec = if !args.use_cache {
+        generate_witness(&host_cli).await?
+    } else {
+        Duration::ZERO
+    };
 
     // Get the stdin for the block.
     let sp1_stdin = get_proof_stdin(&host_cli)?;
@@ -113,28 +100,17 @@ async fn main() -> Result<()> {
             ))
             .expect("saving proof failed");
     } else {
-        let start_time = Instant::now();
-        let (_, report) = prover
-            .execute(MULTI_BLOCK_ELF, sp1_stdin.clone())
-            .run()
-            .unwrap();
-        let execution_duration = start_time.elapsed();
+        let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 
-        let l2_chain_id = data_fetcher.get_l2_chain_id().await.unwrap();
-        let report_path = format!(
-            "execution-reports/multi/{}/{}-{}.csv",
-            l2_chain_id, l2_start_block, l2_end_block
-        );
-
-        // Create the report directory if it doesn't exist.
-        let report_dir = format!("execution-reports/multi/{}", l2_chain_id);
-        if !std::path::Path::new(&report_dir).exists() {
-            fs::create_dir_all(&report_dir).unwrap();
-        }
-
-        let block_data = data_fetcher
-            .get_l2_block_data_range(l2_start_block, l2_end_block)
-            .await?;
+        let (block_data, report, execution_duration) = execute_proof(
+            &prover,
+            &data_fetcher,
+            sp1_stdin,
+            l2_chain_id,
+            l2_start_block,
+            l2_end_block,
+        )
+        .await?;
 
         let stats = ExecutionStats::new(
             &block_data,
@@ -142,7 +118,13 @@ async fn main() -> Result<()> {
             witness_generation_time_sec.as_secs(),
             execution_duration.as_secs(),
         );
+
         println!("Execution Stats: \n{:?}", stats);
+
+        let report_path = format!(
+            "execution-reports/multi/{}/{}-{}.csv",
+            l2_chain_id, l2_start_block, l2_end_block
+        );
 
         // Write to CSV.
         let mut csv_writer = csv::Writer::from_path(report_path)?;

--- a/scripts/prove/src/lib.rs
+++ b/scripts/prove/src/lib.rs
@@ -1,0 +1,61 @@
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Ok, Result};
+use kona_host::HostCli;
+use op_succinct_host_utils::{
+    fetcher::{BlockInfo, OPSuccinctDataFetcher},
+    witnessgen::WitnessGenExecutor,
+};
+use sp1_sdk::{ExecutionReport, ProverClient, SP1Stdin};
+
+pub const DEFAULT_RANGE: u64 = 5;
+
+pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
+
+pub async fn generate_witness(host_cli: &HostCli) -> Result<Duration> {
+    let start_time = Instant::now();
+
+    // Start the server and native client.
+    let mut witnessgen_executor = WitnessGenExecutor::default();
+    witnessgen_executor.spawn_witnessgen(&host_cli).await?;
+    witnessgen_executor.flush().await?;
+
+    let witness_generation_time_sec = start_time.elapsed();
+    println!(
+        "Witness Generation Duration: {:?}",
+        witness_generation_time_sec.as_secs()
+    );
+
+    Ok(witness_generation_time_sec)
+}
+
+pub async fn execute_proof(
+    prover: &ProverClient,
+    data_fetcher: &OPSuccinctDataFetcher,
+    sp1_stdin: SP1Stdin,
+    l2_chain_id: u64,
+    l2_start_block: u64,
+    l2_end_block: u64,
+) -> Result<(Vec<BlockInfo>, ExecutionReport, Duration)> {
+    let start_time = Instant::now();
+    let (_, report) = prover
+        .execute(MULTI_BLOCK_ELF, sp1_stdin.clone())
+        .run()
+        .unwrap();
+    let execution_duration = start_time.elapsed();
+
+    // Create the report directory if it doesn't exist.
+    let report_dir = format!("execution-reports/multi/{}", l2_chain_id);
+    if !std::path::Path::new(&report_dir).exists() {
+        fs::create_dir_all(&report_dir)?;
+    }
+
+    let block_data = data_fetcher
+        .get_l2_block_data_range(l2_start_block, l2_end_block)
+        .await?;
+
+    Ok((block_data, report, execution_duration))
+}

--- a/scripts/prove/src/lib.rs
+++ b/scripts/prove/src/lib.rs
@@ -20,7 +20,7 @@ pub async fn generate_witness(host_cli: &HostCli) -> Result<Duration> {
 
     // Start the server and native client.
     let mut witnessgen_executor = WitnessGenExecutor::default();
-    witnessgen_executor.spawn_witnessgen(&host_cli).await?;
+    witnessgen_executor.spawn_witnessgen(host_cli).await?;
     witnessgen_executor.flush().await?;
 
     let witness_generation_time_sec = start_time.elapsed();

--- a/scripts/prove/src/lib.rs
+++ b/scripts/prove/src/lib.rs
@@ -32,7 +32,7 @@ pub async fn generate_witness(host_cli: &HostCli) -> Result<Duration> {
     Ok(witness_generation_time_sec)
 }
 
-pub async fn execute_proof(
+pub async fn execute_multi(
     prover: &ProverClient,
     data_fetcher: &OPSuccinctDataFetcher,
     sp1_stdin: SP1Stdin,

--- a/scripts/prove/src/lib.rs
+++ b/scripts/prove/src/lib.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use anyhow::{Ok, Result};
 use kona_host::HostCli;
@@ -36,7 +33,6 @@ pub async fn execute_multi(
     prover: &ProverClient,
     data_fetcher: &OPSuccinctDataFetcher,
     sp1_stdin: SP1Stdin,
-    l2_chain_id: u64,
     l2_start_block: u64,
     l2_end_block: u64,
 ) -> Result<(Vec<BlockInfo>, ExecutionReport, Duration)> {
@@ -46,12 +42,6 @@ pub async fn execute_multi(
         .run()
         .unwrap();
     let execution_duration = start_time.elapsed();
-
-    // Create the report directory if it doesn't exist.
-    let report_dir = format!("execution-reports/multi/{}", l2_chain_id);
-    if !std::path::Path::new(&report_dir).exists() {
-        fs::create_dir_all(&report_dir)?;
-    }
 
     let block_data = data_fetcher
         .get_l2_block_data_range(l2_start_block, l2_end_block)

--- a/scripts/prove/tests/common/mod.rs
+++ b/scripts/prove/tests/common/mod.rs
@@ -1,0 +1,67 @@
+use reqwest::Client;
+use serde_json::json;
+
+pub async fn post_to_github_pr(
+    owner: &str,
+    repo: &str,
+    pr_number: &str,
+    token: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let base_url = format!("https://api.github.com/repos/{}/{}", owner, repo);
+
+    // Get all comments on the PR
+    let comments_url = format!("{}/issues/{}/comments", base_url, pr_number);
+    let comments_response = client
+        .get(&comments_url)
+        .header("Authorization", format!("token {}", token))
+        .header("User-Agent", "sp1-perf-bot")
+        .send()
+        .await?;
+
+    let comments: Vec<serde_json::Value> = comments_response.json().await?;
+
+    // Look for an existing comment from our bot
+    let bot_comment = comments.iter().find(|comment| {
+        comment["user"]["login"]
+            .as_str()
+            .map(|login| login == "github-actions[bot]")
+            .unwrap_or(false)
+    });
+
+    if let Some(existing_comment) = bot_comment {
+        // Update the existing comment
+        let comment_url = existing_comment["url"].as_str().unwrap();
+        let response = client
+            .patch(comment_url)
+            .header("Authorization", format!("token {}", token))
+            .header("User-Agent", "sp1-perf-bot")
+            .json(&json!({
+                "body": message
+            }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(format!("Failed to update comment: {:?}", response.text().await?).into());
+        }
+    } else {
+        // Create a new comment
+        let response = client
+            .post(&comments_url)
+            .header("Authorization", format!("token {}", token))
+            .header("User-Agent", "sp1-perf-bot")
+            .json(&json!({
+                "body": message
+            }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(format!("Failed to post comment: {:?}", response.text().await?).into());
+        }
+    }
+
+    Ok(())
+}

--- a/scripts/prove/tests/common/mod.rs
+++ b/scripts/prove/tests/common/mod.rs
@@ -1,6 +1,7 @@
 use reqwest::Client;
 use serde_json::json;
 
+/// Posts the provided message on the provided PR on Github.
 pub async fn post_to_github_pr(
     owner: &str,
     repo: &str,

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use common::post_to_github_pr;
+use op_succinct_host_utils::{
+    block_range::get_validated_block_range,
+    fetcher::{CacheMode, OPSuccinctDataFetcher},
+    get_proof_stdin,
+    stats::ExecutionStats,
+    ProgramType,
+};
+use op_succinct_prove::{execute_proof, generate_witness, DEFAULT_RANGE};
+use sp1_sdk::ProverClient;
+
+mod common;
+
+#[tokio::test]
+async fn execute_batch() -> Result<()> {
+    dotenv::dotenv()?;
+
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+
+    // Take the latest blocks
+    let (l2_start_block, l2_end_block) =
+        get_validated_block_range(&data_fetcher, None, None, DEFAULT_RANGE).await?;
+
+    let host_cli = data_fetcher
+        .get_host_cli_args(
+            l2_start_block,
+            l2_end_block,
+            ProgramType::Multi,
+            CacheMode::DeleteCache,
+        )
+        .await?;
+
+    let witness_generation_time_sec = generate_witness(&host_cli).await?;
+
+    // Get the stdin for the block.
+    let sp1_stdin = get_proof_stdin(&host_cli)?;
+
+    let prover = ProverClient::new();
+
+    let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
+
+    let (block_data, report, execution_duration) = execute_proof(
+        &prover,
+        &data_fetcher,
+        sp1_stdin,
+        l2_chain_id,
+        l2_start_block,
+        l2_end_block,
+    )
+    .await?;
+
+    let stats = ExecutionStats::new(
+        &block_data,
+        &report,
+        witness_generation_time_sec.as_secs(),
+        execution_duration.as_secs(),
+    );
+
+    let stats = stats.to_string();
+
+    println!("Execution Stats: \n{:?}", stats);
+
+    if let (Ok(owner), Ok(repo), Ok(pr_number), Ok(token)) = (
+        std::env::var("REPO_OWNER"),
+        std::env::var("REPO_NAME"),
+        std::env::var("PR_NUMBER"),
+        std::env::var("GITHUB_TOKEN"),
+    ) {
+        post_to_github_pr(&owner, &repo, &pr_number, &token, &stats)
+            .await
+            .unwrap();
+    }
+
+    Ok(())
+}

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -7,7 +7,7 @@ use op_succinct_host_utils::{
     stats::{ExecutionStats, MarkdownExecutionStats},
     ProgramType,
 };
-use op_succinct_prove::{execute_proof, generate_witness, DEFAULT_RANGE};
+use op_succinct_prove::{execute_multi, generate_witness, DEFAULT_RANGE};
 use sp1_sdk::ProverClient;
 
 mod common;
@@ -40,7 +40,7 @@ async fn execute_batch() -> Result<()> {
 
     let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 
-    let (block_data, report, execution_duration) = execute_proof(
+    let (block_data, report, execution_duration) = execute_multi(
         &prover,
         &data_fetcher,
         sp1_stdin,

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -4,7 +4,7 @@ use op_succinct_host_utils::{
     block_range::get_validated_block_range,
     fetcher::{CacheMode, OPSuccinctDataFetcher},
     get_proof_stdin,
-    stats::ExecutionStats,
+    stats::{ExecutionStats, MarkdownExecutionStats},
     ProgramType,
 };
 use op_succinct_prove::{execute_proof, generate_witness, DEFAULT_RANGE};
@@ -57,9 +57,7 @@ async fn execute_batch() -> Result<()> {
         execution_duration.as_secs(),
     );
 
-    let stats = stats.to_string();
-
-    println!("Execution Stats: \n{:?}", stats);
+    println!("Execution Stats: \n{:?}", stats.to_string());
 
     if let (Ok(owner), Ok(repo), Ok(pr_number), Ok(token)) = (
         std::env::var("REPO_OWNER"),
@@ -67,9 +65,15 @@ async fn execute_batch() -> Result<()> {
         std::env::var("PR_NUMBER"),
         std::env::var("GITHUB_TOKEN"),
     ) {
-        post_to_github_pr(&owner, &repo, &pr_number, &token, &stats)
-            .await
-            .unwrap();
+        post_to_github_pr(
+            &owner,
+            &repo,
+            &pr_number,
+            &token,
+            &MarkdownExecutionStats::new(stats).to_string(),
+        )
+        .await
+        .unwrap();
     }
 
     Ok(())

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -38,13 +38,10 @@ async fn execute_batch() -> Result<()> {
 
     let prover = ProverClient::new();
 
-    let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
-
     let (block_data, report, execution_duration) = execute_multi(
         &prover,
         &data_fetcher,
         sp1_stdin,
-        l2_chain_id,
         l2_start_block,
         l2_end_block,
     )

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use kona_host::HostCli;
 use log::info;
 use op_succinct_host_utils::{
-    block_range::get_validated_block_range,
+    block_range::{get_rolling_block_range, get_validated_block_range},
     fetcher::{CacheMode, OPSuccinctDataFetcher},
     get_proof_stdin,
     stats::ExecutionStats,
@@ -41,6 +41,9 @@ struct CostEstimatorArgs {
     /// Use cached witness generation.
     #[clap(long)]
     use_cache: bool,
+    /// Use a fixed recent range.
+    #[clap(long)]
+    rolling: bool,
     /// The environment file to use.
     #[clap(long, default_value = ".env")]
     env_file: PathBuf,
@@ -282,8 +285,11 @@ async fn main() -> Result<()> {
     let l2_chain_id = data_fetcher.get_l2_chain_id().await?;
 
     const DEFAULT_RANGE: u64 = 5;
-    let (l2_start_block, l2_end_block) =
-        get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?;
+    let (l2_start_block, l2_end_block) = if args.rolling {
+        get_rolling_block_range(&data_fetcher, DEFAULT_RANGE).await?
+    } else {
+        get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?
+    };
 
     let split_ranges = split_range(l2_start_block, l2_end_block, l2_chain_id, args.batch_size);
 

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -20,11 +20,13 @@ use std::{
     future::Future,
     io::Seek,
     path::PathBuf,
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::task::block_in_place;
 
 pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
+
+const TWO_WEEKS: Duration = Duration::from_secs(14 * 24 * 60 * 60);
 
 /// The arguments for the host executable.
 #[derive(Debug, Clone, Parser)]
@@ -286,7 +288,7 @@ async fn main() -> Result<()> {
 
     const DEFAULT_RANGE: u64 = 5;
     let (l2_start_block, l2_end_block) = if args.rolling {
-        get_rolling_block_range(&data_fetcher, DEFAULT_RANGE).await?
+        get_rolling_block_range(&data_fetcher, TWO_WEEKS, DEFAULT_RANGE).await?
     } else {
         get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?
     };

--- a/utils/host/src/block_range.rs
+++ b/utils/host/src/block_range.rs
@@ -42,3 +42,17 @@ pub async fn get_validated_block_range(
 
     Ok((l2_start_block, l2_end_block))
 }
+
+// Get a fixed recent (less than 2 weeks) block range.
+pub async fn get_rolling_block_range(
+    data_fetcher: &OPSuccinctDataFetcher,
+    range: u64,
+) -> Result<(u64, u64)> {
+    let header = data_fetcher.get_l2_header(BlockId::finalized()).await?;
+    let l2_block_time = data_fetcher.get_l2_block_time().await?;
+    let block_count_in_two_weeks = 14 * 24 * 60 * 60 / l2_block_time;
+    let l2_end_block = (header.number / block_count_in_two_weeks) * block_count_in_two_weeks;
+    let l2_start_block = l2_end_block.saturating_sub(range);
+
+    Ok((l2_start_block, l2_end_block))
+}

--- a/utils/host/src/block_range.rs
+++ b/utils/host/src/block_range.rs
@@ -1,4 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::fetcher::OPSuccinctDataFetcher;
 use alloy_eips::BlockId;
@@ -45,13 +45,14 @@ pub async fn get_validated_block_range(
     Ok((l2_start_block, l2_end_block))
 }
 
-/// Get a fixed recent (less than 2 weeks) block range.
+/// Get a fixed recent (less than the provided interval) block range.
 pub async fn get_rolling_block_range(
     data_fetcher: &OPSuccinctDataFetcher,
+    interval: Duration,
     range: u64,
 ) -> Result<(u64, u64)> {
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-    let start_timestanp = now - (now % (14 * 24 * 60 * 60));
+    let start_timestanp = now - (now % interval.as_secs());
     let (_, l2_start_block) = data_fetcher
         .find_l2_block_by_timestamp(start_timestanp)
         .await?;

--- a/utils/host/src/block_range.rs
+++ b/utils/host/src/block_range.rs
@@ -1,3 +1,5 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use crate::fetcher::OPSuccinctDataFetcher;
 use alloy_eips::BlockId;
 use anyhow::{bail, Result};
@@ -43,16 +45,16 @@ pub async fn get_validated_block_range(
     Ok((l2_start_block, l2_end_block))
 }
 
-// Get a fixed recent (less than 2 weeks) block range.
+/// Get a fixed recent (less than 2 weeks) block range.
 pub async fn get_rolling_block_range(
     data_fetcher: &OPSuccinctDataFetcher,
     range: u64,
 ) -> Result<(u64, u64)> {
-    let header = data_fetcher.get_l2_header(BlockId::finalized()).await?;
-    let l2_block_time = data_fetcher.get_l2_block_time().await?;
-    let block_count_in_two_weeks = 14 * 24 * 60 * 60 / l2_block_time;
-    let l2_end_block = (header.number / block_count_in_two_weeks) * block_count_in_two_weeks;
-    let l2_start_block = l2_end_block.saturating_sub(range);
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let start_timestanp = now - (now % (14 * 24 * 60 * 60));
+    let (_, l2_start_block) = data_fetcher
+        .find_l2_block_by_timestamp(start_timestanp)
+        .await?;
 
-    Ok((l2_start_block, l2_end_block))
+    Ok((l2_start_block, l2_start_block + range))
 }

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -730,6 +730,15 @@ impl OPSuccinctDataFetcher {
         Ok(l1_head.timestamp - l1_block_minus_1.timestamp)
     }
 
+    /// Get the L2 block time in seconds.
+    pub async fn get_l2_block_time(&self) -> Result<u64> {
+        let l2_head = self.get_l2_header(BlockId::latest()).await?;
+
+        let l2_head_minus_1 = l2_head.number - 1;
+        let l2_block_minus_1 = self.get_l2_header(l2_head_minus_1.into()).await?;
+        Ok(l2_head.timestamp - l2_block_minus_1.timestamp)
+    }
+
     /// Get the L1 block from which the `l2_end_block` can be derived.
     async fn get_l1_head_with_safe_head(&self, l2_end_block: u64) -> Result<(B256, u64)> {
         let l1_block_time_secs = self.get_l1_block_time().await?;

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -49,14 +49,10 @@ fn write_stat(f: &mut fmt::Formatter<'_>, label: &str, value: u64) -> fmt::Resul
 
 impl fmt::Display for ExecutionStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            f,
-            "+--------------------------------+---------------------------+"
-        )?;
         writeln!(f, "| {:<30} | {:<25} |", "Metric", "Value")?;
         writeln!(
             f,
-            "+--------------------------------+---------------------------+"
+            "|--------------------------------|---------------------------|"
         )?;
         write_stat(f, "Batch Start", self.batch_start)?;
         write_stat(f, "Batch End", self.batch_end)?;
@@ -100,11 +96,7 @@ impl fmt::Display for ExecutionStats {
         write_stat(f, "BN Add Cycles", self.bn_add_cycles)?;
         write_stat(f, "BN Mul Cycles", self.bn_mul_cycles)?;
         write_stat(f, "KZG Eval Cycles", self.kzg_eval_cycles)?;
-        write_stat(f, "EC Recover Cycles", self.ec_recover_cycles)?;
-        writeln!(
-            f,
-            "+--------------------------------+---------------------------+"
-        )
+        write_stat(f, "EC Recover Cycles", self.ec_recover_cycles)
     }
 }
 

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -49,10 +49,14 @@ fn write_stat(f: &mut fmt::Formatter<'_>, label: &str, value: u64) -> fmt::Resul
 
 impl fmt::Display for ExecutionStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )?;
         writeln!(f, "| {:<30} | {:<25} |", "Metric", "Value")?;
         writeln!(
             f,
-            "|--------------------------------|---------------------------|"
+            "+--------------------------------+---------------------------+"
         )?;
         write_stat(f, "Batch Start", self.batch_start)?;
         write_stat(f, "Batch End", self.batch_end)?;
@@ -96,7 +100,11 @@ impl fmt::Display for ExecutionStats {
         write_stat(f, "BN Add Cycles", self.bn_add_cycles)?;
         write_stat(f, "BN Mul Cycles", self.bn_mul_cycles)?;
         write_stat(f, "KZG Eval Cycles", self.kzg_eval_cycles)?;
-        write_stat(f, "EC Recover Cycles", self.ec_recover_cycles)
+        write_stat(f, "EC Recover Cycles", self.ec_recover_cycles)?;
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )
     }
 }
 
@@ -145,6 +153,73 @@ impl ExecutionStats {
             witness_generation_time_sec,
             total_execution_time_sec,
         }
+    }
+}
+
+/// A [ExecutionStats] that can be displayed as Markdown.
+pub struct MarkdownExecutionStats(ExecutionStats);
+
+impl MarkdownExecutionStats {
+    /// Creates a [MarkdownExecutionStats].
+    pub fn new(inner: ExecutionStats) -> Self {
+        Self(inner)
+    }
+}
+
+impl fmt::Display for MarkdownExecutionStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "| {:<30} | {:<25} |", "Metric", "Value")?;
+        writeln!(
+            f,
+            "|--------------------------------|---------------------------|"
+        )?;
+        write_stat(f, "Batch Start", self.0.batch_start)?;
+        write_stat(f, "Batch End", self.0.batch_end)?;
+        write_stat(
+            f,
+            "Witness Generation (seconds)",
+            self.0.witness_generation_time_sec,
+        )?;
+        write_stat(
+            f,
+            "Execution Duration (seconds)",
+            self.0.total_execution_time_sec,
+        )?;
+        write_stat(f, "Total Instruction Count", self.0.total_instruction_count)?;
+        write_stat(
+            f,
+            "Oracle Verify Cycles",
+            self.0.oracle_verify_instruction_count,
+        )?;
+        write_stat(f, "Derivation Cycles", self.0.derivation_instruction_count)?;
+        write_stat(
+            f,
+            "Block Execution Cycles",
+            self.0.block_execution_instruction_count,
+        )?;
+        write_stat(
+            f,
+            "Blob Verification Cycles",
+            self.0.blob_verification_instruction_count,
+        )?;
+        write_stat(f, "Total SP1 Gas", self.0.total_sp1_gas)?;
+        write_stat(f, "Number of Blocks", self.0.nb_blocks)?;
+        write_stat(f, "Number of Transactions", self.0.nb_transactions)?;
+        write_stat(f, "Ethereum Gas Used", self.0.eth_gas_used)?;
+        write_stat(f, "Cycles per Block", self.0.cycles_per_block)?;
+        write_stat(f, "Cycles per Transaction", self.0.cycles_per_transaction)?;
+        write_stat(f, "Transactions per Block", self.0.transactions_per_block)?;
+        write_stat(f, "Gas Used per Block", self.0.gas_used_per_block)?;
+        write_stat(
+            f,
+            "Gas Used per Transaction",
+            self.0.gas_used_per_transaction,
+        )?;
+        write_stat(f, "BN Pair Cycles", self.0.bn_pair_cycles)?;
+        write_stat(f, "BN Add Cycles", self.0.bn_add_cycles)?;
+        write_stat(f, "BN Mul Cycles", self.0.bn_mul_cycles)?;
+        write_stat(f, "KZG Eval Cycles", self.0.kzg_eval_cycles)?;
+        write_stat(f, "EC Recover Cycles", self.0.ec_recover_cycles)
     }
 }
 


### PR DESCRIPTION
The goal of this PR is to display stats on a proof execution on CI.

In order to not pollute `multi` binary with CI related stuff, I did a small refactoring of the witness generation and proof execution part, moving them to `lib` so they can be used by the binary and also an integration test.

The code that call Github API is mainly copied from the one in SP1.

I also did a small change to the cost estimator binary to alway take a block range in the last 2 weeks.