### PR TITLE
chore: remove bls patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8024,8 +8024,3 @@ dependencies = [
  "sha3",
  "subtle",
 ]
-
-[[patch.unused]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-4.0.0#36b2a9d68b40dd08d2b0ac2843769a6a16608c91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,4 +124,3 @@ substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-s
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-4.0.0", features = ["groups"] }

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -79,9 +79,9 @@ async fn update_l2oo_config() -> Result<()> {
 
     // Set the verifier address
     let verifier = env::var("VERIFIER_ADDRESS").unwrap_or_else(|_| {
-        // Default to Groth16 VerifierGateway contract address
-        // Source: https://docs.succinct.xyz/docs/verification/onchain/contract-addresses
-        "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B".to_string()
+        // Default to PLONK VerifierGateway contract address
+        // Source: https://docs.succinct.xyz/docs/sp1/verification/onchain/contract-addresses
+        "0x3B6041173B80E77f038f3F2C0f9744f04837185e".to_string()
     });
 
     let starting_block_number = match env::var("STARTING_BLOCK_NUMBER") {

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -79,9 +79,9 @@ async fn update_l2oo_config() -> Result<()> {
 
     // Set the verifier address
     let verifier = env::var("VERIFIER_ADDRESS").unwrap_or_else(|_| {
-        // Default to PLONK VerifierGateway contract address
-        // Source: https://docs.succinct.xyz/docs/sp1/verification/onchain/contract-addresses
-        "0x3B6041173B80E77f038f3F2C0f9744f04837185e".to_string()
+        // Default to Groth16 VerifierGateway contract address
+        // Source: https://docs.succinct.xyz/docs/verification/onchain/contract-addresses
+        "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B".to_string()
     });
 
     let starting_block_number = match env::var("STARTING_BLOCK_NUMBER") {


### PR DESCRIPTION
The BLS patch is unused and can be safely removed.