### PR TITLE
fix: post report to GitHub on PRs only

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -56,3 +58,4 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POST_TO_GITHUB: ${{ github.event_name == 'pull_request' }}

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -56,21 +56,27 @@ async fn execute_batch() -> Result<()> {
 
     println!("Execution Stats: \n{:?}", stats.to_string());
 
-    if let (Ok(owner), Ok(repo), Ok(pr_number), Ok(token)) = (
-        std::env::var("REPO_OWNER"),
-        std::env::var("REPO_NAME"),
-        std::env::var("PR_NUMBER"),
-        std::env::var("GITHUB_TOKEN"),
-    ) {
-        post_to_github_pr(
-            &owner,
-            &repo,
-            &pr_number,
-            &token,
-            &MarkdownExecutionStats::new(stats).to_string(),
-        )
-        .await
-        .unwrap();
+    if std::env::var("POST_TO_GITHUB")
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or_default()
+    {
+        if let (Ok(owner), Ok(repo), Ok(pr_number), Ok(token)) = (
+            std::env::var("REPO_OWNER"),
+            std::env::var("REPO_NAME"),
+            std::env::var("PR_NUMBER"),
+            std::env::var("GITHUB_TOKEN"),
+        ) {
+            post_to_github_pr(
+                &owner,
+                &repo,
+                &pr_number,
+                &token,
+                &MarkdownExecutionStats::new(stats).to_string(),
+            )
+            .await
+            .unwrap();
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Adds an `POST_TO_GITHUB` env variable to control when report is posted to GitHub.