### PR TITLE
fix: oracle upgrader can update from 0x0

### DIFF
--- a/contracts/script/validity/OPSuccinctUpgrader.s.sol
+++ b/contracts/script/validity/OPSuccinctUpgrader.s.sol
@@ -31,6 +31,7 @@ contract OPSuccinctUpgrader is Script, Utils {
         if (OPSuccinctL2OutputOracleImpl == address(0)) {
             console.log("Deploying new OPSuccinctL2OutputOracle impl");
             OPSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle());
+            cfg.opSuccinctL2OutputOracleImpl = OPSuccinctL2OutputOracleImpl;
         }
 
         vm.stopBroadcast();


### PR DESCRIPTION
If the implementation address is 0, the oracle upgrade script does not actually use the newly-deployed implementation.