### PR TITLE
chore(utils): update block data range

### DIFF
--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -347,11 +347,16 @@ impl OPSuccinctDataFetcher {
         Ok(fee_data)
     }
 
-    /// Get the aggregate block statistics for a range of blocks.
+    /// Get the aggregate block statistics for a range of blocks exclusive of the start block.
+    ///
+    /// When proving a range in OP Succinct, we are proving the transition from the block hash
+    /// of the start block to the block hash of the end block. This means that we don't expend resources
+    /// to "prove" the start block. This is why the start block is not included in the range for which
+    /// we fetch block data.
     pub async fn get_l2_block_data_range(&self, start: u64, end: u64) -> Result<Vec<BlockInfo>> {
         use futures::stream::{self, StreamExt};
 
-        let block_data = stream::iter(start..=end)
+        let block_data = stream::iter(start + 1..=end)
             .map(|block_number| async move {
                 let block = self
                     .l2_provider

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -129,7 +129,8 @@ impl ExecutionStats {
         let total_gas_used: u64 = block_data.iter().map(|b| b.gas_used).sum();
 
         Self {
-            // The first block is not included in the cycles, or in the gas used.
+            // The "block data" does not include the first block (as it's not executed), so we need to subtract 1 to give the user back the 
+            // block corresponding to the blockhash they're proving from.
             batch_start: block_data[0].block_number - 1,
             batch_end: block_data[block_data.len() - 1].block_number,
             total_instruction_count: report.total_instruction_count(),

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -130,7 +130,7 @@ impl ExecutionStats {
 
         Self {
             // The first block is not included in the cycles, or in the gas used.
-            batch_start: block_data[0].block_number + 1,
+            batch_start: block_data[0].block_number - 1,
             batch_end: block_data[block_data.len() - 1].block_number,
             total_instruction_count: report.total_instruction_count(),
             total_sp1_gas: 0,

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -129,7 +129,8 @@ impl ExecutionStats {
         let total_gas_used: u64 = block_data.iter().map(|b| b.gas_used).sum();
 
         Self {
-            batch_start: block_data[0].block_number,
+            // The first block is not included in the cycles, or in the gas used.
+            batch_start: block_data[0].block_number - 1,
             batch_end: block_data[block_data.len() - 1].block_number,
             total_instruction_count: report.total_instruction_count(),
             total_sp1_gas: 0,

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -130,7 +130,7 @@ impl ExecutionStats {
 
         Self {
             // The first block is not included in the cycles, or in the gas used.
-            batch_start: block_data[0].block_number - 1,
+            batch_start: block_data[0].block_number + 1,
             batch_end: block_data[block_data.len() - 1].block_number,
             total_instruction_count: report.total_instruction_count(),
             total_sp1_gas: 0,


### PR DESCRIPTION
Fixes fetching the block data for the very first block in the range, which is actually not executed nor proven. This prevents including non-executed blocks in stats, especially for the number of blocks, leading to more accurate estimates.