### PR TITLE
fix(contracts): make new fields backward compatible (additive) with previous layout

### DIFF
--- a/contracts/src/OPSuccinctL2OutputOracle.sol
+++ b/contracts/src/OPSuccinctL2OutputOracle.sol
@@ -84,14 +84,14 @@ contract OPSuccinctL2OutputOracle is Initializable, ISemver {
     /// @notice The hash of the chain's rollup config, which ensures the proofs submitted are for the correct chain.
     bytes32 public rollupConfigHash;
 
+    /// @notice A trusted mapping of block numbers to block hashes.
+    mapping(uint256 => bytes32) public historicBlockHashes;
+
     /// @notice The owner of the contract, who has admin permissions.
     address public owner;
 
     /// @notice The proposers that can propose new proofs.
     mapping(address => bool) public approvedProposers;
-
-    /// @notice A trusted mapping of block numbers to block hashes.
-    mapping(uint256 => bytes32) public historicBlockHashes;
 
     ////////////////////////////////////////////////////////////
     //                         Events                         //


### PR DESCRIPTION
This commit https://github.com/succinctlabs/op-succinct/commit/ef9f4bb1da6255a8c89e861b0ec06b92a382fd6d#diff-f3123986d1de1aece94262c62b71934f21cd59d61442264eacd7ab88f7ec1a01 made the new layout incompatible with the new features (ownable, multiple proposer)

Re-ordering to keep it backward compatible and ease migrations