### PR TITLE
fix: skip first block in cost estimation for initial range

### DIFF
--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -67,7 +67,9 @@ async fn main() -> Result<()> {
         proof
             .save(format!(
                 "{}/{}-{}.bin",
-                proof_dir, l2_start_block, l2_end_block
+                proof_dir,
+                l2_start_block + 1,
+                l2_end_block
             ))
             .expect("saving proof failed");
     } else {
@@ -93,7 +95,9 @@ async fn main() -> Result<()> {
 
         let report_path = format!(
             "execution-reports/multi/{}/{}-{}.csv",
-            l2_chain_id, l2_start_block, l2_end_block
+            l2_chain_id,
+            l2_start_block + 1,
+            l2_end_block
         );
 
         // Write to CSV.

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -98,7 +98,16 @@ async fn execute_blocks_and_write_stats_csv(
             let (_, report) = result.unwrap();
 
             // Get the existing execution stats and modify it in place.
-            let execution_stats = ExecutionStats::new(block_data, &report, 0, 0);
+            // Skip the first block if this is the very first range, as this is not actually executed
+            let first_block_number = block_data.first()
+                .map(|block| block.block_number)
+                .expect("`block_data` is empty");
+            let block_data = if first_block_number == start {
+                block_data.iter().skip(1).cloned().collect()
+            } else {
+                block_data.clone()
+            };
+            let execution_stats = ExecutionStats::new(&block_data, &report, 0, 0);
 
             let mut file = OpenOptions::new()
                 .read(true)

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -59,7 +59,9 @@ async fn execute_blocks_and_write_stats_csv(
     let root_dir = PathBuf::from(cargo_metadata.workspace_root);
     let report_path = root_dir.join(format!(
         "execution-reports/{}/{}-{}-report.csv",
-        l2_chain_id, start, end
+        l2_chain_id,
+        start + 1,
+        end
     ));
     // Create the parent directory if it doesn't exist
     if let Some(parent) = report_path.parent() {
@@ -212,10 +214,7 @@ async fn main() -> Result<()> {
         split_range_basic(l2_start_block, l2_end_block, args.batch_size)
     };
 
-    info!(
-        "The span batch ranges which will be executed: {:?}",
-        split_ranges
-    );
+    info!("The span batch ranges: {:?}", split_ranges);
 
     let cache_mode = if args.use_cache {
         CacheMode::KeepCache
@@ -258,7 +257,9 @@ async fn main() -> Result<()> {
     let root_dir = PathBuf::from(cargo_metadata.workspace_root);
     let report_path = root_dir.join(format!(
         "execution-reports/{}/{}-{}-report.csv",
-        l2_chain_id, l2_start_block, l2_end_block
+        l2_chain_id,
+        l2_start_block + 1,
+        l2_end_block
     ));
 
     // Read the execution stats from the CSV file and aggregate them to output to the user.

--- a/utils/host/src/block_range.rs
+++ b/utils/host/src/block_range.rs
@@ -51,20 +51,20 @@ pub async fn get_validated_block_range(
     };
 
     // If start block not provided, use end block - default_range
-    let l2_start_block = match start {
-        Some(start) => start,
-        None => max(1, l2_end_block.saturating_sub(default_range)),
+    let l2_initial_state_block = match start {
+        Some(start) => start - 1,
+        None => max(1, l2_end_block.saturating_sub(default_range + 1)),
     };
 
-    if l2_start_block >= l2_end_block {
+    if l2_initial_state_block >= l2_end_block {
         bail!(
-            "Start block ({}) must be less than end block ({})",
-            l2_start_block,
+            "Initial state block ({}) must be less than end block ({})",
+            l2_initial_state_block,
             l2_end_block
         );
     }
 
-    Ok((l2_start_block, l2_end_block))
+    Ok((l2_initial_state_block, l2_end_block))
 }
 
 /// Get a fixed recent (less than the provided interval) block range.


### PR DESCRIPTION
When calculating execution statistics for cost estimation, skip the first block if it's the very first range in the sequence, as this block is not actually executed. This prevents including non-executed blocks in stats, especially for the number of blocks, leading to more accurate estimates.