### PR TITLE
simplification book.yml

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -60,10 +60,7 @@ jobs:
       - name: Archive artifact
         shell: sh
         run: |
-          chmod -c -R +rX "target/book" |
-          while read line; do
-             echo "::warning title=Invalid file permissions automatically fixed::$line"
-          done
+         chmod -R +rX "target/book"
           tar \
             --dereference --hard-dereference \
             --directory "target/book" \


### PR DESCRIPTION
The "chmod -c" option isn’t really needed here since "-c" isn’t usually used for bulk changes and can be left out. If you don’t need detailed output about the changes, you can simplify the command.