### PR TITLE
feat(contracts): implement `OPSuccinctPermissionedFaultDisputeGame`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Show Forge version
         working-directory: contracts/

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -23,6 +23,7 @@
   - [Update Contract Parameters](./contracts/update-parameters.md)
   - [Modifications to Original `L2OutputOracle`](./contracts/modifications.md)
 - [Fault Proofs](./fault_proofs/fault_proof_architecture.md)
+  - [Permissioned Game](./fault_proofs/permissioned_game.md)
 - [Experimental](./experimental/intro.md)
   - [OptimismPortalV2](./experimental/optimism-portal-v2.md)
 - [FAQ](./faq.md)

--- a/book/fault_proofs/permissioned_game.md
+++ b/book/fault_proofs/permissioned_game.md
@@ -1,0 +1,48 @@
+# Permissioned Fault Dispute Game
+
+The `OPSuccinctPermissionedFaultDisputeGame` is a specialized child contract of the `OPSuccinctFaultDisputeGame` that implements role-based access control to restrict who can participate in the game. This contract can serve as a fallback in cases where a permissionless system is undesirable or if the existing permissionless system encounters issues.
+
+## Overview
+In a typical fault proof system, multiple entities may freely propose and challenge state roots in order to reach consensus. However, permissionless designs can introduce complexity and costs that some networks might prefer to avoid. By contrast, the `OPSuccinctPermissionedFaultDisputeGame` restricts participation via two new roles: a `Proposer` and a `Challenger`.
+
+Each relevant interaction—including `prove`, `challenge`, and `resolve`—is accessible only to addresses that have been granted one of these roles. Furthermore, the `initialize()` function is exclusively reserved for the `Proposer`.
+
+In the event that you wish to switch back to a permissionless approach, the `RESPECTED_GAME_TYPE` parameter in the `OptimismPortal` can be changed to reference a different dispute game deployment.
+
+## Roles
+This contract introduces two immutable roles:
+
+`Proposer`
+
+- Can create a new `PermissionedFaultDisputeGame` through the factory contract.
+- Can participate in the games they have created (submit proofs, resolve games, etc.).
+- Is stored in the internal immutable variable `PROPOSER`.
+
+`Challenger`
+
+- Can challenge games created by the `Proposer`.
+- Is stored in the internal immutable variable `CHALLENGER`.
+
+These roles are set once in the constructor and cannot be changed afterward.
+
+## Access Control Modifiers
+To enforce the restricted access, each state-mutating function in this contract is overridden and guarded by at least one of the following checks:
+
+- `onlyProposer`: Ensures the caller is the `PROPOSER`.
+- `onlyChallenger`: Ensures the caller is the `CHALLENGER`.
+
+Any call from an address outside of `PROPOSER` or `CHALLENGER` will revert.
+
+Additionally, the `initialize()` function is only callable if `tx.origin` is the `PROPOSER`. This further ensures that no other address can set up or finalize the initial parameters of a newly created game.
+
+## Benefits
+
+- Controlled Environment: Provides a more controlled environment for dispute resolution compared to a fully permissionless system.
+- Cost Management: Limits the number of participants, potentially reducing on-chain costs associated with open participation.
+- Fallback Mechanism: Serves as a backup system if the primary (permissionless) mechanism fails or becomes prohibitively expensive.
+- Simplified Security Model: By limiting who can interact, the attack surface is reduced, improving overall security.
+
+## Limitations
+
+- Centralization: Restricting access to just two addresses introduces a more centralized approach.
+- Immutable Roles: Once set, the roles cannot be changed, so mistakes in deployment or role assignment are permanent. Need to redeploy the contract to change the roles.

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -188,7 +188,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver {
 
     /// @notice Initializes the contract.
     /// @dev This function may only be called once.
-    function initialize() external payable virtual {
+    function initialize() public payable virtual {
         // SAFETY: Any revert in this function will bubble up to the DisputeGameFactory and
         // prevent the game from being created.
         //
@@ -293,7 +293,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver {
     ////////////////////////////////////////////////////////////////
 
     /// @notice Challenges the game.
-    function challenge() external payable returns (ProposalStatus) {
+    function challenge() public payable virtual returns (ProposalStatus) {
         // INVARIANT: Can only challenge a game that has not been challenged yet.
         if (claimData.status != ProposalStatus.Unchallenged) revert ClaimAlreadyChallenged();
 
@@ -319,7 +319,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver {
 
     /// @notice Proves the game.
     /// @param proofBytes The proof bytes to validate the claim.
-    function prove(bytes calldata proofBytes) external returns (ProposalStatus) {
+    function prove(bytes calldata proofBytes) public virtual returns (ProposalStatus) {
         // INVARIANT: Cannot prove a game if the clock has timed out.
         if (uint64(block.timestamp) > claimData.deadline.raw()) revert ClockTimeExceeded();
 
@@ -358,7 +358,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver {
     ///         or there is a challenge but the prover has provided a valid proof within the `MAX_PROVE_DURATION`.
     ///         `CHALLENGER_WINS` when the proposer's claim has been challenged, but the proposer has not proven
     ///         its claim within the `MAX_PROVE_DURATION`.
-    function resolve() external returns (GameStatus) {
+    function resolve() public virtual returns (GameStatus) {
         // INVARIANT: Resolution cannot occur unless the game has already been resolved.
         if (status != GameStatus.IN_PROGRESS) revert ClaimAlreadyResolved();
 

--- a/contracts/src/fp/OPSuccinctPermissionedFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctPermissionedFaultDisputeGame.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+
+// Contracts
+import {OPSuccinctFaultDisputeGame} from "src/fp/OPSuccinctFaultDisputeGame.sol";
+
+// Libraries
+import {Duration, GameStatus} from "src/dispute/lib/Types.sol";
+import {BadAuth} from "src/dispute/lib/Errors.sol";
+
+// Interfaces
+import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
+import {IDisputeGameFactory} from "src/dispute/interfaces/IDisputeGameFactory.sol";
+
+/// @title OPSuccinctPermissionedFaultDisputeGame
+/// @notice OPSuccinctPermissionedFaultDisputeGame is a contract that inherits from `OPSuccinctFaultDisputeGame`, and contains two roles:
+///         - The `challenger` role, which is allowed to challenge a game.
+///         - The `proposer` role, which is allowed to create proposals and participate in their game.
+///         This contract exists as a way for networks to support the fault proof iteration of the OptimismPortal
+///         contract without needing to support a fully permissionless system. Permissionless systems can introduce
+///         costs that certain networks may not wish to support. This contract can also be used as a fallback mechanism
+///         in case of a failure in the permissionless fault proof system in the stage one release.
+contract OPSuccinctPermissionedFaultDisputeGame is OPSuccinctFaultDisputeGame {
+    /// @notice An address that is allowed to challenge games.
+    address internal immutable CHALLENGER;
+    /// @notice An address that is allowed to propose games.
+    address internal immutable PROPOSER;
+
+    modifier onlyChallenger() {
+        if (msg.sender != CHALLENGER) {
+            revert BadAuth();
+        }
+        _;
+    }
+
+    modifier onlyProposer() {
+        if (msg.sender != PROPOSER) {
+            revert BadAuth();
+        }
+        _;
+    }
+
+    /// @param _maxChallengeDuration The maximum duration allowed for a challenger to challenge a game.
+    /// @param _maxProveDuration The maximum duration allowed for a proposer to prove against a challenge.
+    /// @param _disputeGameFactory The factory that creates the dispute games.
+    /// @param _sp1Verifier The address of the SP1 verifier that verifies the proof for the aggregation program.
+    /// @param _rollupConfigHash The rollup config hash for the L2 network.
+    /// @param _aggregationVkey The vkey for the aggregation program.
+    /// @param _rangeVkeyCommitment The commitment to the range vkey.
+    /// @param _genesisL2BlockNumber The L2 block number of the genesis block.
+    /// @param _genesisL2OutputRoot The L2 output root of the genesis block.
+    /// @param _proofReward The proof reward for the game.
+    /// @param _challenger An address that is allowed to challenge games.
+    /// @param _proposer An address that is allowed to propose games.
+    constructor(
+        Duration _maxChallengeDuration,
+        Duration _maxProveDuration,
+        IDisputeGameFactory _disputeGameFactory,
+        ISP1Verifier _sp1Verifier,
+        bytes32 _rollupConfigHash,
+        bytes32 _aggregationVkey,
+        bytes32 _rangeVkeyCommitment,
+        uint256 _genesisL2BlockNumber,
+        bytes32 _genesisL2OutputRoot,
+        uint256 _proofReward,
+        address _challenger,
+        address _proposer
+    )
+        OPSuccinctFaultDisputeGame(
+            _maxChallengeDuration,
+            _maxProveDuration,
+            _disputeGameFactory,
+            _sp1Verifier,
+            _rollupConfigHash,
+            _aggregationVkey,
+            _rangeVkeyCommitment,
+            _genesisL2BlockNumber,
+            _genesisL2OutputRoot,
+            _proofReward
+        )
+    {
+        CHALLENGER = _challenger;
+        PROPOSER = _proposer;
+    }
+
+    /// @inheritdoc OPSuccinctFaultDisputeGame
+    function initialize() public payable override {
+        if (tx.origin != PROPOSER) revert BadAuth();
+        super.initialize();
+    }
+
+    /// @inheritdoc OPSuccinctFaultDisputeGame
+    function challenge() public payable override onlyChallenger returns (ProposalStatus) {
+        return super.challenge();
+    }
+
+    /// @inheritdoc OPSuccinctFaultDisputeGame
+    function prove(bytes calldata proofBytes) public override onlyProposer returns (ProposalStatus) {
+        return super.prove(proofBytes);
+    }
+
+    /// @inheritdoc OPSuccinctFaultDisputeGame
+    function resolve() public override onlyProposer onlyChallenger returns (GameStatus) {
+        return super.resolve();
+    }
+}

--- a/contracts/test/fp/OPSuccinctPermissionedFaultDisputeGame.t.sol
+++ b/contracts/test/fp/OPSuccinctPermissionedFaultDisputeGame.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Testing
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+// Libraries
+import {Claim, Duration, GameStatus, GameType} from "src/dispute/lib/Types.sol";
+import {BadAuth} from "src/dispute/lib/Errors.sol";
+
+// Contracts
+import {DisputeGameFactory} from "src/dispute/DisputeGameFactory.sol";
+import {OPSuccinctPermissionedFaultDisputeGame} from "src/fp/OPSuccinctPermissionedFaultDisputeGame.sol";
+import {SP1MockVerifier} from "@sp1-contracts/src/SP1MockVerifier.sol";
+
+// Interfaces
+import {IDisputeGame} from "src/dispute/interfaces/IDisputeGame.sol";
+import {IDisputeGameFactory} from "src/dispute/interfaces/IDisputeGameFactory.sol";
+import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
+
+contract OPSuccinctPermissionedFaultDisputeGameTest is Test {
+    DisputeGameFactory factory;
+    ERC1967Proxy factoryProxy;
+
+    OPSuccinctPermissionedFaultDisputeGame gameImpl;
+    OPSuccinctPermissionedFaultDisputeGame game;
+
+    address proposer = address(0x123);
+    address challenger = address(0x456);
+    address unauthorized_address = address(0x789);
+
+    // Fixed parameters
+    GameType gameType = GameType.wrap(42);
+    Duration maxChallengeDuration = Duration.wrap(12 hours);
+    Duration maxProveDuration = Duration.wrap(3 days);
+    Claim rootClaim = Claim.wrap(keccak256("rootClaim"));
+
+    function setUp() public {
+        // Deploy the implementation contract for DisputeGameFactory
+        DisputeGameFactory factoryImpl = new DisputeGameFactory();
+
+        // Deploy a proxy pointing to the factory implementation
+        factoryProxy = new ERC1967Proxy(
+            address(factoryImpl), abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
+        );
+
+        // Cast the proxy to the factory contract
+        factory = DisputeGameFactory(address(factoryProxy));
+
+        // Create a mock verifier
+        SP1MockVerifier sp1Verifier = new SP1MockVerifier();
+
+        // Parameters for the OPSuccinctFaultDisputeGame
+        bytes32 rollupConfigHash = bytes32(0);
+        bytes32 aggregationVkey = bytes32(0);
+        bytes32 rangeVkeyCommitment = bytes32(0);
+        uint256 genesisL2BlockNumber = 0;
+        bytes32 genesisL2OutputRoot = keccak256("genesis");
+        uint256 proofReward = 1 ether;
+
+        // Deploy the reference implementation of OPSuccinctPermissionedFaultDisputeGame
+        gameImpl = new OPSuccinctPermissionedFaultDisputeGame(
+            maxChallengeDuration,
+            maxProveDuration,
+            IDisputeGameFactory(address(factory)),
+            ISP1Verifier(address(sp1Verifier)),
+            rollupConfigHash,
+            aggregationVkey,
+            rangeVkeyCommitment,
+            genesisL2BlockNumber,
+            genesisL2OutputRoot,
+            proofReward,
+            challenger,
+            proposer
+        );
+
+        // Set the init bond on the factory for our specific GameType
+        factory.setInitBond(gameType, 1 ether);
+
+        // Register our reference implementation under the specified gameType
+        factory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
+
+        vm.startPrank(proposer, proposer); // The second argument sets tx.origin to the proposer
+        vm.deal(proposer, 1 ether); // extra funds for testing
+        game = OPSuccinctPermissionedFaultDisputeGame(
+            address(
+                factory.create{value: 1 ether}(
+                    gameType,
+                    rootClaim,
+                    // encode l2BlockNumber = 1000, parentIndex = uint32.max
+                    abi.encodePacked(uint256(1000), type(uint32).max)
+                )
+            )
+        );
+
+        vm.stopPrank();
+    }
+
+    // =========================================
+    // Test: Only proposer can propose (testing initialize)
+    // =========================================
+    function testOnlyProposerCanPropose() public {
+        vm.startPrank(challenger);
+        vm.deal(challenger, 1 ether);
+        vm.expectRevert(BadAuth.selector);
+        game = OPSuccinctPermissionedFaultDisputeGame(
+            address(
+                factory.create{value: 1 ether}(
+                    gameType,
+                    rootClaim,
+                    // encode l2BlockNumber = 1000, parentIndex = uint32.max
+                    abi.encodePacked(uint256(1000), type(uint32).max)
+                )
+            )
+        );
+    }
+
+    // =========================================
+    // Test: Only challenger can challenge
+    // =========================================
+    function testOnlyChallengerCanChallenge() public {
+        vm.startPrank(proposer);
+        vm.deal(proposer, 1 ether);
+        vm.expectRevert(BadAuth.selector);
+        game.challenge{value: 1 ether}();
+        vm.stopPrank();
+    }
+
+    // =========================================
+    // Test: Only proposer can prove
+    // =========================================
+    function testOnlyProposerCanProve() public {
+        vm.startPrank(challenger);
+        vm.deal(challenger, 1 ether);
+        vm.expectRevert(BadAuth.selector);
+        game.prove(bytes(""));
+        vm.stopPrank();
+    }
+
+    // =========================================
+    // Test: Only proposer and challenger can resolve
+    // =========================================
+    function testOnlyProposerAndChallengerCanResolve() public {
+        vm.startPrank(unauthorized_address);
+        vm.expectRevert(BadAuth.selector);
+        game.resolve();
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
The `OPSuccinctPermissionedFaultDisputeGame` is a specialized child contract of the `OPSuccinctFaultDisputeGame` that implements role-based access control to restrict who can participate in the game. This contract can serve as a fallback in cases where a permissionless system is undesirable or if the existing permissionless system encounters issues.

# Overview
In a typical fault proof system, multiple entities may freely propose and challenge state roots in order to reach consensus. However, permissionless designs can introduce complexity and costs that some networks might prefer to avoid. By contrast, the `OPSuccinctPermissionedFaultDisputeGame` restricts participation via two new roles: a Proposer and a Challenger.

Each relevant interaction—including prove, challenge, resolve—is accessible only to addresses that have been granted one of these roles. Furthermore, the initialize() function is exclusively reserved for the Proposer.

In the event that you wish to switch back to a permissionless approach, the `RESPECTED_GAME_TYPE` parameter in the `OptimismPortal` can be changed to switch back.

# Optimism's implementation
See [PermissionedDisputeGame.sol](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol)