### PR TITLE
refactor: contract deployment

### DIFF
--- a/book/getting-started/configuration.md
+++ b/book/getting-started/configuration.md
@@ -15,14 +15,7 @@ If your OP Stack chain's admin is a multi-sig or contract, you will need to use 
 To update the `L2OutputOracle` implementation with an EOA `ADMIN` key, run the following command in `/contracts`.
 
 ```bash
-forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
-    --rpc-url $L1_RPC \
-    --private-key $PRIVATE_KEY \
-    --verify \
-    --verifier etherscan \
-    --etherscan-api-key $ETHERSCAN_API_KEY \
-    --broadcast \
-    --ffi
+just upgrade-oracle
 ```
 
 ### `ADMIN` key is not an EOA
@@ -30,14 +23,8 @@ forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
 If the owner of the `L2OutputOracle` is not an EOA (e.g. multisig, contract), set `EXECUTE_UPGRADE_CALL` to `false`. This will output the raw calldata for the upgrade call, which can be executed by the owner.
 
 ```bash
-EXECUTE_UPGRADE_CALL=false forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
-    --rpc-url $L1_RPC \
-    --private-key $PRIVATE_KEY \
-    --verify \
-    --verifier etherscan \
-    --etherscan-api-key $ETHERSCAN_API_KEY \
-    --broadcast \
-    --ffi
+EXECUTE_UPGRADE_CALL=false just upgrade-oracle
+```
 
 ...
 == Logs ==

--- a/book/getting-started/l2-output-oracle.md
+++ b/book/getting-started/l2-output-oracle.md
@@ -41,6 +41,7 @@ In the root directory, create a file called `.env` (mirroring `.env.example`) an
 | `SP1_PRIVATE_KEY` | Key for the Succinct Prover Network. Get access [here](https://docs.succinct.xyz/generating-proofs/prover-network). |
 | `SP1_PROVER` | Default: `network`. Set to `network` to use the Succinct Prover Network. |
 | `PRIVATE_KEY` | Private key for the account that will be deploying the contract and posting output roots to L1. |
+| `ETHERSCAN_API_KEY` | Etherscan API key used for verifying the contract (optional). |
 
 ### 3) Navigate to the contracts directory:
 
@@ -50,7 +51,7 @@ cd contracts
 
 ### 4) Set Deployment Parameters
 
-Inside the `contracts` folder there is a file called `opsuccinctl2ooconfig.json` that contains the parameters for the deployment. The parameters are automatically set based on your RPC's and the owner of your contract is determined by the private key you set in the `.env` file.
+Inside the `contracts` folder there is a file called `opsuccinctl2ooconfig.json` that contains the parameters for the deployment. The parameters are automatically set based on your RPC's and the owner of your contract is determined by default from the private key you set in the `.env` file.
 
 #### Optional Advanced Parameters
 
@@ -65,17 +66,13 @@ Advanced users can set parameters manually in `opsuccinctl2ooconfig.json`, but t
 
 ### 5) Deploy the `OPSuccinctL2OutputOracle` contract:
 
-Run the following command to deploy the `OPSuccinctL2OutputOracle` contract to the L1 chain:
+Run the following command to deploy the `OPSuccinctL2OutputOracle` contract to the L1 chain, which will use the variables in your `.env` file to configure and deploy the contract.
+
+Under the hood, this command will fetch the rollup config and update the `opsuccinctl2ooconfig.json` file with the rollup config hash and initialization data. Afterward, it will deploy the contract and verify it using Etherscan (if you included your Etherscan API key in the `.env` file).
+
 
 ```bash
-forge script script/OPSuccinctDeployer.s.sol:OPSuccinctDeployer \
-    --rpc-url $L1_RPC \
-    --private-key $PRIVATE_KEY \
-    --ffi \
-    --verify \
-    --verifier etherscan \
-    --etherscan-api-key $ETHERSCAN_API_KEY \
-    --broadcast
+just deploy-oracle
 ```
 
 If successful, you should see the following output:
@@ -100,10 +97,10 @@ In these deployment logs, `0x9b520F7d8031d45Eb8A1D9fE911038576931ab95` is the ad
 
 #### Configure Environment
 
-To use a configurable environment, pass the `ENV_FILE` flag with the path to your `.env` file. By default this is the `.env` in your root directory.
+To use a configurable environment, pass the environment file as an argument to the `deploy-oracle` command. This will use the variables in the environment file to fetch the rollup config and initialize the contract.
 
 ```bash
-ENV_FILE=.env.new forge script script/OPSuccinctDeployer.s.sol:OPSuccinctDeployer ...
+just deploy-oracle <env_file>
 ```
 
 ### 6) Add Proxy Address to `.env`

--- a/contracts/opsuccinctl2ooconfig.json
+++ b/contracts/opsuccinctl2ooconfig.json
@@ -4,11 +4,11 @@
   "l2BlockTime": 2,
   "proposer": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
   "rollupConfigHash": "0x5e32d5f9f902c6a46cb75cbdb083ea67b9475d7026542a009dc9d99072f4bdf1",
-  "startingBlockNumber": 20175397,
-  "startingOutputRoot": "0x7221763ecd01d933a9cf800ffaecc2d346707e08f6fa3b44f3dab4cb6293b386",
-  "startingTimestamp": 1732153334,
+  "startingBlockNumber": 20219482,
+  "startingOutputRoot": "0x1e001d71b01f70d88f89045223266dd3556fe60a1e730238ea740fba6d65f7fb",
+  "startingTimestamp": 1732241504,
   "submissionInterval": 1200,
-  "verifierGateway": "0x3B6041173B80E77f038f3F2C0f9744f04837185e",
-  "aggregationVkey": "0x00bc1916ee812b6de22411eb6f13b36b05ae09845535c99cb0f27176674c3064",
-  "rangeVkeyCommitment": "0x6a2c00a94a24b6821bee517f5f21d0514f848f516feb924a1f135463132db456"
+  "verifierGateway": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+  "aggregationVkey": "0x005e6c9a5ce9f43b358f37a1f19e0d2479436d49f920b272daa423cb14c0e00c",
+  "rangeVkeyCommitment": "0x082e381d1ddcb2c252ff02b315311c44548b1b2a399143086dce5cac77ef5a4e"
 }

--- a/contracts/opsuccinctl2ooconfig.json
+++ b/contracts/opsuccinctl2ooconfig.json
@@ -3,12 +3,12 @@
   "finalizationPeriod": 0,
   "l2BlockTime": 2,
   "proposer": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
-  "rollupConfigHash": "0x8dad3aa88de72762859feb6781d937efa8f39c8b681a51443b0abfde108fbbcd",
-  "startingBlockNumber": 4339219,
-  "startingOutputRoot": "0x669f6abbdcb73945c2eb71913121d761d48c85a47acf44535c4d7cc6db39c328",
-  "startingTimestamp": 1730427346,
-  "submissionInterval": 2,
-  "verifierGateway": "0xFFa8019DF57ef983E7EEf247cAbbafD5eC2fa5e6",
-  "aggregationVkey": "0x00909bc72830806c34be200b694f31f925cdd3e2804a999b609a58ff22d1f7f7",
-  "rangeVkeyCommitment": "0x3fbb81ba6c9608e2288b717277e90b322d300fe4005438e756e5d1bb54367da8"
+  "rollupConfigHash": "0x5e32d5f9f902c6a46cb75cbdb083ea67b9475d7026542a009dc9d99072f4bdf1",
+  "startingBlockNumber": 20175397,
+  "startingOutputRoot": "0x7221763ecd01d933a9cf800ffaecc2d346707e08f6fa3b44f3dab4cb6293b386",
+  "startingTimestamp": 1732153334,
+  "submissionInterval": 1200,
+  "verifierGateway": "0x3B6041173B80E77f038f3F2C0f9744f04837185e",
+  "aggregationVkey": "0x00bc1916ee812b6de22411eb6f13b36b05ae09845535c99cb0f27176674c3064",
+  "rangeVkeyCommitment": "0x6a2c00a94a24b6821bee517f5f21d0514f848f516feb924a1f135463132db456"
 }

--- a/contracts/script/OPSuccinctDeployer.s.sol
+++ b/contracts/script/OPSuccinctDeployer.s.sol
@@ -11,12 +11,9 @@ contract OPSuccinctDeployer is Script, Utils {
     function run() public returns (address) {
         vm.startBroadcast();
 
-        // Update the rollup config to match the current chain. If the starting block number is 0, the latest block number and starting output root will be fetched.
-        updateRollupConfig();
-
         Config memory config = readJson("opsuccinctl2ooconfig.json");
 
-        // This initializes the proxy.
+        // This initializes the proxy
         OPSuccinctL2OutputOracle oracleImpl = new OPSuccinctL2OutputOracle();
         Proxy proxy = new Proxy(msg.sender);
 

--- a/contracts/script/OPSuccinctUpgrader.s.sol
+++ b/contracts/script/OPSuccinctUpgrader.s.sol
@@ -11,13 +11,9 @@ contract OPSuccinctUpgrader is Script, Utils {
     function run() public {
         vm.startBroadcast();
 
-        // Update the rollup config to match the current chain. If the starting block number is 0, the latest block number and starting output root will be fetched.
-        updateRollupConfig();
-
         Config memory cfg = readJson("opsuccinctl2ooconfig.json");
 
         address l2OutputOracleProxy = vm.envAddress("L2OO_ADDRESS");
-
         bool executeUpgradeCall = vm.envOr("EXECUTE_UPGRADE_CALL", true);
 
         address OPSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle());

--- a/contracts/test/helpers/Utils.sol
+++ b/contracts/test/helpers/Utils.sol
@@ -68,35 +68,4 @@ contract Utils is Test, JSONDecoder {
         bytes memory data = vm.parseJson(json);
         return abi.decode(data, (Config));
     }
-
-    // This script updates the rollup config hash and the block number in the config.
-    function updateRollupConfig() public {
-        // If ENV_FILE is set, pass it to the fetch-rollup-config binary.
-        string memory envFile = vm.envOr("ENV_FILE", string(".env"));
-
-        // Build the fetch-rollup-config binary. Use the quiet flag to suppress build output.
-        string[] memory inputs = new string[](6);
-        inputs[0] = "cargo";
-        inputs[1] = "build";
-        inputs[2] = "--bin";
-        inputs[3] = "fetch-rollup-config";
-        inputs[4] = "--release";
-        inputs[5] = "--quiet";
-        vm.ffi(inputs);
-
-        // Run the fetch-rollup-config binary which updates the rollup config hash and the block number in the config.
-        // Use the quiet flag to suppress build output.
-        string[] memory inputs2 = new string[](9);
-        inputs2[0] = "cargo";
-        inputs2[1] = "run";
-        inputs2[2] = "--bin";
-        inputs2[3] = "fetch-rollup-config";
-        inputs2[4] = "--release";
-        inputs2[5] = "--quiet";
-        inputs2[6] = "--";
-        inputs2[7] = "--env-file";
-        inputs2[8] = envFile;
-
-        vm.ffi(inputs2);
-    }
 }

--- a/justfile
+++ b/justfile
@@ -138,3 +138,47 @@ deploy-mock-verifier env_file=".env":
     --private-key $PRIVATE_KEY \
     --broadcast \
     $VERIFY_FLAGS
+# Deploy the OPSuccinct L2 Output Oracle
+deploy-oracle env_file=".env":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    
+    # First fetch rollup config using the env file
+    RUST_LOG=info cargo run --bin fetch-rollup-config --release -- --env-file {{env_file}}
+    
+    # Load environment variables
+    source {{env_file}}
+
+    # cd into contracts directory
+    cd contracts
+    
+    # Run the forge deployment script
+    forge script script/OPSuccinctDeployer.s.sol:OPSuccinctDeployer \
+        --rpc-url $L1_RPC \
+        --private-key $PRIVATE_KEY \
+        --broadcast \
+        --verify \
+        --verifier etherscan \
+        --etherscan-api-key $ETHERSCAN_API_KEY
+
+
+# Upgrade the OPSuccinct L2 Output Oracle
+upgrade-oracle env_file=".env":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    
+    # First fetch rollup config using the env file
+    RUST_LOG=info cargo run --bin fetch-rollup-config --release -- --env-file {{env_file}}
+    
+    # Load environment variables
+    source {{env_file}}
+
+    # cd into contracts directory
+    cd contracts
+    
+    # Run the forge upgrade script
+    EXECUTE_UPGRADE_CALL=$EXECUTE_UPGRADE_CALL forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
+        --rpc-url $L1_RPC \
+        --private-key $PRIVATE_KEY \
+        --etherscan-api-key $ETHERSCAN_API_KEY \
+        --broadcast

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -107,26 +107,16 @@ async fn run_native_data_generation(host_clis: &[HostCli]) {
         let mut witnessgen_executor = WitnessGenExecutor::default();
 
         for host_cli in chunk {
-            block_on(witnessgen_executor.spawn_witnessgen(host_cli))
+            witnessgen_executor
+                .spawn_witnessgen(host_cli)
+                .await
                 .expect("Failed to spawn witness generation process");
         }
 
-        block_on(witnessgen_executor.flush()).expect("Failed to generate witnesses");
-    }
-}
-
-/// Utility method for blocking on an async function.
-///
-/// If we're already in a tokio runtime, we'll block in place. Otherwise, we'll create a new
-/// runtime.
-pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
-    // Handle case if we're already in an tokio runtime.
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        block_in_place(|| handle.block_on(fut))
-    } else {
-        // Otherwise create a new runtime.
-        let rt = tokio::runtime::Runtime::new().expect("Failed to create a new runtime");
-        rt.block_on(fut)
+        witnessgen_executor
+            .flush()
+            .await
+            .expect("Failed to generate witnesses");
     }
 }
 

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -17,12 +17,10 @@ use sp1_sdk::{utils, ProverClient};
 use std::{
     cmp::{max, min},
     fs::{self, OpenOptions},
-    future::Future,
     io::Seek,
     path::PathBuf,
     time::{Duration, Instant},
 };
-use tokio::task::block_in_place;
 
 pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
 


### PR DESCRIPTION
Separate fetching the rollup config + deploying the contract, rather than using a forge FFI script.

`just deploy-oracle` and `just upgrade-oracle`