### PR TITLE
chore: remove maili-registry from dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,9 @@ alloy-rpc-types-engine = { version = "0.11.0", default-features = false }
 alloy-rpc-types-beacon = { version = "0.11.0", default-features = false }
 
 # Keccak with the SHA3 patch is more efficient than the default Keccak.
-alloy-primitives = { version = "0.8.19", default-features = false, features = ["sha3-keccak"] }
+alloy-primitives = { version = "0.8.19", default-features = false, features = [
+    "sha3-keccak",
+] }
 alloy-sol-types = { version = "0.8.19", default-features = false }
 
 # OP Alloy
@@ -96,9 +98,10 @@ op-alloy-network = { version = "0.10.0", default-features = false }
 
 # Maili
 maili-consensus = { version = "0.1.6", default-features = false }
-maili-rpc = { version = "0.2.0", default-features = false, features = ["serde"] }
+maili-rpc = { version = "0.2.0", default-features = false, features = [
+    "serde",
+] }
 maili-protocol = { version = "0.2.0", default-features = false }
-maili-registry = { version = "0.2.0", default-features = false }
 maili-genesis = { version = "0.2.0", default-features = false }
 
 # Revm


### PR DESCRIPTION
In #375, I tried to fix ELF workflow by removing pre-release-hook which doesn't reason well why it breaks reproducible ELFs. I found build.rs which seems a huge sus in maili-registry. This PR tries to fix the ELF workflow by removing unnecessary dep.