### PR TITLE
chore: turn off native execution logging

### DIFF
--- a/proposer/succinct/build.rs
+++ b/proposer/succinct/build.rs
@@ -1,5 +1,5 @@
-use op_succinct_build_utils::build_all;
+use op_succinct_build_utils::{build_all, ProgramBuildArgs};
 
 fn main() {
-    build_all();
+    build_all(ProgramBuildArgs::Default);
 }

--- a/scripts/prove/build.rs
+++ b/scripts/prove/build.rs
@@ -1,5 +1,5 @@
-use op_succinct_build_utils::build_all;
+use op_succinct_build_utils::{build_all, ProgramBuildArgs};
 
 fn main() {
-    build_all();
+    build_all(ProgramBuildArgs::Default);
 }

--- a/scripts/utils/build.rs
+++ b/scripts/utils/build.rs
@@ -1,5 +1,5 @@
-use op_succinct_build_utils::build_all;
+use op_succinct_build_utils::{build_all, ProgramBuildArgs};
 
 fn main() {
-    build_all();
+    build_all(ProgramBuildArgs::Default);
 }


### PR DESCRIPTION
Add `ProgramBuildArgs`, which enables declaratively specifying whether to build the native program with the `tracing-subscriber` feature on, which will emit helpful debugging logs.