### PR TITLE
fix: debug_chainConfig don't return terminalTotalDifficultyPassed

### DIFF
--- a/utils/host/src/rollup_config.rs
+++ b/utils/host/src/rollup_config.rs
@@ -61,6 +61,7 @@ pub(crate) struct ChainConfig {
     ecotone_time: u64,
     fjord_time: u64,
     terminal_total_difficulty: u64,
+    #[serde(default)]
     terminal_total_difficulty_passed: bool,
     optimism: OptimismConfig,
 }


### PR DESCRIPTION
For some reason, during my test on Kurtosis Optimism package, the json returned by `debug_chainConfig` didn't contains the `terminalTotalDifficultyPassed` field.