### PR TITLE
fix(script): `upgrade-oracle` justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,12 +149,12 @@ upgrade-oracle env_file=".env":
     if [ -n "${DEPLOY_PK:-}" ]; then ENV_VARS="$ENV_VARS DEPLOY_PK=$DEPLOY_PK"; fi
     
     if [ "${EXECUTE_UPGRADE_CALL:-true}" = "false" ]; then
-        $ENV_VARS forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
+        env $ENV_VARS forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
             --rpc-url $L1_RPC \
             --private-key $PRIVATE_KEY \
             --etherscan-api-key $ETHERSCAN_API_KEY
     else
-        $ENV_VARS forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
+        env $ENV_VARS forge script script/OPSuccinctUpgrader.s.sol:OPSuccinctUpgrader \
             --rpc-url $L1_RPC \
             --private-key $PRIVATE_KEY \
             --verify \


### PR DESCRIPTION
Without `env`, multiple environment variables separated by spaces would cause `L2OO_ADDRESS=0x...` to attempt to be executed as a command. This would cause the entire `upgrade-oracle` command to fail.