### PR TITLE
chore(server): `Arc` shared state

### DIFF
--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -33,6 +33,7 @@ use sp1_sdk::{
 use std::{
     env, fs,
     str::FromStr,
+    sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 use tower_http::limit::RequestBodyLimitLayer;
@@ -50,9 +51,10 @@ async fn main() -> Result<()> {
 
     dotenv::dotenv().ok();
 
-    let prover = ProverClient::builder().cpu().build();
-    let (range_pk, range_vk) = prover.setup(RANGE_ELF);
-    let (agg_pk, agg_vk) = prover.setup(AGG_ELF);
+    let network_prover = Arc::new(ProverClient::builder().network().build());
+
+    let (range_pk, range_vk) = network_prover.setup(RANGE_ELF);
+    let (agg_pk, agg_vk) = network_prover.setup(AGG_ELF);
     let multi_block_vkey_u8 = u32_to_u8(range_vk.vk.hash_u32());
     let range_vkey_commitment = B256::from(multi_block_vkey_u8);
     let agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
@@ -84,13 +86,14 @@ async fn main() -> Result<()> {
         agg_vkey_hash,
         range_vkey_commitment,
         rollup_config_hash,
-        range_vk,
-        range_pk,
-        agg_vk,
-        agg_pk,
+        range_vk: Arc::new(range_vk),
+        range_pk: Arc::new(range_pk),
+        agg_vk: Arc::new(agg_vk),
+        agg_pk: Arc::new(agg_pk),
         range_proof_strategy,
         agg_proof_strategy,
         agg_proof_mode,
+        network_prover,
     };
 
     let app = Router::new()
@@ -189,8 +192,8 @@ async fn request_span_proof(
         }
     };
 
-    let client = ProverClient::builder().network().build();
-    let proof_id = client
+    let proof_id = state
+        .network_prover
         .prove(&state.range_pk, &sp1_stdin)
         .compressed()
         .strategy(state.range_proof_strategy)
@@ -288,8 +291,6 @@ async fn request_agg_proof(
         }
     };
 
-    let prover = ProverClient::builder().network().build();
-
     let stdin =
         match get_agg_proof_stdin(proofs, boot_infos, headers, &state.range_vk, l1_head.into()) {
             Ok(s) => s,
@@ -302,7 +303,8 @@ async fn request_agg_proof(
             }
         };
 
-    let proof_id = match prover
+    let proof_id = match state
+        .network_prover
         .prove(&state.agg_pk, &stdin)
         .mode(state.agg_proof_mode)
         .strategy(state.agg_proof_strategy)
@@ -367,8 +369,11 @@ async fn request_mock_span_proof(
     };
 
     let start_time = Instant::now();
-    let prover = ProverClient::builder().cpu().build();
-    let (pv, report) = prover.execute(RANGE_ELF, &sp1_stdin).run().unwrap();
+    let (pv, report) = state
+        .network_prover
+        .execute(RANGE_ELF, &sp1_stdin)
+        .run()
+        .unwrap();
     let execution_duration = start_time.elapsed();
 
     let block_data = fetcher
@@ -473,8 +478,6 @@ async fn request_mock_agg_proof(
         }
     };
 
-    let prover = ProverClient::builder().mock().build();
-
     let stdin =
         match get_agg_proof_stdin(proofs, boot_infos, headers, &state.range_vk, l1_head.into()) {
             Ok(s) => s,
@@ -484,6 +487,7 @@ async fn request_mock_agg_proof(
             }
         };
 
+    let prover = ProverClient::builder().mock().build();
     let proof = match prover
         .prove(&state.agg_pk, &stdin)
         .mode(state.agg_proof_mode)
@@ -509,16 +513,16 @@ async fn request_mock_agg_proof(
 
 /// Get the status of a proof.
 async fn get_proof_status(
+    State(state): State<SuccinctProposerConfig>,
     Path(proof_id): Path<String>,
 ) -> Result<(StatusCode, Json<ProofStatus>), AppError> {
     info!("Received proof status request: {:?}", proof_id);
 
-    let client = ProverClient::builder().network().build();
-
     let proof_id_bytes = hex::decode(proof_id)?;
 
     // This request will time out if the server is down.
-    let (status, maybe_proof) = match client
+    let (status, maybe_proof) = match state
+        .network_prover
         .get_proof_status(B256::from_slice(&proof_id_bytes))
         .await
     {

--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<()> {
     dotenv::dotenv().ok();
 
     let network_prover = Arc::new(ProverClient::builder().network().build());
-
     let (range_pk, range_vk) = network_prover.setup(RANGE_ELF);
     let (agg_pk, agg_vk) = network_prover.setup(AGG_ELF);
     let multi_block_vkey_u8 = u32_to_u8(range_vk.vk.hash_u32());

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use alloy_primitives::B256;
 use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -7,6 +5,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use sp1_sdk::{
     network::FulfillmentStrategy, NetworkProver, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey,
 };
+use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidateConfigRequest {

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -4,7 +4,9 @@ use alloy_primitives::B256;
 use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use sp1_sdk::{network::FulfillmentStrategy, NetworkProver, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey};
+use sp1_sdk::{
+    network::FulfillmentStrategy, NetworkProver, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidateConfigRequest {

--- a/proposer/succinct/src/lib.rs
+++ b/proposer/succinct/src/lib.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use alloy_primitives::B256;
 use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use sp1_sdk::{network::FulfillmentStrategy, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey};
+use sp1_sdk::{network::FulfillmentStrategy, NetworkProver, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidateConfigRequest {
@@ -76,16 +78,17 @@ pub struct ProofStatus {
 /// to the contract's configuration.
 #[derive(Clone)]
 pub struct SuccinctProposerConfig {
-    pub range_vk: SP1VerifyingKey,
-    pub range_pk: SP1ProvingKey,
-    pub agg_pk: SP1ProvingKey,
-    pub agg_vk: SP1VerifyingKey,
+    pub range_vk: Arc<SP1VerifyingKey>,
+    pub range_pk: Arc<SP1ProvingKey>,
+    pub agg_pk: Arc<SP1ProvingKey>,
+    pub agg_vk: Arc<SP1VerifyingKey>,
     pub agg_vkey_hash: B256,
     pub range_vkey_commitment: B256,
     pub rollup_config_hash: B256,
     pub range_proof_strategy: FulfillmentStrategy,
     pub agg_proof_strategy: FulfillmentStrategy,
     pub agg_proof_mode: SP1ProofMode,
+    pub network_prover: Arc<NetworkProver>,
 }
 
 /// Deserialize a vector of base64 strings into a vector of vectors of bytes. Go serializes


### PR DESCRIPTION
Previously, the memory usage in the `server` would balloon because the proving keys were cloned every time a new concurrent request was made.

We can instead wrap the `ProvingKey`, `VerificationKey` and `ProverClient` in an `Arc`, which keeps the memory usage low.

`with_state` requires that the `State` is `S: Clone + Send + Sync + 'static`.