### PR TITLE
chore: unify solady

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "contracts/lib/openzeppelin-contracts-upgradeable"]
 	path = contracts/lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
-[submodule "contracts/lib/solady-v0.0.281"]
-	path = contracts/lib/solady-v0.0.281
-	url = https://github.com/vectorized/solady
 [submodule "contracts/lib/lib-keccak"]
 	path = contracts/lib/lib-keccak
 	url = https://github.com/ethereum-optimism/lib-keccak

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -9,7 +9,6 @@ remappings = [
     "@optimism/=lib/optimism/packages/contracts-bedrock/",
     "@forge-std/=lib/forge-std/src/",
     "@solady/=lib/solady/src",
-    "@solady-v0.0.281/=lib/solady-v0.0.281/src",
     # Note: Use zobront/sp1-contracts as the current version for SP1 contracts is not compatible with the hard
     # version for 0.8.15 on some Optimism contracts.
     "@sp1-contracts/=lib/sp1-contracts/contracts/",

--- a/contracts/test/validity/OPSuccinctDisputeGame.t.sol
+++ b/contracts/test/validity/OPSuccinctDisputeGame.t.sol
@@ -6,10 +6,10 @@ import {Utils} from "../helpers/Utils.sol";
 import {OPSuccinctL2OutputOracle} from "../../src/validity/OPSuccinctL2OutputOracle.sol";
 import {OPSuccinctDisputeGame} from "../../src/validity/OPSuccinctDisputeGame.sol";
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
-import {LibCWIA} from "@solady-v0.0.281/utils/legacy/LibCWIA.sol";
+import {LibClone} from "@solady/utils/LibClone.sol";
 
 contract OPSuccinctL2OutputOracleTest is Test, Utils {
-    using LibCWIA for address;
+    using LibClone for address;
 
     // Example proof data for the BoB testnet. Tx: https://sepolia.etherscan.io/tx/0x35df99dce5db3d7644a005bd582af2d66533b56fdb01970f248d96e8053fc0ba
     uint256 checkpointedL1BlockNum = 7438547;

--- a/contracts/test/validity/OPSuccinctDisputeGameFactory.t.sol
+++ b/contracts/test/validity/OPSuccinctDisputeGameFactory.t.sol
@@ -7,7 +7,7 @@ import {Utils} from "../helpers/Utils.sol";
 
 // Libraries
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
-import {LibCWIA} from "@solady-v0.0.281/utils/legacy/LibCWIA.sol";
+import {LibClone} from "@solady/utils/LibClone.sol";
 
 import {GameType, Claim} from "src/dispute/lib/Types.sol";
 
@@ -18,7 +18,7 @@ import {OPSuccinctDisputeGame} from "../../src/validity/OPSuccinctDisputeGame.so
 import {DisputeGameFactory} from "src/dispute/DisputeGameFactory.sol";
 
 contract OPSuccinctDisputeGameFactoryTest is Test, Utils {
-    using LibCWIA for address;
+    using LibClone for address;
 
     // Example proof data for the BoB testnet. Tx: https://sepolia.etherscan.io/tx/0x35df99dce5db3d7644a005bd582af2d66533b56fdb01970f248d96e8053fc0ba
     uint256 checkpointedL1BlockNum = 7438547;


### PR DESCRIPTION
Unifies solady dependency to version v0.0.158, which is the version used by Optimism.

Necessary changes are made since LibBytes is not implemented in v0.0.158.