### PR TITLE
chore(proposer): add sqlite3 to docker image for ops

### DIFF
--- a/proposer/op/Dockerfile.op_proposer
+++ b/proposer/op/Dockerfile.op_proposer
@@ -26,6 +26,7 @@ FROM ubuntu:22.04
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -y \
     ca-certificates \
+    sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the built op-proposer binary from the previous stage


### PR DESCRIPTION
Include sqlite3 in op proposer image to facilitate proof ops (e.g. debug local proof status, re-request failed proofs with different params)