### PR TITLE
fix(proposer): `SplitRangeBasedOnSafeHeads` fallback

### DIFF
--- a/proposer/op/proposer/range.go
+++ b/proposer/op/proposer/range.go
@@ -195,13 +195,14 @@ func (l *L2OutputSubmitter) GetRangeProofBoundaries(ctx context.Context) error {
 	var spans []Span
 	// If the safeDB is activated, we use the safeHead based range splitting algorithm.
 	// Otherwise, we use the simple range splitting algorithm.
+	spans = l.SplitRangeBasic(newL2StartBlock, newL2EndBlock)
 	if safeDBActivated {
-		spans, err = l.SplitRangeBasedOnSafeHeads(ctx, newL2StartBlock, newL2EndBlock)
-		if err != nil {
-			return fmt.Errorf("failed to split range based on safe heads: %w", err)
+		safeHeadSpans, err := l.SplitRangeBasedOnSafeHeads(ctx, newL2StartBlock, newL2EndBlock)
+		if err == nil {
+			spans = safeHeadSpans
+		} else {
+			l.Log.Warn("failed to split range based on safe heads, using basic range splitting", "err", err)
 		}
-	} else {
-		spans = l.SplitRangeBasic(newL2StartBlock, newL2EndBlock)
 	}
 
 


### PR DESCRIPTION
It is possible for the `safeDB` to exist, but `optimism_safeHeadAtL1Block` fails on a specific block because the `safeDb` is not fully synced.

In this case, add a fallback to the safe db range-splitting algorithm to use the basic range splitting algorithm in the event of an error.