### PR TITLE
feat(proposer): remove manual network proof timeout

### DIFF
--- a/proposer/op/proposer/flags/flags.go
+++ b/proposer/op/proposer/flags/flags.go
@@ -94,6 +94,7 @@ var (
 	ProofTimeoutFlag = &cli.Uint64Flag{
 		Name:    "proof-timeout",
 		Usage:   "Maximum time in seconds to spend generating a proof before giving up",
+		// If a proof takes more than 4 hours, assume the cluster failed to set it to failed state.
 		Value:   14400,
 		EnvVars: prefixEnvVars("MAX_PROOF_TIME"),
 	}

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -50,17 +50,10 @@ func (l *L2OutputSubmitter) ProcessPendingProofs() error {
 			continue
 		}
 
-		// TODO: Is this proof timeout logic necessary? Users should be able to count on the proof being fulfilled or unclaimed.
-		timeout := uint64(time.Now().Unix()) > req.ProofRequestTime+l.DriverSetup.Cfg.ProofTimeout
-		if timeout || proofStatus.Status == SP1ProofStatusUnclaimed {
+		if proofStatus.Status == SP1ProofStatusUnclaimed {
 			// Record the failure reason.
-			if timeout {
-				l.Log.Info("Proof timed out", "id", req.ProverRequestID)
-				l.Metr.RecordProveFailure("Timeout")
-			} else {
-				l.Log.Info("Proof unclaimed", "id", req.ProverRequestID, "reason", proofStatus.UnclaimDescription.String())
-				l.Metr.RecordProveFailure(proofStatus.UnclaimDescription.String())
-			}
+			l.Log.Info("Proof unclaimed", "id", req.ProverRequestID, "reason", proofStatus.UnclaimDescription.String())
+			l.Metr.RecordProveFailure(proofStatus.UnclaimDescription.String())
 
 			err = l.RetryRequest(req, proofStatus)
 			if err != nil {


### PR DESCRIPTION
The proof timeout logic was necessary when we could not assume that the network would correctly set the status of the proof to failed, and the application (op-succinct) had to do this itself to re-request a proof.

This inadvertently causes a backlogged cluster to become even more backlogged. 

Ex.
Requested proofs on the cluster (which are capped at `maxConcurrentProofRequests` per proposer) have been generating for > `proofTimeout` seconds (e.g. 4 hours). The application "times out" the proofs in it's own state, and re-requests the proofs, putting more load on the network.