### PR TITLE
feat: make misc changes to `OPSuccinctFaultDisputeGame`

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -24,7 +24,6 @@ import {
     ClockTimeExceeded,
     GameNotFinalized,
     GameNotInProgress,
-    GameNotResolved,
     IncorrectBondAmount,
     InvalidBondDistributionMode,
     NoCreditToClaim,
@@ -507,12 +506,6 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         } else if (bondDistributionMode != BondDistributionMode.UNDECIDED) {
             // We shouldn't get here, but sanity check just in case.
             revert InvalidBondDistributionMode();
-        }
-
-        // Make sure that the game is resolved.
-        // AnchorStateRegistry should be checking this but we're being defensive here.
-        if (resolvedAt.raw() == 0) {
-            revert GameNotResolved();
         }
 
         // Game must be finalized according to the AnchorStateRegistry.

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -603,6 +603,22 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     }
 
     ////////////////////////////////////////////////////////////////
+    //                       MISC EXTERNAL                        //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Returns the credit balance of a given recipient.
+    /// @param _recipient The recipient of the credit.
+    /// @return credit_ The credit balance of the recipient.
+    function credit(address _recipient) external view returns (uint256 credit_) {
+        if (bondDistributionMode == BondDistributionMode.REFUND) {
+            credit_ = refundModeCredit[_recipient];
+        } else {
+            // Always return normal credit balance by default unless we're in refund mode.
+            credit_ = normalModeCredit[_recipient];
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////
     //                     IMMUTABLE GETTERS                      //
     ////////////////////////////////////////////////////////////////
 

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -459,6 +459,9 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
                     normalModeCredit[claimData.prover] = CHALLENGER_BOND;
                     normalModeCredit[gameCreator()] = address(this).balance - CHALLENGER_BOND;
                 }
+            } else {
+                // We shouldn't get here, but sanity check just in case.
+                revert InvalidProposalStatus();
             }
         }
 

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -424,7 +424,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             // Parent game is invalid so this game is invalid too. Therefore the challenger wins and gets all bonds.
             // If the game has not been challenged then there will not be any challenger address and the bond is burned.
             status = GameStatus.CHALLENGER_WINS;
-            normalModeCredit[claimData.counteredBy] += address(this).balance;
+            normalModeCredit[claimData.counteredBy] = address(this).balance;
         } else {
             // INVARIANT: Game must be completed either by clock expiration or valid proof.
             if (!gameOver()) revert GameNotOver();
@@ -433,23 +433,32 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             if (claimData.status == ProposalStatus.Unchallenged) {
                 // Claim is unchallenged, defender wins, game creator gets everything.
                 status = GameStatus.DEFENDER_WINS;
-                normalModeCredit[gameCreator()] += address(this).balance;
+                normalModeCredit[gameCreator()] = address(this).balance;
             } else if (claimData.status == ProposalStatus.Challenged) {
                 // Claim is challenged, challenger wins, challenger wins everything
                 status = GameStatus.CHALLENGER_WINS;
-                normalModeCredit[claimData.counteredBy] += address(this).balance;
+                normalModeCredit[claimData.counteredBy] = address(this).balance;
             } else if (claimData.status == ProposalStatus.UnchallengedAndValidProofProvided) {
                 // Claim is unchallenged but a valid proof was provided, defender wins, game
                 // creator gets everything. Note that the prover does not receive any reward in
                 // this particular case.
                 status = GameStatus.DEFENDER_WINS;
-                normalModeCredit[gameCreator()] += address(this).balance;
+                normalModeCredit[gameCreator()] = address(this).balance;
             } else if (claimData.status == ProposalStatus.ChallengedAndValidProofProvided) {
                 // Claim is challenged but a valid proof was provided, defender wins, prover gets
                 // the challenger's bond and the game creator gets everything else.
                 status = GameStatus.DEFENDER_WINS;
-                normalModeCredit[claimData.prover] += CHALLENGER_BOND;
-                normalModeCredit[gameCreator()] += address(this).balance - CHALLENGER_BOND;
+
+                // If the prover is same as the proposer, the proposer takes the entire bond.
+                if (claimData.prover == gameCreator()) {
+                    normalModeCredit[claimData.prover] = address(this).balance;
+                }
+                // If the prover is different from the proposer, the proposer gets the initial bond back,
+                // and the prover gets the challenger's bond.
+                else {
+                    normalModeCredit[claimData.prover] = CHALLENGER_BOND;
+                    normalModeCredit[gameCreator()] = address(this).balance - CHALLENGER_BOND;
+                }
             }
         }
 

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -218,6 +218,9 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         // INVARIANT: The game must not have already been initialized.
         if (initialized) revert AlreadyInitialized();
 
+        // INVARIANT: The game can only be initialized by the dispute game factory.
+        if (address(DISPUTE_GAME_FACTORY) != msg.sender) revert IncorrectDisputeGameFactory();
+
         // INVARIANT: The proposer must be whitelisted.
         if (!ACCESS_MANAGER.isAllowedProposer(gameCreator())) revert BadAuth();
 

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -463,7 +463,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
                     normalModeCredit[gameCreator()] = address(this).balance - CHALLENGER_BOND;
                 }
             } else {
-                // We shouldn't get here, but sanity check just in case.
+                // This edge case shouldn't be reached, sanity check just in case.
                 revert InvalidProposalStatus();
             }
         }
@@ -616,7 +616,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         if (bondDistributionMode == BondDistributionMode.REFUND) {
             credit_ = refundModeCredit[_recipient];
         } else {
-            // Always return normal credit balance by default unless we're in refund mode.
+            // Always return normal credit balance by default unless in refund mode.
             credit_ = normalModeCredit[_recipient];
         }
     }

--- a/contracts/src/fp/lib/Errors.sol
+++ b/contracts/src/fp/lib/Errors.sol
@@ -25,3 +25,6 @@ error GameNotOver();
 
 /// @notice Thrown when the proposal status is invalid.
 error InvalidProposalStatus();
+
+/// @notice Thrown when the game is initialized by an incorrect factory.
+error IncorrectDisputeGameFactory();

--- a/contracts/src/fp/lib/Errors.sol
+++ b/contracts/src/fp/lib/Errors.sol
@@ -22,3 +22,6 @@ error GameOver();
 
 /// @notice Thrown when the game is not over.
 error GameNotOver();
+
+/// @notice Thrown when the proposal status is invalid.
+error InvalidProposalStatus();

--- a/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
+++ b/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
@@ -21,7 +21,8 @@ import {
     InvalidParentGame,
     ClaimAlreadyChallenged,
     GameOver,
-    GameNotOver
+    GameNotOver,
+    IncorrectDisputeGameFactory
 } from "src/fp/lib/Errors.sol";
 import {AggregationOutputs} from "src/lib/Types.sol";
 
@@ -672,6 +673,36 @@ contract OPSuccinctFaultDisputeGameTest is Test {
 
         vm.expectRevert(BadAuth.selector);
         game.challenge{value: 1 ether}();
+
+        vm.stopPrank();
+    }
+
+    // =========================================
+    // Test: Cannot initialize new factory with same implementation
+    // =========================================
+    function testCannotInitializeNewFactoryWithSameImplementation() public {
+        // Deploy the implementation contract for new DisputeGameFactory.
+        DisputeGameFactory newFactoryImpl = new DisputeGameFactory();
+
+        // Deploy a proxy pointing to the new factory implementation.
+        ERC1967Proxy newFactoryProxy = new ERC1967Proxy(
+            address(newFactoryImpl), abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
+        );
+
+        // Cast the proxy to the DisputeGameFactory interface.
+        DisputeGameFactory newFactory = DisputeGameFactory(address(newFactoryProxy));
+
+        // Set the implementation with the same implementation as the old factory.
+        newFactory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
+        newFactory.setInitBond(gameType, 1 ether);
+
+        vm.startPrank(proposer);
+        vm.deal(proposer, 1 ether);
+
+        vm.expectRevert(IncorrectDisputeGameFactory.selector);
+        newFactory.create{value: 1 ether}(
+            gameType, Claim.wrap(keccak256("new-claim")), abi.encodePacked(uint256(3000), uint32(1))
+        );
 
         vm.stopPrank();
     }

--- a/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
+++ b/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
@@ -614,7 +614,7 @@ contract OPSuccinctFaultDisputeGameTest is Test {
     // Test: Cannot close the game before it is resolved
     // =========================================
     function testCannotCloseGameBeforeResolved() public {
-        vm.expectRevert(GameNotResolved.selector);
+        vm.expectRevert(GameNotFinalized.selector);
         game.closeGame();
     }
 


### PR DESCRIPTION
Made misc changes to `OPSuccinctFaultDisputeGame`.

1. Removed redundant game resolution check in `closeGame` since the subsequent call to `ANCHOR_STATE_REGISTRY.isGameFinalized(IDisputeGame(address(this)))` verifies the game's resolution status.
2. Refactored to use = instead of += for bond distribution.
3. Added proposal status sanity check for resolution.
4. Added credit getter like OP's implementation.
5. Added dispute game factory check since there could be misalignment with the factory and the game impl contract.

