### PR TITLE
chore(ci): docker tag

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -37,6 +37,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
@@ -49,6 +50,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha


### PR DESCRIPTION
If the tag does not follow semver formatting (e.g. `1.0.0` or `v1.0.0`), the Docker image will not be tagged with the tag.

The following change will tag the image (e.g. `op-succinct-v1.2.0`).