### PR TITLE
chore: fix contract verification

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -18,7 +18,8 @@ remappings = [
     "src/libraries/=lib/optimism/packages/contracts-bedrock/src/libraries/",
     "src/L1/=lib/optimism/packages/contracts-bedrock/src/L1/",
     "src/L2/=lib/optimism/packages/contracts-bedrock/src/L2/",
-    "src/dispute/=lib/optimism/packages/contracts-bedrock/src/dispute/"
+    "src/dispute/=lib/optimism/packages/contracts-bedrock/src/dispute/",
+    "src/universal/=lib/optimism/packages/contracts-bedrock/src/universal/",
 ]
 
 # Enable read-write access to opsuccinctl2ooconfig.json


### PR DESCRIPTION
Fixes contract verification error for `DisputeGameFactory`.

When running `just deploy-dispute-game-factory` below verification error occurred. This was due to missing change from #378, which needs `src/universal` remapping added.

```
Fail - Unable to verify. Solidity Compilation Error: Source "src/universal/interfaces/ISemver.sol" not found: File not found.
```