### PR TITLE
feat: update to kona `aurelien/patch-11-29` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.12",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-primitives 0.8.12",
  "alloy-rlp",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-primitives 0.8.12",
  "async-channel",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#b6eb4f657b64913f0ee90b90aaffe155dd29e806"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4375,7 +4375,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c74832aa474b670309c20fffc2a869fa141edab7c79ff7963fad0a08de60bae1"
 dependencies = [
  "alloy-primitives 0.8.12",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -517,6 +518,16 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "alloy-rpc-types-debug"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2253bee958658ebd614c07a61c40580e09dd1fad3f017684314442332ab753"
+dependencies = [
+ "alloy-primitives 0.8.12",
+ "serde",
 ]
 
 [[package]]
@@ -1031,6 +1042,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1726,14 +1749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "command-fds"
-version = "0.3.0"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
- "nix",
- "thiserror 1.0.69",
- "tokio",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2590,6 +2611,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2666,7 @@ dependencies = [
  "cfg-if",
  "kona-driver",
  "kona-executor",
+ "kona-preimage",
  "kona-proof",
  "op-alloy-genesis",
  "op-alloy-rpc-types-engine",
@@ -3692,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3701,14 +3744,14 @@ dependencies = [
  "alloy-rpc-types-engine",
  "async-trait",
  "cfg-if",
- "kona-common",
- "kona-common-proc",
  "kona-derive",
  "kona-driver",
  "kona-executor",
  "kona-mpt",
  "kona-preimage",
  "kona-proof",
+ "kona-std-fpvm",
+ "kona-std-fpvm-proc",
  "lru",
  "op-alloy-consensus",
  "op-alloy-genesis",
@@ -3723,32 +3766,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "kona-common"
-version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
-dependencies = [
- "cfg-if",
- "linked_list_allocator",
- "thiserror 2.0.3",
-]
-
-[[package]]
-name = "kona-common-proc"
-version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
-dependencies = [
- "anyhow",
- "cfg-if",
- "kona-common",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "kona-derive"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3767,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.12",
@@ -3785,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3803,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3818,17 +3838,15 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "command-fds",
- "futures",
  "kona-client",
- "kona-common",
  "kona-derive",
  "kona-mpt",
  "kona-preimage",
  "kona-proof",
+ "kona-std-fpvm",
  "op-alloy-genesis",
  "op-alloy-protocol",
- "os_pipe",
+ "op-alloy-rpc-types-engine",
  "reqwest 0.12.9",
  "revm",
  "rocksdb",
@@ -3842,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-primitives 0.8.12",
  "alloy-rlp",
@@ -3854,9 +3872,10 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-primitives 0.8.12",
+ "async-channel",
  "async-trait",
  "rkyv 0.8.8",
  "thiserror 2.0.3",
@@ -3866,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kona?rev=574f5f56793ac592b5b31ffdd2cf683ac8371226#574f5f56793ac592b5b31ffdd2cf683ac8371226"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3888,7 +3907,34 @@ dependencies = [
  "serde_json",
  "spin 0.9.8",
  "thiserror 2.0.3",
+ "tokio",
  "tracing",
+]
+
+[[package]]
+name = "kona-std-fpvm"
+version = "0.1.0"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "kona-preimage",
+ "linked_list_allocator",
+ "thiserror 2.0.3",
+ "tracing",
+]
+
+[[package]]
+name = "kona-std-fpvm-proc"
+version = "0.1.0"
+source = "git+https://github.com/succinctlabs/kona?branch=aurelien/patch-11-29#3297de4acd94b7b4797f6714542b7489d9c3a5b9"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "kona-std-fpvm",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3944,7 +3990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4130,17 +4176,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -4340,7 +4375,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4496,9 +4531,11 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.12",
  "alloy-rpc-types-engine",
+ "alloy-serde",
  "derive_more 1.0.0",
  "op-alloy-consensus",
  "op-alloy-protocol",
+ "serde",
  "thiserror 2.0.3",
 ]
 
@@ -4524,13 +4561,13 @@ dependencies = [
  "async-trait",
  "itertools 0.13.0",
  "kona-client",
- "kona-common",
  "kona-derive",
  "kona-driver",
  "kona-executor",
  "kona-mpt",
  "kona-preimage",
  "kona-proof",
+ "kona-std-fpvm",
  "kzg-rs",
  "log",
  "op-alloy-consensus",
@@ -4750,16 +4787,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "overload"
@@ -5082,6 +5109,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,18 +44,18 @@ tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 # kona
 # Note: Switch to latest version of kona once the std::process::Command issue is resolved.
 # Branch: patch-kona-proof-v0.1.0
-kona-common = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-common-proc = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-preimage = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226", features = [
+kona-std-fpvm = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-std-fpvm-proc = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-preimage = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29", features = [
     "rkyv",
 ] }
-kona-mpt = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-driver = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-derive = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226", default-features = false }
-kona-executor = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-client = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-host = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
-kona-proof = { git = "https://github.com/succinctlabs/kona", rev = "574f5f56793ac592b5b31ffdd2cf683ac8371226" }
+kona-mpt = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-driver = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-derive = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29", default-features = false }
+kona-executor = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-client = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-host = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
+kona-proof = { git = "https://github.com/succinctlabs/kona", branch = "aurelien/patch-11-29" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/programs/fault-proof/Cargo.toml
+++ b/programs/fault-proof/Cargo.toml
@@ -21,6 +21,7 @@ sp1-zkvm = { workspace = true }
 kona-executor.workspace = true
 kona-driver.workspace = true
 kona-proof.workspace = true
+kona-preimage.workspace = true
 
 # op-succinct
 op-succinct-client-utils.workspace = true

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<()> {
             execution_duration.as_secs(),
         );
 
-        println!("Execution Stats: \n{:?}", stats);
+        println!("Execution Stats: \n{stats}");
 
         // Create the report directory if it doesn't exist.
         let report_dir = format!("execution-reports/multi/{}", l2_chain_id);

--- a/utils/client/Cargo.toml
+++ b/utils/client/Cargo.toml
@@ -26,7 +26,7 @@ op-alloy-protocol.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 
 # workspace (kona)
-kona-common.workspace = true
+kona-std-fpvm.workspace = true
 kona-client.workspace = true
 kona-preimage.workspace = true
 kona-mpt.workspace = true

--- a/utils/client/src/pipes.rs
+++ b/utils/client/src/pipes.rs
@@ -1,19 +1,18 @@
 //! Contains FPVM-specific constructs for the `kona-client` program.
 
-use kona_client::PipeHandle;
-use kona_common::FileDescriptor;
 use kona_preimage::{HintWriter, OracleReader};
+use kona_std_fpvm::{FileChannel, FileDescriptor};
 
 /// The global preimage oracle reader pipe.
-static ORACLE_READER_PIPE: PipeHandle =
-    PipeHandle::new(FileDescriptor::PreimageRead, FileDescriptor::PreimageWrite);
+static ORACLE_READER_PIPE: FileChannel =
+    FileChannel::new(FileDescriptor::PreimageRead, FileDescriptor::PreimageWrite);
 
 /// The global hint writer pipe.
-static HINT_WRITER_PIPE: PipeHandle =
-    PipeHandle::new(FileDescriptor::HintRead, FileDescriptor::HintWrite);
+static HINT_WRITER_PIPE: FileChannel =
+    FileChannel::new(FileDescriptor::HintRead, FileDescriptor::HintWrite);
 
 /// The global preimage oracle reader.
-pub static ORACLE_READER: OracleReader<PipeHandle> = OracleReader::new(ORACLE_READER_PIPE);
+pub static ORACLE_READER: OracleReader<FileChannel> = OracleReader::new(ORACLE_READER_PIPE);
 
 /// The global hint writer.
-pub static HINT_WRITER: HintWriter<PipeHandle> = HintWriter::new(HINT_WRITER_PIPE);
+pub static HINT_WRITER: HintWriter<FileChannel> = HintWriter::new(HINT_WRITER_PIPE);

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -690,14 +690,6 @@ impl OPSuccinctDataFetcher {
             }
         };
 
-        // The native programs are built with profile release-client-lto in build.rs
-        let exec_directory = match multi_block {
-            ProgramType::Single => {
-                format!("{}/target/release-client-lto/fault-proof", workspace_root)
-            }
-            ProgramType::Multi => format!("{}/target/release-client-lto/range", workspace_root),
-        };
-
         // Delete the data directory if the cache mode is DeleteCache.
         match cache_mode {
             CacheMode::KeepCache => (),
@@ -745,7 +737,7 @@ impl OPSuccinctDataFetcher {
                     .to_string(),
             ),
             data_dir: Some(data_directory.into()),
-            exec: Some(exec_directory),
+            native: true,
             server: false,
             rollup_config_path: Some(rollup_config_path),
             v: std::env::var("VERBOSITY")

--- a/utils/host/src/witnessgen.rs
+++ b/utils/host/src/witnessgen.rs
@@ -40,9 +40,8 @@ pub fn convert_host_cli_to_args(host_cli: &HostCli) -> Vec<String> {
         args.push("--data-dir".to_string());
         args.push(dir.to_string_lossy().into_owned());
     }
-    if let Some(exec) = &host_cli.exec {
-        args.push("--exec".to_string());
-        args.push(exec.to_string());
+    if host_cli.native {
+        args.push("--native".to_string());
     }
     if host_cli.server {
         args.push("--server".to_string());


### PR DESCRIPTION
Main changes:

* `kona-common` renamed to `kona-std-fpvm`
* `kona-common-proc` renamed to `kona-std-fpvm-proc`
* `KonaExecutor` refactoring
* `--exec` arg replace by `--native` option, so it's not possible to pass the executable path anymore, but it seems it wasn't used