### PR TITLE
chore: update network configs and documentation versions

### DIFF
--- a/book/advanced/verify-binaries.md
+++ b/book/advanced/verify-binaries.md
@@ -37,15 +37,15 @@ Then build the binaries:
 ```bash
 cd programs/range
 # Build the range-elf
-cargo prove build --elf-name range-elf --docker --tag "v3.0.0"
+cargo prove build --elf-name range-elf --docker --tag "v3.4.0"
 
 cd programs/dummy-range
 # Build the dummy-range-elf
-cargo prove build --elf-name dummy-range-elf --docker --tag "v3.0.0"
+cargo prove build --elf-name dummy-range-elf --docker --tag "v3.4.0"
 
 cd ../aggregation
 # Build the aggregation-elf
-cargo prove build --elf-name aggregation-elf --docker --tag "v3.0.0"
+cargo prove build --elf-name aggregation-elf --docker --tag "v3.4.0"
 ```
 
 Now, verify the binaries by confirming the output of `vkey` matches the vkeys on the contract. The `vkey` program outputs the verification keys


### PR DESCRIPTION
- The versions must match the SP1 versions (sp1-zkvm and sp1-build) used in the project.

- Using different versions may lead to incompatibility or build errors.

- The documentation must reflect the current state of the project.