### PR TITLE
fix: various tweaks of the succinct fdg

### DIFF
--- a/book/fault_proofs/challenger.md
+++ b/book/fault_proofs/challenger.md
@@ -11,7 +11,7 @@ Before running the challenger, ensure you have:
 3. The DisputeGameFactory contract deployed (See [Deploy](./deploy.md))
 4. Sufficient ETH balance for:
    - Transaction fees
-   - Challenge bonds (proof rewards)
+   - Challenger bonds (proof rewards)
 5. Required environment variables properly configured (See [Configuration](#configuration))
 
 ## Overview

--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -119,14 +119,16 @@ cargo run --bin vkey --release
    forge script script/fp/DeployOPSuccinctFDG.s.sol --broadcast --rpc-url <RPC_URL> --private-key <PRIVATE_KEY>
    ```
 
-## Contract Parameters
+## Optional Environment Variables
 
 The deployment script deploys the contract with the following parameters:
 
-- **Initial Bond**: 0.01 ETH by default (configurable via `INITIAL_BOND` in wei, so 10000000000000000 wei for 0.01 ETH).
-- **Proof Reward**: 0.01 ETH by default (configurable via `PROOF_REWARD` in wei, so 10000000000000000 wei for 0.01 ETH).
-- **Starting Anchor Root**: Genesis configuration with block number 0.
-- **Access Control**: Permissionless (address(0) can propose and challenge).
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `INITIAL_BOND` | Initial bond for the game. | 1000000000000000 (for 0.001 ETH) |
+| `CHALLENGER_BOND` | Challenger bond for the game. | 1000000000000000 (for 0.001 ETH) |
+
+These values highly depend on the economic model of the L2 chain. For example, `CHALLENGER_BOND` can be set to 10x of the proving cost needed to prove a game, to prevent frivolous challenges.
 
 ## Post-Deployment
 
@@ -134,7 +136,7 @@ After deployment, the script will output the addresses of:
 - Factory Proxy.
 - Game Implementation.
 - SP1 Verifier.
-- Portal2.
+- OptimismPortal2.
 - Anchor State Registry.
 - Access Manager.
 

--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -125,8 +125,8 @@ The deployment script deploys the contract with the following parameters:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `INITIAL_BOND_IN_WEI` | Initial bond for the game. | 1000000000000000 (for 0.001 ETH) |
-| `CHALLENGER_BOND_IN_WEI` | Challenger bond for the game. | 1000000000000000 (for 0.001 ETH) |
+| `INITIAL_BOND_WEI` | Initial bond for the game. | 1_000_000_000_000_000 (for 0.001 ETH) |
+| `CHALLENGER_BOND_WEI` | Challenger bond for the game. | 1_000_000_000_000_000 (for 0.001 ETH) |
 
 Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 

--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -125,8 +125,10 @@ The deployment script deploys the contract with the following parameters:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `INITIAL_BOND` | Initial bond for the game. | 1000000000000000 (for 0.001 ETH) |
-| `CHALLENGER_BOND` | Challenger bond for the game. | 1000000000000000 (for 0.001 ETH) |
+| `INITIAL_BOND_IN_WEI` | Initial bond for the game. | 1000000000000000 (for 0.001 ETH) |
+| `CHALLENGER_BOND_IN_WEI` | Challenger bond for the game. | 1000000000000000 (for 0.001 ETH) |
+
+Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 
 These values highly depend on the economic model of the L2 chain. For example, `CHALLENGER_BOND` can be set to 10x of the proving cost needed to prove a game, to prevent frivolous challenges.
 

--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -130,7 +130,7 @@ The deployment script deploys the contract with the following parameters:
 
 Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 
-These values highly depend on the economic model of the L2 chain. For example, `CHALLENGER_BOND` can be set to 10x of the proving cost needed to prove a game, to prevent frivolous challenges.
+These values depend on the L2 chain, and the total value secured. Generally, to prevent frivolous challenges, `CHALLENGER_BOND` should be set to at least 10x of the proving cost needed to prove a game.
 
 ## Post-Deployment
 

--- a/book/fault_proofs/fault_proof_architecture.md
+++ b/book/fault_proofs/fault_proof_architecture.md
@@ -84,7 +84,7 @@ In this example, Proposal 3A would always resolve to `CHALLENGER_WINS`, as its p
 - `ROLLUP_CONFIG_HASH`: Hash of the chain's rollup configuration
 - `AGGREGATION_VKEY`: The verification key for the aggregation SP1 program.
 - `RANGE_VKEY_COMMITMENT`: The commitment to the BabyBear representation of the verification key of the range SP1 program.
-- `PROOF_REWARD`: Amount of ETH required to submit a challenge (the reward given to a proof generator).
+- `CHALLENGER_BOND`: Amount of ETH required to submit a challenge (given to prover if they provide a valid proof).
 - `ANCHOR_STATE_REGISTRY`: The anchor state registry contract.
 - `ACCESS_MANAGER`: The access manager contract.
 
@@ -196,15 +196,14 @@ function challenge() external payable returns (ProposalStatus)
 
 Allows participants to challenge a proposal by:
 
-- Depositing the proof reward (the challenge bond)
+- Depositing the challenger bond (the proof reward)
 - Setting the proposal deadline to be `+ provingTime` over the current timestamp
 - Updating proposal state to `ProposalStatus.Challenged`
 
 Attempting to challenge a game will revert if:
-- Game is already challenged, proven or resolved
-- Deadline has already passed
+- Game is over (past deadline or already proven)
 - Challenger is not whitelisted
-
+- Incorrect bond amount provided
 
 ### Proving
 
@@ -215,9 +214,7 @@ function prove(bytes calldata proofBytes) external returns (ProposalStatus)
 Validates a proposal with a proof:
 
 - Timing Requirements
-  - Must be submitted before the proof deadline
-  - Clock starts when game is created (for unchallenged proofs)
-  - Clock starts when game is challenged (for challenged proofs)
+  - Must be submitted before the game is over (deadline passed or already proven)
 
 - Proof Verification
   - Uses SP1 verifier to validate the aggregation proof against public inputs:
@@ -254,15 +251,20 @@ function resolve() external returns (GameStatus)
 
 Resolves the game by:
 
-- Checking parent game status. Ensures that the parent game is resolved and that the proposal is valid. If the proposal is invalid (aka `CHALLENGER_WINS`), then set the current game status to `CHALLENGER_WINS`.
-- If the current game is in `UnchallengedAndValidProofProvided` or `ChallengedAndValidProofProvided` state, then set `DEFENDER_WINS`.
-- Ensure that the deadline has passed, and if the proposal is `Unchallenged`, then set `DEFENDER_WINS`.
-- Ensure that the deadline has passed, and if the proposal is `Challenged`, then set `CHALLENGER_WINS`
-- Distributing bonds based on outcome
-  - Distribution result is stored in `mapping(address => uint256) public normalModeCredit;`.
-  - Actual distribution is done when appropriate recipient calls `claimCredit()`.
-  - If parent game is `CHALLENGER_WINS`, then the proposer's bond is distributed to the challenger.
-  - But if there was no challenge for the current game, then the proposer's bond is burned.
+- Checking parent game status:
+  - Must be resolved
+  - Must be respected
+  - Must not be blacklisted
+  - Must not be retired
+  - If parent game is `CHALLENGER_WINS`, current game automatically resolves to `CHALLENGER_WINS`
+
+- For other cases:
+  - Game must be over (past deadline or proven)
+  - Resolution depends on final state:
+    - Unchallenged: `DEFENDER_WINS`, proposer gets its bond back
+    - Challenged: `CHALLENGER_WINS`, challenger gets everything
+    - UnchallengedAndValidProofProvided: `DEFENDER_WINS`, proposer gets its bond back
+    - ChallengedAndValidProofProvided: `DEFENDER_WINS`, prover gets challenger bond, proposer gets its bond back
 
 Attempting to resolve will revert if:
 - Parent game is not yet resolved
@@ -305,7 +307,7 @@ Bond distribution modes:
 The contract implements a bond system to incentivize honest behavior:
 
 1. **Proposal Bond**: Required to submit a proposal.
-2. **Proof Reward (Challenge Bond)**: Required to challenge a proposal, which is paid to successful provers.
+2. **Challenger Bond (Proof Reward)**: Required to challenge a proposal, which is paid to successful provers.
 
 ### Time Windows
 

--- a/book/fault_proofs/fault_proof_architecture.md
+++ b/book/fault_proofs/fault_proof_architecture.md
@@ -324,4 +324,6 @@ Two key time windows ensure fair participation:
 
 ## Acknowledgements
 
-Zach Obront, who worked on the first version of OP Succinct, prototyped a similar `MultiProof` dispute game implementation with OP Succinct as part of his work with the Ithaca team. This fault proof implementation takes some inspiration from his multiproof work.
+Special thanks to Kelvin Fichter for his invaluable contributions with thorough design reviews, technical guidance, and insightful feedback throughout the development process.
+
+Also, Zach Obront, who worked on the first version of OP Succinct, prototyped a similar `MultiProof` dispute game implementation with OP Succinct as part of his work with the Ithaca team. This fault proof implementation takes some inspiration from his multiproof work.

--- a/book/fault_proofs/fault_proof_architecture.md
+++ b/book/fault_proofs/fault_proof_architecture.md
@@ -84,7 +84,7 @@ In this example, Proposal 3A would always resolve to `CHALLENGER_WINS`, as its p
 - `ROLLUP_CONFIG_HASH`: Hash of the chain's rollup configuration
 - `AGGREGATION_VKEY`: The verification key for the aggregation SP1 program.
 - `RANGE_VKEY_COMMITMENT`: The commitment to the BabyBear representation of the verification key of the range SP1 program.
-- `CHALLENGER_BOND`: Amount of ETH required to submit a challenge (given to prover if they provide a valid proof).
+- `CHALLENGER_BOND`: Amount of ETH required to submit a challenge. If a prover supplies a valid proof, the bond is disbursed to the prover.
 - `ANCHOR_STATE_REGISTRY`: The anchor state registry contract.
 - `ACCESS_MANAGER`: The access manager contract.
 
@@ -326,4 +326,4 @@ Two key time windows ensure fair participation:
 
 Special thanks to Kelvin Fichter for his invaluable contributions with thorough design reviews, technical guidance, and insightful feedback throughout the development process.
 
-Also, Zach Obront, who worked on the first version of OP Succinct, prototyped a similar `MultiProof` dispute game implementation with OP Succinct as part of his work with the Ithaca team. This fault proof implementation takes some inspiration from his multiproof work.
+Zach Obront, who worked on the first version of OP Succinct, prototyped a similar `MultiProof` dispute game implementation with OP Succinct as part of his work with the Ithaca team. This fault proof implementation takes some inspiration from his multiproof work.

--- a/book/fault_proofs/gas_costs.md
+++ b/book/fault_proofs/gas_costs.md
@@ -14,6 +14,7 @@ Creating a new game through the factory costs approximately 330,000 gas. This in
 ### Challenge
 Challenging a game costs approximately 85,000 gas. This includes:
 - State validation checks
+- Game over checks
 - Updating game status
 - Setting challenge deadline
 - Recording challenger address
@@ -21,6 +22,7 @@ Challenging a game costs approximately 85,000 gas. This includes:
 
 ### Proving
 Proving a game costs approximately 280,000~300,000 gas. This includes:
+- Game over checks
 - Proof verification
 - State updates
 - Event emissions

--- a/contracts/script/fp/DeployOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/DeployOPSuccinctFDG.s.sol
@@ -108,13 +108,13 @@ contract DeployOPSuccinctFDG is Script {
             rollupConfigHash,
             aggregationVkey,
             rangeVkeyCommitment,
-            vm.envOr("CHALLENGER_BOND", uint256(0.001 ether)),
+            vm.envOr("CHALLENGER_BOND_IN_WEI", uint256(0.001 ether)),
             IAnchorStateRegistry(address(registry)),
             accessManager
         );
 
         // Set initial bond and implementation in factory.
-        factory.setInitBond(gameType, vm.envOr("INITIAL_BOND", uint256(0.001 ether)));
+        factory.setInitBond(gameType, vm.envOr("INITIAL_BOND_IN_WEI", uint256(0.001 ether)));
         factory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
 
         vm.stopBroadcast();

--- a/contracts/script/fp/DeployOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/DeployOPSuccinctFDG.s.sol
@@ -33,15 +33,20 @@ contract DeployOPSuccinctFDG is Script {
         // Deploy factory proxy.
         ERC1967Proxy factoryProxy = new ERC1967Proxy(
             address(new DisputeGameFactory()),
-            abi.encodeWithSelector(DisputeGameFactory.initialize.selector, msg.sender)
+            abi.encodeWithSelector(
+                DisputeGameFactory.initialize.selector,
+                msg.sender
+            )
         );
         DisputeGameFactory factory = DisputeGameFactory(address(factoryProxy));
 
         GameType gameType = GameType.wrap(uint32(vm.envUint("GAME_TYPE")));
 
         // TODO(fakedev9999): Use real OptimismPortal2.
-        MockOptimismPortal2 portal =
-            new MockOptimismPortal2(gameType, vm.envUint("DISPUTE_GAME_FINALITY_DELAY_SECONDS"));
+        MockOptimismPortal2 portal = new MockOptimismPortal2(
+            gameType,
+            vm.envUint("DISPUTE_GAME_FINALITY_DELAY_SECONDS")
+        );
         console.log("OptimismPortal2:", address(portal));
 
         OutputRoot memory startingAnchorRoot = OutputRoot({
@@ -63,7 +68,9 @@ contract DeployOPSuccinctFDG is Script {
             )
         );
 
-        AnchorStateRegistry registry = AnchorStateRegistry(address(registryProxy));
+        AnchorStateRegistry registry = AnchorStateRegistry(
+            address(registryProxy)
+        );
         console.log("Anchor state registry:", address(registry));
         // Deploy the access manager contract.
         AccessManager accessManager = new AccessManager();
@@ -108,13 +115,16 @@ contract DeployOPSuccinctFDG is Script {
             rollupConfigHash,
             aggregationVkey,
             rangeVkeyCommitment,
-            vm.envOr("CHALLENGER_BOND_IN_WEI", uint256(0.001 ether)),
+            vm.envOr("CHALLENGER_BOND_WEI", uint256(0.001 ether)),
             IAnchorStateRegistry(address(registry)),
             accessManager
         );
 
         // Set initial bond and implementation in factory.
-        factory.setInitBond(gameType, vm.envOr("INITIAL_BOND_IN_WEI", uint256(0.001 ether)));
+        factory.setInitBond(
+            gameType,
+            vm.envOr("INITIAL_BOND_WEI", uint256(0.001 ether))
+        );
         factory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
 
         vm.stopBroadcast();

--- a/contracts/script/fp/DeployOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/DeployOPSuccinctFDG.s.sol
@@ -108,13 +108,13 @@ contract DeployOPSuccinctFDG is Script {
             rollupConfigHash,
             aggregationVkey,
             rangeVkeyCommitment,
-            vm.envOr("PROOF_REWARD", uint256(0.01 ether)),
+            vm.envOr("CHALLENGER_BOND", uint256(0.001 ether)),
             IAnchorStateRegistry(address(registry)),
             accessManager
         );
 
         // Set initial bond and implementation in factory.
-        factory.setInitBond(gameType, vm.envOr("INITIAL_BOND", uint256(0.01 ether)));
+        factory.setInitBond(gameType, vm.envOr("INITIAL_BOND", uint256(0.001 ether)));
         factory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
 
         vm.stopBroadcast();

--- a/contracts/script/fp/DeployOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/DeployOPSuccinctFDG.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 // Libraries
 import {Script} from "forge-std/Script.sol";
@@ -33,20 +33,15 @@ contract DeployOPSuccinctFDG is Script {
         // Deploy factory proxy.
         ERC1967Proxy factoryProxy = new ERC1967Proxy(
             address(new DisputeGameFactory()),
-            abi.encodeWithSelector(
-                DisputeGameFactory.initialize.selector,
-                msg.sender
-            )
+            abi.encodeWithSelector(DisputeGameFactory.initialize.selector, msg.sender)
         );
         DisputeGameFactory factory = DisputeGameFactory(address(factoryProxy));
 
         GameType gameType = GameType.wrap(uint32(vm.envUint("GAME_TYPE")));
 
         // TODO(fakedev9999): Use real OptimismPortal2.
-        MockOptimismPortal2 portal = new MockOptimismPortal2(
-            gameType,
-            vm.envUint("DISPUTE_GAME_FINALITY_DELAY_SECONDS")
-        );
+        MockOptimismPortal2 portal =
+            new MockOptimismPortal2(gameType, vm.envUint("DISPUTE_GAME_FINALITY_DELAY_SECONDS"));
         console.log("OptimismPortal2:", address(portal));
 
         OutputRoot memory startingAnchorRoot = OutputRoot({
@@ -68,9 +63,7 @@ contract DeployOPSuccinctFDG is Script {
             )
         );
 
-        AnchorStateRegistry registry = AnchorStateRegistry(
-            address(registryProxy)
-        );
+        AnchorStateRegistry registry = AnchorStateRegistry(address(registryProxy));
         console.log("Anchor state registry:", address(registry));
         // Deploy the access manager contract.
         AccessManager accessManager = new AccessManager();
@@ -121,10 +114,7 @@ contract DeployOPSuccinctFDG is Script {
         );
 
         // Set initial bond and implementation in factory.
-        factory.setInitBond(
-            gameType,
-            vm.envOr("INITIAL_BOND_WEI", uint256(0.001 ether))
-        );
+        factory.setInitBond(gameType, vm.envOr("INITIAL_BOND_WEI", uint256(0.001 ether)));
         factory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
 
         vm.stopBroadcast();

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -21,7 +21,6 @@ import {
     BadAuth,
     BondTransferFailed,
     ClaimAlreadyResolved,
-    ClockNotExpired,
     ClockTimeExceeded,
     GameNotFinalized,
     GameNotInProgress,

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -122,9 +122,10 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     /// this verification is the output of converting the [u32; 8] range BabyBear verification key to a [u8; 32] array.
     bytes32 internal immutable RANGE_VKEY_COMMITMENT;
 
-    /// @notice The proof reward for the game. This is the amount of the bond that the challenger has to bond to challenge and
-    ///         is the amount of the bond that is distributed to the prover when proven with a valid proof.
-    uint256 internal immutable PROOF_REWARD;
+    /// @notice The challenger bond for the game. This is the amount of the bond that the
+    ///         challenger has to bond to challenge. The prover will receive this bond if they
+    ///         provide a valid proof in response to a challenge.
+    uint256 internal immutable CHALLENGER_BOND;
 
     /// @notice The anchor state registry.
     IAnchorStateRegistry internal immutable ANCHOR_STATE_REGISTRY;
@@ -174,7 +175,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     /// @param _rollupConfigHash The rollup config hash for the L2 network.
     /// @param _aggregationVkey The vkey for the aggregation program.
     /// @param _rangeVkeyCommitment The commitment to the range vkey.
-    /// @param _proofReward The proof reward for the game.
+    /// @param _challengerBond The bond amount that must be submitted by the challenger.
     /// @param _anchorStateRegistry The anchor state registry for the L2 network.
     constructor(
         Duration _maxChallengeDuration,
@@ -184,7 +185,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         bytes32 _rollupConfigHash,
         bytes32 _aggregationVkey,
         bytes32 _rangeVkeyCommitment,
-        uint256 _proofReward,
+        uint256 _challengerBond,
         IAnchorStateRegistry _anchorStateRegistry,
         AccessManager _accessManager
     ) {
@@ -197,7 +198,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         ROLLUP_CONFIG_HASH = _rollupConfigHash;
         AGGREGATION_VKEY = _aggregationVkey;
         RANGE_VKEY_COMMITMENT = _rangeVkeyCommitment;
-        PROOF_REWARD = _proofReward;
+        CHALLENGER_BOND = _challengerBond;
         ANCHOR_STATE_REGISTRY = _anchorStateRegistry;
         ACCESS_MANAGER = _accessManager;
     }
@@ -251,11 +252,11 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
 
             // NOTE(fakedev9999): We're performing a subset of the checks from AnchorStateRegistry.isGameProper()
             // plus isGameRespected(). Since we're pulling the parent game directly from the factory, we can skip
-            // the isGameRegistered() check and even if the parent game's game type is retired, if it was respected
-            // when created, it's considered as a proper game. We verify that the game:
-            // 1. Is not blacklisted (isGameBlacklisted()).
-            // 2. Was a respected game type when created (isGameRespected()).
-            if (ANCHOR_STATE_REGISTRY.isGameBlacklisted(proxy) || !ANCHOR_STATE_REGISTRY.isGameRespected(proxy)) {
+            // the isGameRegistered() check.
+            if (
+                !ANCHOR_STATE_REGISTRY.isGameRespected(proxy) || ANCHOR_STATE_REGISTRY.isGameBlacklisted(proxy)
+                    || ANCHOR_STATE_REGISTRY.isGameRetired(proxy)
+            ) {
                 revert InvalidParentGame();
             }
 
@@ -334,11 +335,11 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         // INVARIANT: The challenger must be whitelisted.
         if (!ACCESS_MANAGER.isAllowedChallenger(msg.sender)) revert BadAuth();
 
-        // INVARIANT: Cannot challenge a game if the clock has already expired.
-        if (uint64(block.timestamp) > claimData.deadline.raw()) revert ClockTimeExceeded();
+        // INVARIANT: Cannot challenge if the game is over.
+        if (gameOver()) revert GameOver();
 
         // If the required bond is not met, revert.
-        if (msg.value != PROOF_REWARD) revert IncorrectBondAmount();
+        if (msg.value != CHALLENGER_BOND) revert IncorrectBondAmount();
 
         // Update the counteredBy address
         claimData.counteredBy = msg.sender;
@@ -360,11 +361,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     /// @notice Proves the game.
     /// @param proofBytes The proof bytes to validate the claim.
     function prove(bytes calldata proofBytes) external returns (ProposalStatus) {
-        // INVARIANT: Cannot prove a game if the clock has timed out.
-        if (uint64(block.timestamp) > claimData.deadline.raw()) revert ClockTimeExceeded();
-
-        // INVARIANT: Cannot prove a claim that has already been proven
-        if (claimData.prover != address(0)) revert AlreadyProven();
+        // INVARIANT: Cannot prove if the game is over.
+        if (gameOver()) revert GameOver();
 
         // Decode the public values to check the claim root
         AggregationOutputs memory publicValues = AggregationOutputs({
@@ -376,6 +374,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             rangeVkeyCommitment: RANGE_VKEY_COMMITMENT
         });
 
+        // Verify the proof.
+        // Note that this will revert if the proof is invalid.
         SP1_VERIFIER.verifyProof(AGGREGATION_VKEY, abi.encode(publicValues), proofBytes);
 
         // Update the prover address
@@ -399,10 +399,9 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         if (parentIndex() != type(uint32).max) {
             (,, IDisputeGame parentGame) = DISPUTE_GAME_FACTORY.gameAtIndex(parentIndex());
             return parentGame.status();
-        }
-        // If this is the first dispute game (i.e. parent game index is `uint32.max`),
-        // then the parent game's status is considered as `DEFENDER_WINS`.
-        else {
+        } else {
+            // If this is the first dispute game (i.e. parent game index is `uint32.max`), then the
+            // parent game's status is considered as `DEFENDER_WINS`.
             return GameStatus.DEFENDER_WINS;
         }
     }
@@ -418,66 +417,47 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
 
         // INVARIANT: Cannot resolve a game if the parent game has not been resolved.
         GameStatus parentGameStatus = getParentGameStatus();
-
         if (parentGameStatus == GameStatus.IN_PROGRESS) revert ParentGameNotResolved();
 
         // INVARIANT: If the parent game's claim is invalid, then the current game's claim is invalid.
         if (parentGameStatus == GameStatus.CHALLENGER_WINS) {
-            claimData.status = ProposalStatus.Resolved;
+            // Parent game is invalid so this game is invalid too, challenger wins, challenger gets
+            // everything. If the game has not been challenged then there will not be any
+            // challenger address and the bond is essentially burned (given to address(0)).
             status = GameStatus.CHALLENGER_WINS;
-            resolvedAt = Timestamp.wrap(uint64(block.timestamp));
-
-            // Record the challenger's reward.
             normalModeCredit[claimData.counteredBy] += address(this).balance;
+        } else {
+            // INVARIANT: Game must be completed either by clock expiration or valid proof.
+            if (!gameOver()) revert GameNotOver();
 
-            emit Resolved(status);
-
-            return status;
+            // Determine status based on claim status.
+            if (claimData.status == ProposalStatus.Unchallenged) {
+                // Claim is unchallenged, defender wins, game creator gets everything.
+                status = GameStatus.DEFENDER_WINS;
+                normalModeCredit[gameCreator()] += address(this).balance;
+            } else if (claimData.status == ProposalStatus.Challenged) {
+                // Claim is challenged, challenger wins, challenger wins everything
+                status = GameStatus.CHALLENGER_WINS;
+                normalModeCredit[claimData.counteredBy] += address(this).balance;
+            } else if (claimData.status == ProposalStatus.UnchallengedAndValidProofProvided) {
+                // Claim is unchallenged but a valid proof was provided, defender wins, game
+                // creator gets everything. Note that the prover does not receive any reward in
+                // this particular case.
+                status = GameStatus.DEFENDER_WINS;
+                normalModeCredit[gameCreator()] += address(this).balance;
+            } else if (claimData.status == ProposalStatus.ChallengedAndValidProofProvided) {
+                // Claim is challenged but a valid proof was provided, defender wins, prover gets
+                // the challenger's bond and the game creator gets everything else.
+                status = GameStatus.DEFENDER_WINS;
+                normalModeCredit[claimData.prover] += CHALLENGER_BOND;
+                normalModeCredit[gameCreator()] += address(this).balance - CHALLENGER_BOND;
+            }
         }
 
-        if (claimData.status == ProposalStatus.Unchallenged) {
-            if (claimData.deadline.raw() >= uint64(block.timestamp)) revert ClockNotExpired();
-
-            claimData.status = ProposalStatus.Resolved;
-            status = GameStatus.DEFENDER_WINS;
-            resolvedAt = Timestamp.wrap(uint64(block.timestamp));
-
-            // Record the proposer's reward.
-            normalModeCredit[gameCreator()] += address(this).balance;
-
-            emit Resolved(status);
-        } else if (claimData.status == ProposalStatus.Challenged) {
-            if (claimData.deadline.raw() >= uint64(block.timestamp)) revert ClockNotExpired();
-            claimData.status = ProposalStatus.Resolved;
-            status = GameStatus.CHALLENGER_WINS;
-            resolvedAt = Timestamp.wrap(uint64(block.timestamp));
-
-            // Record the challenger's reward.
-            normalModeCredit[claimData.counteredBy] += address(this).balance;
-
-            emit Resolved(status);
-        } else if (claimData.status == ProposalStatus.UnchallengedAndValidProofProvided) {
-            claimData.status = ProposalStatus.Resolved;
-            status = GameStatus.DEFENDER_WINS;
-            resolvedAt = Timestamp.wrap(uint64(block.timestamp));
-
-            // Record the proposer's reward.
-            normalModeCredit[gameCreator()] += address(this).balance;
-
-            emit Resolved(status);
-        } else if (claimData.status == ProposalStatus.ChallengedAndValidProofProvided) {
-            claimData.status = ProposalStatus.Resolved;
-            status = GameStatus.DEFENDER_WINS;
-            resolvedAt = Timestamp.wrap(uint64(block.timestamp));
-
-            // Record the proof reward for the prover.
-            normalModeCredit[claimData.prover] += PROOF_REWARD;
-
-            // Record the remaining balance (proposer's bond) for the proposer.
-            normalModeCredit[gameCreator()] += address(this).balance - PROOF_REWARD;
-
-            emit Resolved(status);
-        }
+        // Mark the game as resolved.
+        claimData.status = ProposalStatus.Resolved;
+        resolvedAt = Timestamp.wrap(uint64(block.timestamp));
+        emit Resolved(status);
 
         return status;
     }
@@ -560,6 +540,12 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         emit GameClosed(bondDistributionMode);
     }
 
+    /// @notice Determines if the game is finished.
+    /// @return gameOver_ True if the game is either expired or proven.
+    function gameOver() public view returns (bool gameOver_) {
+        gameOver_ = claimData.deadline.raw() < uint64(block.timestamp) || claimData.prover != address(0);
+    }
+
     /// @notice Getter for the game type.
     /// @dev The reference impl should be entirely different depending on the type (fault, validity)
     ///      i.e. The game type should indicate the security model.
@@ -635,8 +621,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         registry_ = ANCHOR_STATE_REGISTRY;
     }
 
-    /// @notice Returns the proof reward.
-    function proofReward() external view returns (uint256 proofReward_) {
-        proofReward_ = PROOF_REWARD;
+    /// @notice Returns the challenger bond amount.
+    function challengerBond() external view returns (uint256 challengerBond_) {
+        challengerBond_ = CHALLENGER_BOND;
     }
 }

--- a/contracts/src/fp/lib/Errors.sol
+++ b/contracts/src/fp/lib/Errors.sol
@@ -17,5 +17,8 @@ error InvalidParentGame();
 /// @notice Thrown when the parent game is not resolved.
 error ParentGameNotResolved();
 
-/// @notice Thrown when the claim has already been proven.
-error AlreadyProven();
+/// @notice Thrown when the game is over.
+error GameOver();
+
+/// @notice Thrown when the game is not over.
+error GameNotOver();

--- a/fault_proof/bin/challenger.rs
+++ b/fault_proof/bin/challenger.rs
@@ -37,7 +37,7 @@ where
     l2_provider: L2Provider,
     l1_provider_with_wallet: L1ProviderWithWallet<F, P>,
     factory: DisputeGameFactoryInstance<(), L1ProviderWithWallet<F, P>>,
-    proof_reward: U256,
+    challenger_bond: U256,
 }
 
 impl<F, P> OPSuccinctChallenger<F, P>
@@ -59,7 +59,7 @@ where
             l2_provider: ProviderBuilder::default().on_http(config.l2_rpc.clone()),
             l1_provider_with_wallet: l1_provider_with_wallet.clone(),
             factory: factory.clone(),
-            proof_reward: factory.fetch_proof_reward(config.game_type).await?,
+            challenger_bond: factory.fetch_challenger_bond(config.game_type).await?,
         })
     }
 
@@ -71,7 +71,7 @@ where
         // TODO(fakedev9999): Potentially need to add a gas provider.
         let receipt = game
             .challenge()
-            .value(self.proof_reward)
+            .value(self.challenger_bond)
             .send()
             .await
             .context("Failed to send challenge transaction")?

--- a/fault_proof/bin/challenger.rs
+++ b/fault_proof/bin/challenger.rs
@@ -68,7 +68,6 @@ where
         let game =
             OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider_with_wallet.clone());
 
-        // TODO(fakedev9999): Potentially need to add a gas provider.
         let receipt = game
             .challenge()
             .value(self.challenger_bond)

--- a/fault_proof/bin/proposer.rs
+++ b/fault_proof/bin/proposer.rs
@@ -105,7 +105,6 @@ where
 
         let extra_data = <(U256, u32)>::abi_encode_packed(&(l2_block_number, parent_game_index));
 
-        // TODO(fakedev9999): Potentially need to add a gas provider.
         let receipt = self
             .factory
             .create(

--- a/fault_proof/src/contract.rs
+++ b/fault_proof/src/contract.rs
@@ -66,8 +66,8 @@ sol! {
         /// @notice Returns the anchor state registry contract.
         function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_);
 
-        /// @notice Returns the proof reward.
-        function proofReward() external view returns (uint256 proofReward_);
+        /// @notice Returns the challenger bond amount.
+        function challengerBond() external view returns (uint256 challengerBond_);
     }
 
     #[allow(missing_docs)]

--- a/fault_proof/src/lib.rs
+++ b/fault_proof/src/lib.rs
@@ -503,7 +503,6 @@ where
         }
 
         let contract = OPSuccinctFaultDisputeGame::new(game_address, self.provider());
-        // TODO(fakedev9999): Potentially need to add a gas provider.
         let receipt = contract
             .resolve()
             .send()

--- a/fault_proof/src/lib.rs
+++ b/fault_proof/src/lib.rs
@@ -125,8 +125,8 @@ where
     /// Fetches the bond required to create a game.
     async fn fetch_init_bond(&self, game_type: u32) -> Result<U256>;
 
-    /// Fetches the proof reward required to challenge a game.
-    async fn fetch_proof_reward(&self, game_type: u32) -> Result<U256>;
+    /// Fetches the challenger bond required to challenge a game.
+    async fn fetch_challenger_bond(&self, game_type: u32) -> Result<U256>;
 
     /// Fetches the latest game index.
     async fn fetch_latest_game_index(&self) -> Result<Option<U256>>;
@@ -201,12 +201,12 @@ where
         Ok(init_bond._0)
     }
 
-    /// Fetches the proof reward required to challenge a game.
-    async fn fetch_proof_reward(&self, game_type: u32) -> Result<U256> {
+    /// Fetches the challenger bond required to challenge a game.
+    async fn fetch_challenger_bond(&self, game_type: u32) -> Result<U256> {
         let game_impl_address = self.gameImpls(game_type).call().await?._0;
         let game_impl = OPSuccinctFaultDisputeGame::new(game_impl_address, self.provider());
-        let proof_reward = game_impl.proofReward().call().await?;
-        Ok(proof_reward.proofReward_)
+        let challenger_bond = game_impl.challengerBond().call().await?;
+        Ok(challenger_bond.challengerBond_)
     }
 
     /// Fetches the latest game index.


### PR DESCRIPTION
Misc suggestions from @smartcontracts in #403 + test fixing + updating docs.

# Changes
- Add the `isGameRetired` check back in because game retirement is the primary response mechanism
- Rename proof reward to challenger bond for clarity
- Add a `gameOver` function that combines the proof check + timestamp check for clarity
- General cleanup/simplification of the resolution function

