### PR TITLE
feat: Add default block range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,8 @@ dependencies = [
  "op-succinct-build-utils",
  "op-succinct-client-utils",
  "op-succinct-host-utils",
+ "reqwest 0.12.8",
+ "serde_json",
  "sp1-sdk",
  "tokio",
 ]

--- a/proposer/op/op_proposer.sh
+++ b/proposer/op/op_proposer.sh
@@ -15,7 +15,7 @@
     --max-concurrent-proof-requests=${MAX_CONCURRENT_PROOF_REQUESTS:-10} \
     --db-path=${DB_PATH:-/usr/local/bin/dbdata} \
     --op-succinct-server-url=${OP_SUCCINCT_SERVER_URL:-http://op-succinct-server:3000} \
-    --max-block-range-per-span-proof=${MAX_BLOCK_RANGE_PER_SPAN_PROOF:-20} \
+    --max-block-range-per-span-proof=${MAX_BLOCK_RANGE_PER_SPAN_PROOF:-300} \
     --use-cached-db=${USE_CACHED_DB:-false} \
     --metrics.enabled=${METRICS_ENABLED:-true} \
     --metrics.port=${METRICS_PORT:-7300} \


### PR DESCRIPTION
Add a default block range of 300. This configuration works well for empty chains.