### PR TITLE
chore: fix function name in comment

### DIFF
--- a/proposer/op/proposer/utils/utils.go
+++ b/proposer/op/proposer/utils/utils.go
@@ -183,7 +183,7 @@ func convertBaseFeeParams(rawConfig map[string]interface{}, key string) {
 	}
 }
 
-// GetAllSpanBatchesInBlockRange fetches span batches within a range of L2 blocks.
+// GetAllSpanBatchesInL2BlockRange fetches span batches within a range of L2 blocks.
 func GetAllSpanBatchesInL2BlockRange(config BatchDecoderConfig) ([]SpanBatchRange, error) {
 	rollupCfg, err := setupBatchDecoderConfig(&config)
 	if err != nil {


### PR DESCRIPTION
fix function name in comment