### PR TITLE
fix: enable command to run cost estimator default

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,9 +29,14 @@ run-multi start end use-cache="false" prove="false":
   cargo run --bin multi --release -- --start {{start}} --end {{end}} $CACHE_FLAG $PROVE_FLAG
 
 # Runs the cost estimator for a given block range.
-cost-estimator start end:
+# If no range is provided, runs for the last 5 finalized blocks.
+cost-estimator *args='':
   #!/usr/bin/env bash
-  cargo run --bin cost-estimator --release -- --start {{start}} --end {{end}}
+  if [ -z "{{args}}" ]; then
+    cargo run --bin cost-estimator --release
+  else
+    cargo run --bin cost-estimator --release -- {{args}}
+  fi
 
   # Output the data required for the ZKVM execution.
   echo "$L1_HEAD $L2_OUTPUT_ROOT $L2_CLAIM $L2_BLOCK_NUMBER $L2_CHAIN_ID"

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -20,7 +20,7 @@ pub struct HostExecutorArgs {
     #[clap(long)]
     pub rolling: bool,
     /// The number of blocks to use for the default range.
-    #[clap(long, default_value = "100")]
+    #[clap(long, default_value = "5")]
     pub default_range: u64,
     /// The environment file to use.
     #[clap(long, default_value = ".env")]

--- a/utils/host/src/block_range.rs
+++ b/utils/host/src/block_range.rs
@@ -18,22 +18,16 @@ pub async fn get_validated_block_range(
     end: Option<u64>,
     default_range: u64,
 ) -> Result<(u64, u64)> {
-    // If safeDB is activated, get the L2 safe head. If not, use the finalized block.
-    let safe_db_activated = data_fetcher.is_safe_db_activated().await?;
-    let end_number = if safe_db_activated {
-        let header = data_fetcher.get_l1_header(BlockId::latest()).await?;
-        let safe_head_response: SafeHeadResponse = data_fetcher
-            .fetch_rpc_data_with_mode(
-                RPCMode::L2Node,
-                "optimism_safeHeadAtL1Block",
-                vec![format!("0x{:x}", header.number).into()],
-            )
-            .await?;
-        safe_head_response.safe_head.number
-    } else {
-        let header = data_fetcher.get_l2_header(BlockId::finalized()).await?;
-        header.number
-    };
+    // Get the latest finalized block number when end block is not provided.
+    // Even though the safeDB is activated, we use the finalized block number as the
+    // end block by default to ensure the program doesn't run into L2 Block Validation
+    // Failure error.
+    // L2 Block Validation Failure error might still occur. See
+    // [Troubleshooting](../troubleshooting.md#l2-block-validation-failure) for more details.
+    let end_number = data_fetcher
+        .get_l2_header(BlockId::finalized())
+        .await?
+        .number;
 
     // If end block not provided, use latest finalized block
     let l2_end_block = match end {

--- a/utils/host/src/stats.rs
+++ b/utils/host/src/stats.rs
@@ -129,7 +129,7 @@ impl ExecutionStats {
         let total_gas_used: u64 = block_data.iter().map(|b| b.gas_used).sum();
 
         Self {
-            // The "block data" does not include the first block (as it's not executed), so we need to subtract 1 to give the user back the 
+            // The "block data" does not include the first block (as it's not executed), so we need to subtract 1 to give the user back the
             // block corresponding to the blockhash they're proving from.
             batch_start: block_data[0].block_number - 1,
             batch_end: block_data[block_data.len() - 1].block_number,


### PR DESCRIPTION
Enables command to run cost estimator default, which is described in the cost estimator doc.

Includes change to use latest finalized block for end block as default. This is to avoid L2 Block Validation Failure error when
running cost estimator default.