### PR TITLE
fix(proposer): submission interval

### DIFF
--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -78,7 +78,7 @@ func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest, status ProofStat
 		return err
 	}
 
-	// TODO: Once execution errors are added, update this to retry only when there's an execution error returned on
+	// TODO: Once execution errors are added, update this to split the range only when there's an execution error returned on
 	// a SPAN proof.
 	// Retry same request.
 	err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -78,39 +78,13 @@ func (l *L2OutputSubmitter) RetryRequest(req *ent.ProofRequest, status ProofStat
 		return err
 	}
 
-	if req.Type == proofrequest.TypeAGG {
-		l.Log.Info("AGG proof failed, retrying", "id", req.ID)
-		// Retry same request if range is 1 block.
-		err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)
-		if err != nil {
-			l.Log.Error("failed to retry proof request", "err", err)
-			return err
-		}
-	} else {
-		l.Log.Info("SPAN proof failed, retrying", "id", req.ID)
-		// Split the proof in two if range is > 1, otherwise retry same request.
-		if (req.EndBlock-req.StartBlock) > 1 {
-			mid := (req.StartBlock + req.EndBlock) / 2
-			// Create two new proof requests, one from [start, mid] and one from [mid, end]. The requests
-			// are consecutive and overlapping.
-			err = l.db.NewEntry(req.Type, req.StartBlock, mid)
-			if err != nil {
-				l.Log.Error("failed to add first proof request", "err", err)
-				return err
-			}
-			err = l.db.NewEntry(req.Type, mid, req.EndBlock)
-			if err != nil {
-				l.Log.Error("failed to add second proof request", "err", err)
-				return err
-			}
-		} else {
-			// Retry same request if range is 1 block.
-			err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)
-			if err != nil {
-				l.Log.Error("failed to retry proof request", "err", err)
-				return err
-			}
-		}
+	// TODO: Once execution errors are added, update this to retry only when there's an execution error returned on
+	// a SPAN proof.
+	// Retry same request.
+	err = l.db.NewEntry(req.Type, req.StartBlock, req.EndBlock)
+	if err != nil {
+		l.Log.Error("failed to retry proof request", "err", err)
+		return err
 	}
 
 	return nil
@@ -293,7 +267,9 @@ func (l *L2OutputSubmitter) requestRealProof(proofType proofrequest.Type, jsonBo
 	if err := json.Unmarshal(resp, &response); err != nil {
 		return nil, fmt.Errorf("error decoding JSON response: %w", err)
 	}
-	l.Log.Info("successfully submitted proof", "proofID", response.ProofID)
+	// Format the proof ID as a hex string.
+	proofIdHex := fmt.Sprintf("%x", response.ProofID)
+	l.Log.Info("successfully submitted proof", "proofID", proofIdHex)
 	return response.ProofID, nil
 }
 

--- a/proposer/op/proposer/range.go
+++ b/proposer/op/proposer/range.go
@@ -193,8 +193,6 @@ func (l *L2OutputSubmitter) GetRangeProofBoundaries(ctx context.Context) error {
 	// if err != nil {
 	// 	l.Log.Warn("safeDB is not activated. Using simple range splitting algorithm.", "err", err)
 	// }
-	// // If the safeDB is activated, we use the safeHead based range splitting algorithm.
-	// // Otherwise, we use the simple range splitting algorithm.
 	// if safeDBActivated {
 	// 	safeHeadSpans, err := l.SplitRangeBasedOnSafeHeads(ctx, newL2StartBlock, newL2EndBlock)
 	// 	if err == nil {

--- a/proposer/op/proposer/range.go
+++ b/proposer/op/proposer/range.go
@@ -185,25 +185,24 @@ func (l *L2OutputSubmitter) GetRangeProofBoundaries(ctx context.Context) error {
 	// Note: Originally, this used the L1 finalized block. However, to satisfy the new API, we now use the L2 finalized block.
 	newL2EndBlock := status.FinalizedL2.Number
 
-	// Check if the safeDB is activated on the L2 node. If it is, we use the safeHead based range
-	// splitting algorithm. Otherwise, we use the simple range splitting algorithm.
-	safeDBActivated, err := l.isSafeDBActivated(ctx, rollupClient)
-	if err != nil {
-		l.Log.Warn("safeDB is not activated. Using simple range splitting algorithm.", "err", err)
-	}
-
-	var spans []Span
 	// If the safeDB is activated, we use the safeHead based range splitting algorithm.
 	// Otherwise, we use the simple range splitting algorithm.
-	spans = l.SplitRangeBasic(newL2StartBlock, newL2EndBlock)
-	if safeDBActivated {
-		safeHeadSpans, err := l.SplitRangeBasedOnSafeHeads(ctx, newL2StartBlock, newL2EndBlock)
-		if err == nil {
-			spans = safeHeadSpans
-		} else {
-			l.Log.Warn("failed to split range based on safe heads, using basic range splitting", "err", err)
-		}
-	}
+	spans := l.SplitRangeBasic(newL2StartBlock, newL2EndBlock)
+
+	// // Check if the safeDB is activated on the L2 node. If it is, we use the safeHead based range
+	// // splitting algorithm. Otherwise, we use the simple range splitting algorithm.
+	// safeDBActivated, err := l.isSafeDBActivated(ctx, rollupClient)
+	// if err != nil {
+	// 	l.Log.Warn("safeDB is not activated. Using simple range splitting algorithm.", "err", err)
+	// }
+	// if safeDBActivated {
+	// 	safeHeadSpans, err := l.SplitRangeBasedOnSafeHeads(ctx, newL2StartBlock, newL2EndBlock)
+	// 	if err == nil {
+	// 		spans = safeHeadSpans
+	// 	} else {
+	// 		l.Log.Warn("failed to split range based on safe heads, using basic range splitting", "err", err)
+	// 	}
+	// }
 
 
 	// Add each span to the DB. If there are no spans, we will not create any proofs.

--- a/proposer/op/proposer/range.go
+++ b/proposer/op/proposer/range.go
@@ -204,7 +204,6 @@ func (l *L2OutputSubmitter) GetRangeProofBoundaries(ctx context.Context) error {
 	// 	}
 	// }
 
-
 	// Add each span to the DB. If there are no spans, we will not create any proofs.
 	for _, span := range spans {
 		err := l.db.NewEntry(proofrequest.TypeSPAN, span.Start, span.End)

--- a/proposer/op/proposer/range.go
+++ b/proposer/op/proposer/range.go
@@ -185,8 +185,6 @@ func (l *L2OutputSubmitter) GetRangeProofBoundaries(ctx context.Context) error {
 	// Note: Originally, this used the L1 finalized block. However, to satisfy the new API, we now use the L2 finalized block.
 	newL2EndBlock := status.FinalizedL2.Number
 
-	// If the safeDB is activated, we use the safeHead based range splitting algorithm.
-	// Otherwise, we use the simple range splitting algorithm.
 	spans := l.SplitRangeBasic(newL2StartBlock, newL2EndBlock)
 
 	// // Check if the safeDB is activated on the L2 node. If it is, we use the safeHead based range
@@ -195,6 +193,8 @@ func (l *L2OutputSubmitter) GetRangeProofBoundaries(ctx context.Context) error {
 	// if err != nil {
 	// 	l.Log.Warn("safeDB is not activated. Using simple range splitting algorithm.", "err", err)
 	// }
+	// // If the safeDB is activated, we use the safeHead based range splitting algorithm.
+	// // Otherwise, we use the simple range splitting algorithm.
 	// if safeDBActivated {
 	// 	safeHeadSpans, err := l.SplitRangeBasedOnSafeHeads(ctx, newL2StartBlock, newL2EndBlock)
 	// 	if err == nil {


### PR DESCRIPTION
Split the range according to `splitRangeBasic`, as advanced range splitting is an over-optimization.

Don't split the range on failure in half until we have more insight into the error type. We should only split on execution errors for the span proofs.