### PR TITLE
fix: update OPSuccinctFaultDisputeGame with nits

### DIFF
--- a/book/fault_proofs/fault_proof_architecture.md
+++ b/book/fault_proofs/fault_proof_architecture.md
@@ -231,6 +231,11 @@ Validates a proof for a proposal:
     - If challenged: prover receives the challenger's bond
     - If unchallenged: no reward but can have fast finality
 
+Proving will revert if:
+- Proof is not submitted before the deadline
+- Proof is not valid
+- If a prover tries to prove a game that has already been proven
+
 ### Resolution
 
 ```solidity
@@ -244,6 +249,8 @@ Resolves the game by:
 - Ensure that the deadline has passed, and if the proposal is `Unchallenged`, then set `DEFENDER_WON`.
 - Ensure that the deadline has passed, and if the proposal is `Challenged`, then set `CHALLENGER_WON`
 - Distributing bonds based on outcome
+    - Distribution result is stored in `mapping(address => uint256) public credit;`.
+    - Actual distribution is done when appropriate recipient calls `claimCredit()`.
     - If parent game is `CHALLENGER_WON`, then the proposer's bond is distributed to the challenger.
       But if there was no challenge for the current game, then the proposer's bond is burned.
 

--- a/book/fault_proofs/fault_proof_architecture.md
+++ b/book/fault_proofs/fault_proof_architecture.md
@@ -231,8 +231,8 @@ Validates a proof for a proposal:
     - If challenged: prover receives the challenger's bond
     - If unchallenged: no reward but can have fast finality
 
-Proving will revert if:
-- Proof is not submitted before the deadline
+Attempting to submit a proof will revert if:
+- Proof is not submitted before the proof deadline
 - Proof is not valid
 - If a prover tries to prove a game that has already been proven
 

--- a/contracts/src/fp/lib/Errors.sol
+++ b/contracts/src/fp/lib/Errors.sol
@@ -16,3 +16,6 @@ error InvalidParentGame();
 
 /// @notice Thrown when the parent game is not resolved.
 error ParentGameNotResolved();
+
+/// @notice Thrown when the claim has already been proven.
+error AlreadyProven();


### PR DESCRIPTION
Updates OPSuccinctFaultDisputeGame for with nits:
- Prevent front-running `prove()`/`resolve()` -> add check for `claimData.prover` to accept the initial proof
- Prevent DOS attack -> switch to pull based reward distribution like [optimism](https://github.com/ethereum-optimism/optimism/blob/d83cefb2cf3d244e29c0391e3adc56534476dc06/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol#L951).
