### PR TITLE
fix: error logging

### DIFF
--- a/contracts/opsuccinctl2ooconfig.json
+++ b/contracts/opsuccinctl2ooconfig.json
@@ -5,11 +5,11 @@
   "owner": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
   "proposer": "0xDEd0000E32f8F40414d3ab3a830f735a3553E18e",
   "rollupConfigHash": "0x71241d0f92749d7365aaaf6a015de550816632a4e4e84e273f865f582e8190aa",
-  "startingBlockNumber": 228600,
-  "startingOutputRoot": "0x92f0c5d048ecf1baecd500a0f74e74e448c90d025e1537e8e5a980b1d04ea333",
-  "startingTimestamp": 1734404604,
-  "submissionInterval": 2,
+  "startingBlockNumber": 349460,
+  "startingOutputRoot": "0x976350d8d672a46ffa14faefac53827df68cebcb86305b5042b9f9cc963107d1",
+  "startingTimestamp": 1735613204,
+  "submissionInterval": 1200,
   "verifier": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
-  "aggregationVkey": "0x000fd40837604d14c32f0a0c6cb7f011274195f8029cec268be80aea22c561e1",
-  "rangeVkeyCommitment": "0x38a92ced5bf5edbf6b1affb013c9f75c4ecec3223743088b734e6dd34d7f046c"
+  "aggregationVkey": "0x00d4e72bc998d0528b0722a53bedd9c6f0143c9157af194ad4bb2502e37a496f",
+  "rangeVkeyCommitment": "0x33e3678015df481724af3aac49d000923caeec277027610b1490f857769f9459"
 }

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -399,15 +399,14 @@ func (l *L2OutputSubmitter) GetProofStatus(proofId string) (ProofStatusResponse,
 			Error string `json:"error"`
 		}
 		if err := json.Unmarshal(body, &errResp); err == nil {
-			l.Log.Error("Get proof status request failed",
+			l.Log.Error("Failed to get proof status",
 				"status", resp.StatusCode,
 				"error", errResp.Error)
 		} else {
-			l.Log.Error("Get proof status request failed", 
+			l.Log.Error("Failed to get unmarshal proof status error message", 
 				"status", resp.StatusCode,
-				"body", string(body))
+				"body", body)
 		}
-		l.Metr.RecordWitnessGenFailure("Failed")
 		return ProofStatusResponse{}, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
 	}
 

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -340,7 +340,19 @@ func (l *L2OutputSubmitter) makeProofRequest(proofType proofrequest.Type, jsonBo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		l.Log.Error("Witness generation request failed", "status", resp.StatusCode, "body", resp.Body)
+		body, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &errResp); err == nil {
+			l.Log.Error("Witness generation request failed",
+				"status", resp.StatusCode,
+				"error", errResp.Error)
+		} else {
+			l.Log.Error("Witness generation request failed", 
+				"status", resp.StatusCode,
+				"body", string(body))
+		}
 		l.Metr.RecordWitnessGenFailure("Failed")
 		return nil, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
 	}
@@ -382,6 +394,20 @@ func (l *L2OutputSubmitter) GetProofStatus(proofId string) (ProofStatusResponse,
 
 	// If the response status code is not 200, return an error.
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &errResp); err == nil {
+			l.Log.Error("Get proof status request failed",
+				"status", resp.StatusCode,
+				"error", errResp.Error)
+		} else {
+			l.Log.Error("Get proof status request failed", 
+				"status", resp.StatusCode,
+				"body", string(body))
+		}
+		l.Metr.RecordWitnessGenFailure("Failed")
 		return ProofStatusResponse{}, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
 	}
 

--- a/proposer/op/proposer/prove.go
+++ b/proposer/op/proposer/prove.go
@@ -335,6 +335,7 @@ func (l *L2OutputSubmitter) makeProofRequest(proofType proofrequest.Type, jsonBo
 			l.Metr.RecordWitnessGenFailure("Timeout")
 			return nil, fmt.Errorf("request timed out after %s: %w", timeout, err)
 		}
+		l.Log.Error("Witness generation request failed", "err", err)
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()

--- a/proposer/op/proposer/range.go
+++ b/proposer/op/proposer/range.go
@@ -49,7 +49,7 @@ func (l *L2OutputSubmitter) GetL1HeadForL2Block(ctx context.Context, rollupClien
 	return 0, fmt.Errorf("could not find an L1 block with an L2 safe head greater than the L2 end block")
 }
 
-func (l *L2OutputSubmitter) isSafeDBActivated(ctx context.Context, rollupClient *sources.RollupClient) (bool, error) {
+func (l *L2OutputSubmitter) IsSafeDBActivated(ctx context.Context, rollupClient *sources.RollupClient) (bool, error) {
 	// Get the sync status of the rollup node.
 	status, err := rollupClient.SyncStatus(ctx)
 	if err != nil {

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -282,7 +282,7 @@ async fn request_agg_proof(
         }
     };
 
-    let l1_head: [u8; 32] = match l1_head_bytes.try_into() {
+    let l1_head: [u8; 32] = match l1_head_bytes.clone().try_into() {
         Ok(array) => array,
         Err(_) => {
             error!(

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -38,7 +38,11 @@ pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Set up the SP1 SDK logger.
     utils::setup_logger();
+
+    // Enable logging.
+    env::set_var("RUST_LOG", "info");
 
     dotenv::dotenv().ok();
 
@@ -264,19 +268,27 @@ async fn request_agg_proof(
             Ok(bytes) => bytes,
             Err(e) => {
                 error!("Failed to decode L1 head hex string: {}", e);
-                return Err(AppError(anyhow::anyhow!("Failed to decode L1 head hex string: {}", e)));
+                return Err(AppError(anyhow::anyhow!(
+                    "Failed to decode L1 head hex string: {}",
+                    e
+                )));
             }
         },
         None => {
             error!("Invalid L1 head format: missing 0x prefix");
-            return Err(AppError(anyhow::anyhow!("Invalid L1 head format: missing 0x prefix")));
+            return Err(AppError(anyhow::anyhow!(
+                "Invalid L1 head format: missing 0x prefix"
+            )));
         }
     };
 
     let l1_head: [u8; 32] = match l1_head_bytes.try_into() {
         Ok(array) => array,
         Err(_) => {
-            error!("Invalid L1 head length: expected 32 bytes, got {}", l1_head_bytes.len());
+            error!(
+                "Invalid L1 head length: expected 32 bytes, got {}",
+                l1_head_bytes.len()
+            );
             return Err(AppError(anyhow::anyhow!(
                 "Invalid L1 head length: expected 32 bytes, got {}",
                 l1_head_bytes.len()

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -259,13 +259,30 @@ async fn request_agg_proof(
         .map(|proof| proof.proof.clone())
         .collect();
 
-    let l1_head_bytes = hex::decode(
-        payload
-            .head
-            .strip_prefix("0x")
-            .expect("Invalid L1 head, no 0x prefix."),
-    )?;
-    let l1_head: [u8; 32] = l1_head_bytes.try_into().unwrap();
+    let l1_head_bytes = match payload.head.strip_prefix("0x") {
+        Some(hex_str) => match hex::decode(hex_str) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("Failed to decode L1 head hex string: {}", e);
+                return Err(AppError(anyhow::anyhow!("Failed to decode L1 head hex string: {}", e)));
+            }
+        },
+        None => {
+            error!("Invalid L1 head format: missing 0x prefix");
+            return Err(AppError(anyhow::anyhow!("Invalid L1 head format: missing 0x prefix")));
+        }
+    };
+
+    let l1_head: [u8; 32] = match l1_head_bytes.try_into() {
+        Ok(array) => array,
+        Err(_) => {
+            error!("Invalid L1 head length: expected 32 bytes, got {}", l1_head_bytes.len());
+            return Err(AppError(anyhow::anyhow!(
+                "Invalid L1 head length: expected 32 bytes, got {}",
+                l1_head_bytes.len()
+            )));
+        }
+    };
 
     let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
         Ok(f) => f,

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -606,7 +606,7 @@ impl OPSuccinctDataFetcher {
     pub async fn fetch_headers_in_range(&self, start: u64, end: u64) -> Result<Vec<Header>> {
         let headers = stream::iter(start..=end)
             .map(|block_number| async move { self.get_l1_header(block_number.into()).await })
-            .buffered(100)
+            .buffered(10)
             .collect::<Vec<Result<Header>>>()
             .await
             .into_iter()


### PR DESCRIPTION
- Reduce the number of concurrent L1 RPC requests to 10.
- Add error handling for the agg proof request.
- Handle the string error logging inside of the proposer.