### PR TITLE
chore: Switch to `OPSuccinctHost`

### DIFF
--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -158,8 +158,8 @@ async fn request_span_proof(
         }
     };
 
-    let host_cli = match fetcher
-        .get_host_cli_args(
+    let host_args = match fetcher
+        .get_host_args(
             payload.start,
             payload.end,
             ProgramType::Multi,
@@ -177,7 +177,7 @@ async fn request_span_proof(
         }
     };
 
-    let mem_kv_store = start_server_and_native_client(host_cli).await?;
+    let mem_kv_store = start_server_and_native_client(host_args).await?;
 
     let sp1_stdin = match get_proof_stdin(mem_kv_store) {
         Ok(stdin) => stdin,
@@ -338,8 +338,8 @@ async fn request_mock_span_proof(
         }
     };
 
-    let host_cli = match fetcher
-        .get_host_cli_args(
+    let host_args = match fetcher
+        .get_host_args(
             payload.start,
             payload.end,
             ProgramType::Multi,
@@ -355,7 +355,7 @@ async fn request_mock_span_proof(
     };
 
     let start_time = Instant::now();
-    let oracle = start_server_and_native_client(host_cli.clone()).await?;
+    let oracle = start_server_and_native_client(host_args.clone()).await?;
     let witness_generation_duration = start_time.elapsed();
 
     let sp1_stdin = match get_proof_stdin(oracle) {
@@ -377,7 +377,7 @@ async fn request_mock_span_proof(
         .get_l2_block_data_range(payload.start, payload.end)
         .await?;
 
-    let l1_head = host_cli.l1_head;
+    let l1_head = host_args.kona_args.l1_head;
     // Get the L1 block number from the L1 head.
     let l1_block_number = fetcher.get_l1_header(l1_head.into()).await?.number;
     let stats = ExecutionStats::new(

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -32,12 +32,12 @@ async fn main() -> Result<()> {
     let (l2_start_block, l2_end_block) =
         get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?;
 
-    let host_cli = data_fetcher
-        .get_host_cli_args(l2_start_block, l2_end_block, ProgramType::Multi, cache_mode)
+    let host_args = data_fetcher
+        .get_host_args(l2_start_block, l2_end_block, ProgramType::Multi, cache_mode)
         .await?;
 
     let start_time = Instant::now();
-    let oracle = start_server_and_native_client(host_cli.clone()).await?;
+    let oracle = start_server_and_native_client(host_args.clone()).await?;
     let witness_generation_duration = start_time.elapsed();
 
     // Get the stdin for the block.
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
             execute_multi(&data_fetcher, sp1_stdin, l2_start_block, l2_end_block).await?;
 
         let l1_block_number = data_fetcher
-            .get_l1_header(host_cli.l1_head.into())
+            .get_l1_header(host_args.l1_head.into())
             .await
             .unwrap()
             .number;

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -21,8 +21,8 @@ async fn execute_batch() -> Result<()> {
     let (l2_start_block, l2_end_block) =
         get_rolling_block_range(&data_fetcher, ONE_HOUR, DEFAULT_RANGE).await?;
 
-    let host_cli = data_fetcher
-        .get_host_cli_args(
+    let host_args = data_fetcher
+        .get_host_args(
             l2_start_block,
             l2_end_block,
             ProgramType::Multi,
@@ -30,7 +30,7 @@ async fn execute_batch() -> Result<()> {
         )
         .await?;
 
-    let oracle = start_server_and_native_client(host_cli.clone()).await?;
+    let oracle = start_server_and_native_client(host_args.clone()).await?;
 
     // Get the stdin for the block.
     let sp1_stdin = get_proof_stdin(oracle)?;
@@ -39,7 +39,7 @@ async fn execute_batch() -> Result<()> {
         execute_multi(&data_fetcher, sp1_stdin, l2_start_block, l2_end_block).await?;
 
     let l1_block_number = data_fetcher
-        .get_l1_header(host_cli.l1_head.into())
+        .get_l1_header(host_args.l1_head.into())
         .await
         .unwrap()
         .number;

--- a/scripts/utils/bin/gen_sp1_test_artifacts.rs
+++ b/scripts/utils/bin/gen_sp1_test_artifacts.rs
@@ -43,10 +43,10 @@ async fn main() -> Result<()> {
     };
 
     // Get the host CLIs in order, in parallel.
-    let host_clis = futures::stream::iter(split_ranges.iter())
+    let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
             data_fetcher
-                .get_host_cli_args(range.start, range.end, ProgramType::Multi, cache_mode)
+                .get_host_args(range.start, range.end, ProgramType::Multi, cache_mode)
                 .await
                 .expect("Failed to get host CLI args")
         })
@@ -55,8 +55,8 @@ async fn main() -> Result<()> {
         .await;
 
     let mut successful_ranges = Vec::new();
-    for (range, host_cli) in split_ranges.iter().zip(host_clis.iter()) {
-        let oracle = start_server_and_native_client(host_cli.clone())
+    for (range, host_args) in split_ranges.iter().zip(host_args.iter()) {
+        let oracle = start_server_and_native_client(host_args.clone())
             .await
             .unwrap();
         let sp1_stdin = get_proof_stdin(oracle).unwrap();

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -47,6 +47,7 @@ sol! {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct OPSuccinctHost {
     pub kona_args: SingleChainHost,
 }
@@ -95,12 +96,10 @@ pub fn get_agg_proof_stdin(
 
 /// Start the server and native client. Each server is tied to a single client.
 pub async fn start_server_and_native_client(
-    cfg: SingleChainHost,
+    cfg: OPSuccinctHost,
 ) -> Result<InMemoryOracle, anyhow::Error> {
-    let host = OPSuccinctHost { kona_args: cfg };
-
     info!("Starting preimage server and client program.");
-    let in_memory_oracle = host.run().await?;
+    let in_memory_oracle = cfg.run().await?;
 
     Ok(in_memory_oracle)
 }


### PR DESCRIPTION
Use `OPSuccinctHost` instead of `SingleChainHost` across the repository to allow for the integration of https://github.com/succinctlabs/op-succinct/pull/388 more easily.