### PR TITLE
feat: add initialization script

### DIFF
--- a/book/advanced/verify-binaries.md
+++ b/book/advanced/verify-binaries.md
@@ -37,11 +37,11 @@ Then build the binaries:
 ```bash
 cd programs/range
 # Build the range-elf
-cargo prove build --elf range-elf --docker
+cargo prove build --elf-name range-elf --docker
 
 cd ../aggregation
 # Build the aggregation-elf
-cargo prove build --elf aggregation-elf --docker
+cargo prove build --elf-name aggregation-elf --docker
 ```
 
 Now, verify the binaries by confirming the output of `vkey` matches the vkeys on the contract. The `vkey` program outputs the verification keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
+    networks:
+      - kt-op
 
   # OP Succinct Proposer
   op-succinct-proposer:
@@ -25,3 +27,10 @@ services:
     # The metrics port is the default port for the OP Proposer.
     ports:
       - "7300:7300"
+    networks:
+      - kt-op
+  
+networks:
+  kt-op:
+    name: kt-op
+    external: true

--- a/initialize_env.sh
+++ b/initialize_env.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Replace the values in the .env file
+l1_rpc="$(kurtosis port print op el-1-geth-lighthouse rpc)"
+l1_beacon_rpc="$(kurtosis port print op cl-1-lighthouse-geth http)"
+l2_rpc="$(kurtosis port print op op-el-1-op-geth-op-node-op-kurtosis rpc)"
+l2_node_rpc="$(kurtosis port print op op-cl-1-op-node-op-geth-op-kurtosis http)"
+
+sed -i "s|^L1_RPC=\".*\"$|L1_RPC=\"http://$l1_rpc\"|" .env
+sed -i "s|^L1_BEACON_RPC=\".*\"$|L1_BEACON_RPC=\"$l1_beacon_rpc\"|" .env
+sed -i "s|^L2_RPC=\".*\"$|L2_RPC=\"$l2_rpc\"|" .env
+sed -i "s|^L2_NODE_RPC=\".*\"$|L2_NODE_RPC=\"$l2_node_rpc\"|" .env
+
+verifier_address=$(just deploy-mock-verifier)
+
+# Extract the contract address from the output using grep and regex
+address=$(echo "$verifier_address" | grep -oP "0: address \K0x[a-fA-F0-9]{40}")
+
+# Check if the address was found
+if [[ -n "$address" ]]; then
+    # Check if VERIFIER_ADDRESS already exists in the .env file
+    if grep -q "VERIFIER_ADDRESS=" .env; then
+        # If it exists, update it with the new address
+        sed -i "s|^VERIFIER_ADDRESS=\".*\"$|VERIFIER_ADDRESS=\"$address\"|" .env
+    else
+        # If it doesn't exist, append it to the .env file
+        echo "VERIFIER_ADDRESS=$address" >> .env
+    fi
+    echo "VERIFIER_ADDRESS has been updated to $address."
+else
+    echo "Contract address not found in the output."
+fi
+
+l2oo_address=$(just deploy-oracle)
+
+# Extract the contract address from the output using grep and regex
+address=$(echo "$l2oo_address" | grep -oP "0: address \K0x[a-fA-F0-9]{40}")
+
+# Check if the address was found
+if [[ -n "$address" ]]; then
+    # Check if L2OO_ADDRESS already exists in the .env file
+    if grep -q "L2OO_ADDRESS=" .env; then
+        # If it exists, update it with the new address
+        sed -i "s|^L2OO_ADDRESS=\".*\"$|L2OO_ADDRESS=\"$address\"|" .env
+    else
+        # If it doesn't exist, append it to the .env file
+        echo "L2OO_ADDRESS=$address" >> .env
+    fi
+    echo "L2OO_ADDRESS has been updated to $address."
+else
+    echo "Contract address not found in the output."
+fi
+
+# Replace the RPCs to work with docker compose
+L1_RPC="el-1-geth-lighthouse:8545"
+L1_BEACON_RPC="cl-1-lighthouse-geth:4000"
+L2_RPC="op-el-1-op-geth-op-node-op-kurtosis:8545"
+L2_NODE_RPC="op-cl-1-op-node-op-geth-op-kurtosis:8547"
+
+sed -i "s|^L1_RPC=\".*\"$|L1_RPC=\"http://$L1_RPC\"|" .env
+sed -i "s|^L1_BEACON_RPC=\".*\"$|L1_BEACON_RPC=\"http://$L1_BEACON_RPC\"|" .env
+sed -i "s|^L2_RPC=\".*\"$|L2_RPC=\"http://$L2_RPC\"|" .env
+sed -i "s|^L2_NODE_RPC=\".*\"$|L2_NODE_RPC=\"http://$L2_NODE_RPC\"|" .env


### PR DESCRIPTION
## Rationale
This PR adds a bash script `initialize_env.sh` to automate the op-succinct contract deployment steps and to fill in the `.env` files as necessary:
- It depends on having the [Kurtosis optimism-package](https://github.com/ethpandaops/optimism-package) as a local L1 and L2.
- It depends on the existence of a `.env` file (example below)
```
L1_RPC="http://el-1-geth-lighthouse:8545"
L1_BEACON_RPC="http://cl-1-lighthouse-geth:4000"
L2_RPC="http://op-el-1-op-geth-op-node-op-kurtosis:8545"
L2_NODE_RPC="http://op-cl-1-op-node-op-geth-op-kurtosis:8547"
PRIVATE_KEY="bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
ETHERSCAN_API_KEY=""
SUBMISSION_INTERVAL="10"

# Known after deploying mock verifier
VERIFIER_ADDRESS="0xEE0fCB8E5cCAD0b4197BAabd633333886f5C364d"

# Known after deploying oracle  
L2OO_ADDRESS="0x086f77C5686dfe3F2f8FE487C5f8d357952C8556"
OP_SUCCINCT_MOCK="true"

# Upgrading oracle
EXECUTE_UPGRADE_CALL="true"

# Server logs
RUST_LOG="info"
RUST_BACKTRACE="full"
```
- This PR also fixes the docs using `--elf` flag to `--elf-name` 
- This PR also modifies the `docker-compose.yml` file to properly attach the op-succinct services to the local Kurtosis enclave

Running the `initialization_env.sh` script will:
- Automatically look for the Kurtosis services and fill in the env variables as necessary
- Run the `just` commands to deploy the mock verifier and the L2 oracle contracts
- Update the env variables to be compatible with docker-compose

## Example
1. Have a running Kurtosis optimism-package devnet in the background
2. Simply create a `.env` file with the above format
3. Run `./initialize_env.sh`
4. Build images as necessary
5. Run `docker compose up`