### PR TITLE
feat: update OP_SUCCINCT game type

### DIFF
--- a/contracts/src/OPSuccinctDisputeGame.sol
+++ b/contracts/src/OPSuccinctDisputeGame.sol
@@ -53,9 +53,9 @@ contract OPSuccinctDisputeGame is ISemver, CWIA, IDisputeGame {
     ///      i.e. The game type should indicate the security model.
     /// @return gameType_ The type of proof system being used.
     function gameType() public pure returns (GameType) {
-        // TODO: Once the following PR https://github.com/ethereum-optimism/optimism/pull/13780 is merged,
+        // TODO: Once the a new version of the Optimism contracts is released,
         // update this to return the correct game type: GameTypes.OP_SUCCINCT
-        return GameType.wrap(3);
+        return GameType.wrap(6);
     }
 
     /// @notice Getter for the creator of the dispute game.

--- a/contracts/src/OPSuccinctDisputeGame.sol
+++ b/contracts/src/OPSuccinctDisputeGame.sol
@@ -53,8 +53,9 @@ contract OPSuccinctDisputeGame is ISemver, CWIA, IDisputeGame {
     ///      i.e. The game type should indicate the security model.
     /// @return gameType_ The type of proof system being used.
     function gameType() public pure returns (GameType) {
-        // TODO: Once the a new version of the Optimism contracts is released,
+        // TODO: Once a new version of the Optimism contracts containing the PR below is released,
         // update this to return the correct game type: GameTypes.OP_SUCCINCT
+        // https://github.com/ethereum-optimism/optimism/pull/13780
         return GameType.wrap(6);
     }
 


### PR DESCRIPTION
The PR adding the `OP_SUCCINCT` game type [has been merged in optimism](https://github.com/ethereum-optimism/optimism/pull/13780#event-15982558845), but finally the number is `6`, not `3`