### PR TITLE
fix: don't disable logs on the server

### DIFF
--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -43,11 +43,11 @@ pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Set up the SP1 SDK logger.
-    utils::setup_logger();
-
     // Enable logging.
     env::set_var("RUST_LOG", "info");
+
+    // Set up the SP1 SDK logger.
+    utils::setup_logger();
 
     dotenv::dotenv().ok();
 


### PR DESCRIPTION
If `RUST_LOG` is not set before the call to:

```rust
utils::setup_logger();
```

all logging is suppressed, as [EnvFilter::try_from_default_env()
](https://github.com/succinctlabs/sp1/blob/dbe622aa4a6a33c88d76298c2a29a1d7ef7e90df/crates/core/machine/src/utils/logger.rs#L15) fails and all logging is set to `off`