### PR TITLE
feat: use execution status to split proofs

### DIFF
--- a/contracts/opsuccinctl2ooconfig.json
+++ b/contracts/opsuccinctl2ooconfig.json
@@ -1,15 +1,15 @@
 {
-  "challenger": "0x0000000000000000000000000000000000000000",
+  "challenger": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
   "finalizationPeriod": 3600,
-  "l2BlockTime": 2,
+  "l2BlockTime": 10,
   "owner": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
   "proposer": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
-  "rollupConfigHash": "0x0d7101e2acc7eae1fb42cfce5c604d14da561726e4e01b509315e5a9f97a9816",
-  "startingBlockNumber": 5726082,
-  "startingOutputRoot": "0x88cf50185686c85146bdfd3aa17c9624b13a7c3ec912f68026c54171735a0be3",
-  "startingTimestamp": 1733804652,
-  "submissionInterval": 1200,
+  "rollupConfigHash": "0x71241d0f92749d7365aaaf6a015de550816632a4e4e84e273f865f582e8190aa",
+  "startingBlockNumber": 228600,
+  "startingOutputRoot": "0x92f0c5d048ecf1baecd500a0f74e74e448c90d025e1537e8e5a980b1d04ea333",
+  "startingTimestamp": 1734404604,
+  "submissionInterval": 2,
   "verifier": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
-  "aggregationVkey": "0x00ea4171dbd0027768055bee7f6d64e17e9cec99b29aad5d18e5d804b967775b",
-  "rangeVkeyCommitment": "0x51decb4a49105f2a1403423f560bc55d6d02e5eb57f21d0c5bd6a661555a8e53"
+  "aggregationVkey": "0x00447343f9cd7df4b54b951589f45a53a352f8eb96902e2bec4282c69d1342ca",
+  "rangeVkeyCommitment": "0x39697ff360c8327522356072263e1d622ed16daf439ee6e82bc3e000456c1992"
 }

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -53,7 +53,7 @@ func (d UnclaimDescription) String() string {
 	}
 }
 
-// SP1FulfillmentStatus represents the status of a proof in the SP1 network.
+// SP1FulfillmentStatus represents the fulfillment status of a proof in the SP1 network.
 type SP1FulfillmentStatus int
 
 const (
@@ -64,7 +64,7 @@ const (
 	SP1FulfillmentStatusUnfulfillable
 )
 
-// SP1ExecutionStatus represents the status of the execution of a proof in the SP1 network.
+// SP1ExecutionStatus represents the execution status of a proof in the SP1 network.
 type SP1ExecutionStatus int
 
 const (

--- a/proposer/op/proposer/rpc_types.go
+++ b/proposer/op/proposer/rpc_types.go
@@ -53,7 +53,7 @@ func (d UnclaimDescription) String() string {
 	}
 }
 
-// SP1ProofStatus represents the status of a proof in the SP1 network.
+// SP1FulfillmentStatus represents the status of a proof in the SP1 network.
 type SP1FulfillmentStatus int
 
 const (
@@ -64,8 +64,20 @@ const (
 	SP1FulfillmentStatusUnfulfillable
 )
 
+// SP1ExecutionStatus represents the status of the execution of a proof in the SP1 network.
+type SP1ExecutionStatus int
+
+const (
+	SP1ExecutionStatusUnspecified SP1ExecutionStatus = iota
+	SP1ExecutionStatusUnexecuted
+	SP1ExecutionStatusExecuted
+	SP1ExecutionStatusUnexecutable
+)
+
 // ProofStatusResponse is the response type for the `/status/:proof_id` RPC from the op-succinct-server.
 type ProofStatusResponse struct {
-	Status             SP1FulfillmentStatus `json:"status"`
-	Proof              []byte               `json:"proof"`
+	FulfillmentStatus SP1FulfillmentStatus `json:"fulfillment_status"`
+	ExecutionStatus   SP1ExecutionStatus   `json:"execution_status"`
+	Proof             []byte               `json:"proof"`
 }
+

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -551,8 +551,8 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::OK,
                     Json(ProofStatus {
-                        fulfillment_status: fulfillment_status.into(),
-                        execution_status: execution_status.into(),
+                        fulfillment_status,
+                        execution_status,
                         proof: proof_bytes,
                     }),
                 ));
@@ -563,8 +563,8 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::OK,
                     Json(ProofStatus {
-                        fulfillment_status: fulfillment_status.into(),
-                        execution_status: execution_status.into(),
+                        fulfillment_status,
+                        execution_status,
                         proof: proof_bytes,
                     }),
                 ));
@@ -575,8 +575,8 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::OK,
                     Json(ProofStatus {
-                        fulfillment_status: fulfillment_status.into(),
-                        execution_status: execution_status.into(),
+                        fulfillment_status,
+                        execution_status,
                         proof: proof_bytes,
                     }),
                 ));
@@ -587,8 +587,8 @@ async fn get_proof_status(
         return Ok((
             StatusCode::OK,
             Json(ProofStatus {
-                fulfillment_status: fulfillment_status.into(),
-                execution_status: execution_status.into(),
+                fulfillment_status,
+                execution_status,
                 proof: vec![],
             }),
         ));
@@ -596,8 +596,8 @@ async fn get_proof_status(
     Ok((
         StatusCode::OK,
         Json(ProofStatus {
-            fulfillment_status: fulfillment_status.into(),
-            execution_status: execution_status.into(),
+            fulfillment_status,
+            execution_status,
             proof: vec![],
         }),
     ))

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -25,7 +25,7 @@ use op_succinct_proposer::{
 use sp1_sdk::{
     network_v2::{
         client::NetworkClient,
-        proto::network::{FulfillmentStatus, FulfillmentStrategy, ProofMode},
+        proto::network::{ExecutionStatus, FulfillmentStatus, FulfillmentStrategy, ProofMode},
     },
     utils, HashableKey, NetworkProverV2, ProverClient, SP1Proof, SP1ProofWithPublicValues,
 };
@@ -400,7 +400,8 @@ async fn request_mock_span_proof(
     Ok((
         StatusCode::OK,
         Json(ProofStatus {
-            status: sp1_sdk::network::proto::network::ProofStatus::ProofFulfilled.into(),
+            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+            execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
             proof: proof_bytes,
         }),
     ))
@@ -489,7 +490,8 @@ async fn request_mock_agg_proof(
     Ok((
         StatusCode::OK,
         Json(ProofStatus {
-            status: sp1_sdk::network::proto::network::ProofStatus::ProofFulfilled.into(),
+            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+            execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
             proof: proof.bytes(),
         }),
     ))
@@ -517,7 +519,8 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ProofStatus {
-                        status: FulfillmentStatus::UnspecifiedFulfillmentStatus.into(),
+                        fulfillment_status: FulfillmentStatus::UnspecifiedFulfillmentStatus.into(),
+                        execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
                         proof: vec![],
                     }),
                 ));
@@ -526,16 +529,17 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ProofStatus {
-                        status: FulfillmentStatus::UnspecifiedFulfillmentStatus.into(),
+                        fulfillment_status: FulfillmentStatus::UnspecifiedFulfillmentStatus.into(),
+                        execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
                         proof: vec![],
                     }),
                 ));
             }
         };
 
-    // TODO: Use execution error for reserved once it's added.
-    let status = status.fulfillment_status();
-    if status == FulfillmentStatus::Fulfilled {
+    let fulfillment_status = status.fulfillment_status;
+    let execution_status = status.execution_status;
+    if fulfillment_status == FulfillmentStatus::Fulfilled as i32 {
         let proof: SP1ProofWithPublicValues = maybe_proof.unwrap();
 
         match proof.proof {
@@ -547,7 +551,8 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::OK,
                     Json(ProofStatus {
-                        status: status.into(),
+                        fulfillment_status: fulfillment_status.into(),
+                        execution_status: execution_status.into(),
                         proof: proof_bytes,
                     }),
                 ));
@@ -558,7 +563,8 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::OK,
                     Json(ProofStatus {
-                        status: status.into(),
+                        fulfillment_status: fulfillment_status.into(),
+                        execution_status: execution_status.into(),
                         proof: proof_bytes,
                     }),
                 ));
@@ -569,18 +575,20 @@ async fn get_proof_status(
                 return Ok((
                     StatusCode::OK,
                     Json(ProofStatus {
-                        status: status.into(),
+                        fulfillment_status: fulfillment_status.into(),
+                        execution_status: execution_status.into(),
                         proof: proof_bytes,
                     }),
                 ));
             }
             _ => (),
         }
-    } else if status == FulfillmentStatus::Unfulfillable {
+    } else if fulfillment_status == FulfillmentStatus::Unfulfillable as i32 {
         return Ok((
             StatusCode::OK,
             Json(ProofStatus {
-                status: status.into(),
+                fulfillment_status: fulfillment_status.into(),
+                execution_status: execution_status.into(),
                 proof: vec![],
             }),
         ));
@@ -588,7 +596,8 @@ async fn get_proof_status(
     Ok((
         StatusCode::OK,
         Json(ProofStatus {
-            status: status.into(),
+            fulfillment_status: fulfillment_status.into(),
+            execution_status: execution_status.into(),
             proof: vec![],
         }),
     ))

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -66,9 +66,9 @@ impl From<String> for UnclaimDescription {
 #[derive(Serialize, Deserialize)]
 /// The status of a proof request.
 pub struct ProofStatus {
-    // Note: Can't use `SP1FulfillmentStatus` directly because `Serialize_repr` and `Deserialize_repr` aren't derived on it.
-    // serde_repr::Serialize_repr and Deserialize_repr are necessary to use `SP1FulfillmentStatus` in this struct.
-    pub status: i32,
+    // Note: Can't use `FulfillmentStatus`/`ExecutionStatus` directly because `Serialize_repr` and `Deserialize_repr` aren't derived on it.
+    pub fulfillment_status: i32,
+    pub execution_status: i32,
     pub proof: Vec<u8>,
 }
 

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -53,7 +53,7 @@ fn get_address(env_var: &str) -> String {
 /// Specifically, updates the following fields in `opsuccinctl2ooconfig.json`:
 /// - rollup_config_hash: Get the hash of the rollup config from the rollup config file.
 /// - l2_block_time: Get the block time from the rollup config.
-/// - starting_block_number: If `USE_CACHED_STARTING_BLOCK` is `false`, set starting_block_number to 10 blocks before the latest block on L2.
+/// - starting_block_number: If `STARTING_BLOCK_NUMBER` is not set, set starting_block_number to the latest finalized block on L2.
 /// - starting_output_root: Set to the output root of the starting block number.
 /// - starting_timestamp: Set to the timestamp of the starting block number.
 /// - chain_id: Get the chain id from the rollup config.


### PR DESCRIPTION
With `network-v2`, we can use the `executionStatus` returned with a proof to split proofs based on an OOM in SP1.

Note: With the embedded allocator, this is no longer necessary.