### PR TITLE
fix(ci): Rolling block range from `finalized`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ dependencies = [
  "kona-client",
  "kona-common",
  "kona-derive",
+ "kona-driver",
  "kona-executor",
  "kona-mpt",
  "kona-preimage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -4338,7 +4338,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/configs/808813/rollup.json
+++ b/configs/808813/rollup.json
@@ -41,6 +41,7 @@
   "ecotone_time": 0,
   "fjord_time": 0,
   "granite_time": 1725984001,
+  "holocene_time": 1732633200,
   "batch_inbox_address": "0x734dde12fd466c14a85de838788efe6f1993c84c",
   "deposit_contract_address": "0xbaaf3bafdbd660380938b27d21c31bb7d072a799",
   "l1_system_config_address": "0x3974436fa4bb4deb5a04ace51a704b10ff5a1f25",

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -24,7 +24,7 @@ use std::{
 
 pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
 
-const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
+const ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
 
 /// The arguments for the host executable.
 #[derive(Debug, Clone, Parser)]
@@ -276,7 +276,7 @@ async fn main() -> Result<()> {
 
     const DEFAULT_RANGE: u64 = 5;
     let (l2_start_block, l2_end_block) = if args.rolling {
-        get_rolling_block_range(&data_fetcher, ONE_HOUR, DEFAULT_RANGE).await?
+        get_rolling_block_range(&data_fetcher, ONE_DAY, DEFAULT_RANGE).await?
     } else {
         get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?
     };

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -24,7 +24,7 @@ use std::{
 
 pub const MULTI_BLOCK_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
 
-const ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
+const TWELVE_HOURS: Duration = Duration::from_secs(60 * 60 * 12);
 
 /// The arguments for the host executable.
 #[derive(Debug, Clone, Parser)]
@@ -276,7 +276,7 @@ async fn main() -> Result<()> {
 
     const DEFAULT_RANGE: u64 = 5;
     let (l2_start_block, l2_end_block) = if args.rolling {
-        get_rolling_block_range(&data_fetcher, ONE_DAY, DEFAULT_RANGE).await?
+        get_rolling_block_range(&data_fetcher, TWELVE_HOURS, DEFAULT_RANGE).await?
     } else {
         get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?
     };
@@ -307,6 +307,8 @@ async fn main() -> Result<()> {
         .buffered(15)
         .collect::<Vec<_>>()
         .await;
+
+    println!("Host CLIs: {:?}", host_clis);
 
     let start_time = Instant::now();
     if !args.use_cache {

--- a/utils/client/Cargo.toml
+++ b/utils/client/Cargo.toml
@@ -33,6 +33,7 @@ kona-mpt.workspace = true
 kona-derive.workspace = true
 kona-proof.workspace = true
 kona-executor.workspace = true
+kona-driver.workspace = true
 
 # general
 serde.workspace = true

--- a/utils/client/src/precompiles/mod.rs
+++ b/utils/client/src/precompiles/mod.rs
@@ -6,10 +6,9 @@ use revm::{
     db::states::state::State,
     handler::register::EvmHandler,
     precompile::{
-        bn128, secp256r1, Precompile, PrecompileResult, PrecompileSpecId, PrecompileWithAddress,
+        bn128, Precompile, PrecompileResult, PrecompileWithAddress,
     },
-    primitives::Bytes,
-    ContextPrecompiles,
+    primitives::{spec_to_generic, Bytes, SpecId},
 };
 
 /// Create an annotated precompile that simply tracks the cycle count of a precompile.
@@ -55,12 +54,9 @@ where
     let spec_id = handler.cfg.spec_id;
 
     handler.pre_execution.load_precompiles = Arc::new(move || {
-        let mut ctx_precompiles =
-            ContextPrecompiles::new(PrecompileSpecId::from_spec_id(spec_id)).clone();
-
-        // With Fjord, EIP-7212 is activated, so we need to load the precompiles for secp256r1.
-        // Alphanet does the same here: https://github.com/paradigmxyz/alphanet/blob/f28e4220a1a637c19ef6b4928e9a427560d46fcb/crates/node/src/evm.rs#L53-L56
-        ctx_precompiles.extend(secp256r1::precompiles());
+        let mut ctx_precompiles = spec_to_generic!(spec_id, {
+            revm::optimism::load_precompiles::<SPEC, (), &mut State<&mut TrieDB<F, H>>>()
+        });
 
         // Extend with ZKVM-accelerated precompiles and annotated precompiles that track the
         // cycle count.

--- a/utils/host/src/block_range.rs
+++ b/utils/host/src/block_range.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use crate::fetcher::OPSuccinctDataFetcher;
 use alloy_eips::BlockId;
@@ -51,10 +51,10 @@ pub async fn get_rolling_block_range(
     interval: Duration,
     range: u64,
 ) -> Result<(u64, u64)> {
-    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-    let start_timestanp = now - (now % interval.as_secs());
+    let header = data_fetcher.get_l2_header(BlockId::finalized()).await?;
+    let start_timestamp = header.timestamp - (header.timestamp % interval.as_secs());
     let (_, l2_start_block) = data_fetcher
-        .find_l2_block_by_timestamp(start_timestanp)
+        .find_l2_block_by_timestamp(start_timestamp)
         .await?;
 
     Ok((l2_start_block, l2_start_block + range))


### PR DESCRIPTION
The following error messages encountered by CI on `main` arise from the end block requested not having a corresponding batch posted to L1.

```shell
Critical error: Data source exhausted
span batch has no new blocks after safe head
```

When setting up CI workflows, it's important to always pick block ranges that are finalized (though they could be safe and that would work as well) to avoid the span batch not being posted for the L2 block yet.