### PR TITLE
fix(fault_proof): fix env file from being overwritten

### DIFF
--- a/fault_proof/src/config.rs
+++ b/fault_proof/src/config.rs
@@ -47,8 +47,6 @@ pub struct ProposerConfig {
 
 impl ProposerConfig {
     pub fn from_env() -> Result<Self> {
-        dotenv::from_filename(".env.proposer").ok();
-
         Ok(Self {
             l1_rpc: env::var("L1_RPC")?.parse().expect("L1_RPC not set"),
             l2_rpc: env::var("L2_RPC")?.parse().expect("L2_RPC not set"),


### PR DESCRIPTION
Fixes env file for proposer from being overwritten.

Env file is already loaded in bin/proposer.rs.

```rust
async fn main() {
    setup_logging();

    let args = Args::parse();
    dotenv::from_filename(args.env_file).ok();
```