### PR TITLE
feat(contracts): Support multiple proposers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
-      - main
+      - "**"
   push:
     branches:
       - main

--- a/book/advanced/l2-output-oracle.md
+++ b/book/advanced/l2-output-oracle.md
@@ -43,7 +43,7 @@ You can configure additional parameters when deploying or upgrading the `OPSucci
 | `STARTING_BLOCK_NUMBER` | Default: The finalized block number on L2. The block number to initialize the contract from. OP Succinct will start proving state roots from this block number. |
 | `SUBMISSION_INTERVAL` | Default: `1000`. The minimum interval in L2 blocks at which checkpoints must be submitted. An aggregation proof can be posted for any range larger than this interval. |
 | `FINALIZATION_PERIOD` | Default: `0`. The time period (in seconds) after which a proposed output becomes finalized and withdrawals can be processed. |
-| `PROPOSER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to submit proofs. Set to `address(0)` to allow permissionless submissions. **Note: Use `addProposer` and `removeProposer` functions to update the list of approved proposers.** |
+| `PROPOSER` | Default: The address of the account associated with `PRIVATE_KEY`. An Ethereum address authorized to submit proofs. Set to `address(0)` to allow permissionless submissions. **Note: Use `addProposer` and `removeProposer` functions to update the list of approved proposers.** |
 | `CHALLENGER` | Default: `address(0)`, no one can dispute proofs. Ethereum address authorized to dispute proofs. |
 | `OWNER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to update the `aggregationVkey`, `rangeVkeyCommitment`, `verifier`, and `rollupConfigHash` parameters and transfer ownership of the contract. In a production setting, set to the governance smart contract or multi-sig of the chain. |
 

--- a/book/advanced/l2-output-oracle.md
+++ b/book/advanced/l2-output-oracle.md
@@ -45,7 +45,7 @@ You can configure additional parameters when deploying or upgrading the `OPSucci
 | `FINALIZATION_PERIOD` | Default: `0`. The time period (in seconds) after which a proposed output becomes finalized and withdrawals can be processed. |
 | `PROPOSER` | Default: The address of the account associated with `PRIVATE_KEY`. An Ethereum address authorized to submit proofs. Set to `address(0)` to allow permissionless submissions. **Note: Use `addProposer` and `removeProposer` functions to update the list of approved proposers.** |
 | `CHALLENGER` | Default: `address(0)`, no one can dispute proofs. Ethereum address authorized to dispute proofs. |
-| `OWNER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to update the `aggregationVkey`, `rangeVkeyCommitment`, `verifier`, and `rollupConfigHash` parameters and transfer ownership of the contract. In a production setting, set to the governance smart contract or multi-sig of the chain. |
+| `OWNER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to update the `aggregationVkey`, `rangeVkeyCommitment`, `verifier`, and `rollupConfigHash` parameters. Can also transfer ownership of the contract and update the approved proposers. In a production setting, set to the governance smart contract or multi-sig of the chain. |
 
 ## Upgrading `OPSuccinctL2OutputOracle`
 

--- a/book/advanced/l2-output-oracle.md
+++ b/book/advanced/l2-output-oracle.md
@@ -43,7 +43,7 @@ You can configure additional parameters when deploying or upgrading the `OPSucci
 | `STARTING_BLOCK_NUMBER` | Default: The finalized block number on L2. The block number to initialize the contract from. OP Succinct will start proving state roots from this block number. |
 | `SUBMISSION_INTERVAL` | Default: `1000`. The minimum interval in L2 blocks at which checkpoints must be submitted. An aggregation proof can be posted for any range larger than this interval. |
 | `FINALIZATION_PERIOD` | Default: `0`. The time period (in seconds) after which a proposed output becomes finalized and withdrawals can be processed. |
-| `PROPOSER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to submit proofs. Set to `address(0)` to allow permissionless submissions. |
+| `PROPOSER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to submit proofs. Set to `address(0)` to allow permissionless submissions. **Note: Use `addProposer` and `removeProposer` functions to update the list of approved proposers.** |
 | `CHALLENGER` | Default: `address(0)`, no one can dispute proofs. Ethereum address authorized to dispute proofs. |
 | `OWNER` | Default: The address of the account associated with `PRIVATE_KEY`. Ethereum address authorized to update the `aggregationVkey`, `rangeVkeyCommitment`, `verifier`, and `rollupConfigHash` parameters and transfer ownership of the contract. In a production setting, set to the governance smart contract or multi-sig of the chain. |
 

--- a/contracts/src/OPSuccinctL2OutputOracle.sol
+++ b/contracts/src/OPSuccinctL2OutputOracle.sol
@@ -141,6 +141,11 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     /// @param added Whether the proposer was added or removed.
     event ProposerUpdated(address indexed proposer, bool added);
 
+    /// @notice Emitted when the submission interval is updated.
+    /// @param oldSubmissionInterval The old submission interval.
+    /// @param newSubmissionInterval The new submission interval.
+    event SubmissionIntervalUpdated(uint256 oldSubmissionInterval, uint256 newSubmissionInterval);
+
     ////////////////////////////////////////////////////////////
     //                         Errors                         //
     ////////////////////////////////////////////////////////////
@@ -435,6 +440,7 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     /// @notice Update the submission interval.
     /// @param _submissionInterval The new submission interval.
     function updateSubmissionInterval(uint256 _submissionInterval) external onlyOwner {
+        emit SubmissionIntervalUpdated(submissionInterval, _submissionInterval);
         submissionInterval = _submissionInterval;
     }
 

--- a/contracts/src/OPSuccinctL2OutputOracle.sol
+++ b/contracts/src/OPSuccinctL2OutputOracle.sol
@@ -62,8 +62,9 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     /// @custom:network-specific
     address public challenger;
 
-    /// @notice The address of the proposer. Can be updated via upgrade.
+    /// @notice The address of the proposer. Can be updated via upgrade. DEPRECATED: Use approvedProposers mapping instead.
     /// @custom:network-specific
+    /// @custom:deprecated
     address public proposer;
 
     /// @notice The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
@@ -86,6 +87,9 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     /// @notice The owner of the contract, who has admin permissions.
     address public owner;
 
+    /// @notice The proposers that can propose new proofs.
+    mapping(address => bool) public approvedProposers;
+    
     /// @notice A trusted mapping of block numbers to block hashes.
     mapping(uint256 => bytes32) public historicBlockHashes;
 
@@ -131,6 +135,11 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     /// @param previousOwner The previous owner address.
     /// @param newOwner The new owner address.
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Emitted when a proposer address is added.
+    /// @param proposer The proposer address.
+    /// @param added Whether the proposer was added or removed.
+    event ProposerUpdated(address indexed proposer, bool added);
 
     ////////////////////////////////////////////////////////////
     //                         Errors                         //
@@ -193,9 +202,11 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
             startingTimestamp = _initParams.startingTimestamp;
         }
 
-        proposer = _initParams.proposer;
         challenger = _initParams.challenger;
         finalizationPeriodSeconds = _initParams.finalizationPeriodSeconds;
+
+        // Add the initial proposer.
+        approvedProposers[_initParams.proposer] = true;
 
         // OP Succinct initialization parameters.
         aggregationVkey = _initParams.aggregationVkey;
@@ -285,9 +296,10 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
         external
         payable
     {
+        // The proposer must be explicitly approved, or the zero address must be approved (permissionless proposing).
         require(
-            msg.sender == proposer || proposer == address(0),
-            "L2OutputOracle: only the proposer address can propose new outputs"
+            approvedProposers[msg.sender] || approvedProposers[address(0)],
+            "L2OutputOracle: only approved proposers can propose new outputs"
         );
 
         require(
@@ -459,5 +471,19 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     function transferOwnership(address _owner) external onlyOwner {
         emit OwnershipTransferred(owner, _owner);
         owner = _owner;
+    }
+
+    /// @notice Adds a new proposer address.
+    /// @param _proposer The new proposer address.
+    function addProposer(address _proposer) external onlyOwner {
+        approvedProposers[_proposer] = true;
+        emit ProposerUpdated(_proposer, true);
+    }
+
+    /// @notice Removes a proposer address.
+    /// @param _proposer The proposer address to remove.
+    function removeProposer(address _proposer) external onlyOwner {
+        approvedProposers[_proposer] = false;
+        emit ProposerUpdated(_proposer, false);
     }
 }

--- a/contracts/src/OPSuccinctL2OutputOracle.sol
+++ b/contracts/src/OPSuccinctL2OutputOracle.sol
@@ -89,7 +89,7 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
 
     /// @notice The proposers that can propose new proofs.
     mapping(address => bool) public approvedProposers;
-    
+
     /// @notice A trusted mapping of block numbers to block hashes.
     mapping(uint256 => bytes32) public historicBlockHashes;
 


### PR DESCRIPTION
Support multiple proposers on the contract.

If `address(0)` is whitelisted, then permissionless proposing is enabled.

Otherwise, the account proposing a new output root with a proof must be explicitly enabled.