### PR TITLE
 feat: add SKIP_L1_PROPOSAL flag to skip L1 transactions

### DIFF
--- a/tools/ci/setup.sh
+++ b/tools/ci/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Add default parameter for skipping L1 transactions
+SKIP_L1_PROPOSAL=${SKIP_L1_PROPOSAL:-false}
+
+echo "--- Installing yarn dependencies"
+
+# Disable global cache so that we can cache `.yarn/cache` in buildkite
+yarn config set enableGlobalCache false
+
+# Check for lockfile before running yarn --immutable
+if [[ -f yarn.lock ]]; then
+    echo "--- Verifying lockfile integrity"
+    yarn --immutable || { echo "Lockfile validation failed! Ensure your lockfile is up to date."; exit 1; }
+else
+    echo "Error: yarn.lock file not found. Aborting."
+    exit 1
+fi
+
+# Need to ensure base branch is up-to-date
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-$BUILDKITE_BRANCH}"
+if [[ -z "$BASE_BRANCH" ]]; then
+    echo "Error: Unable to determine base branch. Ensure BUILDKITE_BRANCH is set."
+    exit 1
+fi
+
+echo "--- Updating local '$BASE_BRANCH' base branch"
+
+# Required for correct Nx affected project resolution
+if git fetch -f --no-tags origin "$BASE_BRANCH:$BASE_BRANCH"; then
+    echo "--- Successfully updated '$BASE_BRANCH'"
+else
+    echo "Error: Failed to fetch base branch '$BASE_BRANCH'. Ensure it exists in the remote repository."
+    exit 1
+fi
+
+# Check SKIP_L1_PROPOSAL flag
+if [ "$SKIP_L1_PROPOSAL" = true ]; then
+    echo "--- Skipping L1 transaction step (SKIP_L1_PROPOSAL=true)"
+    export OP_SUCCINCT_SKIP_L1=true
+fi
+
+echo "--- Building required packages"
+if yarn build; then
+    echo "--- Build completed successfully"
+else
+    echo "Error: Build failed. Check the logs for details."
+    exit 1
+fi 


### PR DESCRIPTION
# Description
Added functionality to skip L1 transactions during testing by introducing a new environment variable `SKIP_L1_PROPOSAL`.

## Changes
- Added `SKIP_L1_PROPOSAL` environment variable (default: false)
- When `SKIP_L1_PROPOSAL=true`, the script sets `OP_SUCCINCT_SKIP_L1=true`
- Added logging to indicate when L1 transactions are being skipped

## Usage
To skip L1 transactions during testing:
bash
SKIP_L1_PROPOSAL=true ./tools/ci/setup.sh

## Testing
- [ ] Tested with `SKIP_L1_PROPOSAL=false` (default behavior)
- [ ] Tested with `SKIP_L1_PROPOSAL=true`
- [ ] Verified that proofs are still generated and stored in database

Closes #258