### PR TITLE
feat: add `handle_bond_claiming` for fp proposer

### DIFF
--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -53,6 +53,7 @@ To get a whitelisted key on the Succinct Prover Network for OP Succinct, fill ou
 | `MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING` | Maximum number of games to check for bond claiming | `100` |
 | `L1_BEACON_RPC` | L1 Beacon RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
 | `L2_NODE_RPC` | L2 Node RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
+| `PROVER_ADDRESS` | Address of the account that will be posting output roots to L1. This address is committed to when generating the aggregation proof to prevent front-running attacks. It can be different from the signing address if you want to separate these roles. Default: The address derived from the `PRIVATE_KEY` environment variable. | (Only used if `FAST_FINALITY_MODE` is `true`) |
 
 ```env
 # Required Configuration

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -50,6 +50,7 @@ To get a whitelisted key on the Succinct Prover Network for OP Succinct, fill ou
 | `ENABLE_GAME_RESOLUTION` | Whether to enable automatic game resolution | `true` |
 | `MAX_GAMES_TO_CHECK_FOR_RESOLUTION` | Maximum number of games to check for resolution | `100` |
 | `MAX_GAMES_TO_CHECK_FOR_DEFENSE` | Maximum number of recent games to check for defense | `100` |
+| `MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING` | Maximum number of games to check for bond claiming | `100` |
 | `L1_BEACON_RPC` | L1 Beacon RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
 | `L2_NODE_RPC` | L2 Node RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
 
@@ -68,6 +69,7 @@ FETCH_INTERVAL=30                   # Polling interval in seconds
 ENABLE_GAME_RESOLUTION=false        # Whether to enable automatic game resolution
 MAX_GAMES_TO_CHECK_FOR_RESOLUTION=100  # Maximum number of games to check for resolution
 MAX_GAMES_TO_CHECK_FOR_DEFENSE=100    # Maximum number of recent games to check for defense
+MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING=100 # Maximum number of games to check for bond claiming
 ```
 
 ### Configuration Steps
@@ -111,6 +113,12 @@ When enabled (`ENABLE_GAME_RESOLUTION=true`), the proposer:
 - Resolves games after their challenge period expires
 - Respects parent-child game relationships in resolution
 - Only resolves games whose parent games are already resolved
+
+### Bond Claiming
+- Monitors games for bond claiming opportunities
+- Only claims bonds from games that:
+  - Are finalized (resolved and airgapped)
+  - Has credit left to claim
 
 ### Chain Monitoring
 - Monitors the L2 chain's finalized (safe) head

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -43,12 +43,14 @@ async fn main() {
         l1_provider_with_wallet.clone(),
     );
 
-    let proposer = OPSuccinctProposer::new(
-        wallet.default_signer().address(), // prover_address
-        l1_provider_with_wallet,
-        factory,
-    )
-    .await
-    .unwrap();
+    // Use PROVER_ADDRESS from env if available, otherwise use wallet's default signer address from the private key.
+    let prover_address = env::var("PROVER_ADDRESS")
+        .ok()
+        .and_then(|addr| addr.parse::<Address>().ok())
+        .unwrap_or_else(|| wallet.default_signer().address());
+
+    let proposer = OPSuccinctProposer::new(prover_address, l1_provider_with_wallet, factory)
+        .await
+        .unwrap();
     proposer.run().await.expect("Runs in an infinite loop");
 }

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -43,6 +43,9 @@ pub struct ProposerConfig {
     /// When game resolution is enabled, the proposer will attempt to resolve games that are
     /// unchallenged up to `max_games_to_check_for_resolution` games behind the latest game.
     pub max_games_to_check_for_resolution: u64,
+
+    /// The maximum number of games to check for bond claiming.
+    pub max_games_to_check_for_bond_claiming: u64,
 }
 
 impl ProposerConfig {
@@ -70,6 +73,9 @@ impl ProposerConfig {
                 .unwrap_or("true".to_string())
                 .parse()?,
             max_games_to_check_for_resolution: env::var("MAX_GAMES_TO_CHECK_FOR_RESOLUTION")
+                .unwrap_or("100".to_string())
+                .parse()?,
+            max_games_to_check_for_bond_claiming: env::var("MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING")
                 .unwrap_or("100".to_string())
                 .parse()?,
         })

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -68,6 +68,12 @@ sol! {
 
         /// @notice Returns the challenger bond amount.
         function challengerBond() external view returns (uint256 challengerBond_);
+
+        /// @notice Claim the credit belonging to the recipient address.
+        function claimCredit(address _recipient) external;
+
+        /// @notice Returns the credit balance of a given recipient.
+        function credit(address _recipient) external view returns (uint256 credit_);
     }
 
     #[allow(missing_docs)]
@@ -79,6 +85,9 @@ sol! {
     contract AnchorStateRegistry {
         /// @notice Returns the current anchor root.
         function getAnchorRoot() public view returns (Hash, uint256);
+
+        /// @notice Returns whether a game is finalized.
+        function isGameFinalized(IDisputeGame _game) public view returns (bool);
     }
 
     #[derive(Debug, PartialEq)]

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -143,10 +143,24 @@ where
         l2_provider: L2Provider,
     ) -> Result<Option<(U256, U256)>>;
 
+    /// Get the anchor state registry address.
+    async fn get_anchor_state_registry_address(&self, game_type: u32) -> Result<Address>;
+
     /// Get the anchor L2 block number.
     ///
     /// This function returns the L2 block number of the anchor game for a given game type.
     async fn get_anchor_l2_block_number(&self, game_type: u32) -> Result<U256>;
+
+    /// Check if a game is finalized.
+    async fn is_game_finalized(&self, game_type: u32, game_address: Address) -> Result<bool>;
+
+    /// Check if a game is claimable.
+    async fn is_claimable(
+        &self,
+        game_type: u32,
+        game_address: Address,
+        claimant: Address,
+    ) -> Result<bool>;
 
     /// Get the oldest game address with a given condition.
     async fn get_oldest_game_address<S, O>(
@@ -181,6 +195,20 @@ where
         &self,
         max_games_to_check_for_defense: u64,
         l2_provider: L2Provider,
+    ) -> Result<Option<Address>>;
+
+    /// Get the oldest game address with claimable bonds.
+    ///
+    /// Claimable games are games that have been finalized and have a determined bond distribution mode.
+    /// We check if the game is finalized by checking if it's not in progress (status is Resolved).
+    ///
+    /// This function checks a window of recent games, starting from
+    /// (latest_game_index - max_games_to_check_for_bond_claiming) up to latest_game_index.
+    async fn get_oldest_claimable_bond_game_address(
+        &self,
+        game_type: u32,
+        max_games_to_check_for_bond_claiming: u64,
+        claimant: Address,
     ) -> Result<Option<Address>>;
 
     /// Determines if we should attempt resolution or not. The `oldest_game_index` is configured
@@ -324,18 +352,73 @@ where
         Ok(Some((block_number, game_index)))
     }
 
+    /// Get the anchor state registry address.
+    async fn get_anchor_state_registry_address(&self, game_type: u32) -> Result<Address> {
+        let game_impl_address = self.gameImpls(game_type).call().await?._0;
+        let game_impl = OPSuccinctFaultDisputeGame::new(game_impl_address, self.provider());
+        let anchor_state_registry_address = game_impl.anchorStateRegistry().call().await?.registry_;
+        Ok(anchor_state_registry_address)
+    }
+
     /// Get the anchor L2 block number.
     ///
     /// This function returns the L2 block number of the anchor game for a given game type.
     async fn get_anchor_l2_block_number(&self, game_type: u32) -> Result<U256> {
-        let game_impl_address = self.gameImpls(game_type).call().await?._0;
-        let game_impl = OPSuccinctFaultDisputeGame::new(game_impl_address, self.provider());
-        let anchor_state_registry = AnchorStateRegistry::new(
-            game_impl.anchorStateRegistry().call().await?.registry_,
-            self.provider(),
-        );
+        let anchor_state_registry_address =
+            self.get_anchor_state_registry_address(game_type).await?;
+        let anchor_state_registry =
+            AnchorStateRegistry::new(anchor_state_registry_address, self.provider());
         let anchor_l2_block_number = anchor_state_registry.getAnchorRoot().call().await?._1;
         Ok(anchor_l2_block_number)
+    }
+
+    /// Check if a game is finalized.
+    async fn is_game_finalized(&self, game_type: u32, game_address: Address) -> Result<bool> {
+        let anchor_state_registry_address =
+            self.get_anchor_state_registry_address(game_type).await?;
+        let anchor_state_registry =
+            AnchorStateRegistry::new(anchor_state_registry_address, self.provider());
+        let is_finalized = anchor_state_registry
+            .isGameFinalized(game_address)
+            .call()
+            .await?;
+        Ok(is_finalized._0)
+    }
+
+    /// Check if a game is claimable.
+    async fn is_claimable(
+        &self,
+        game_type: u32,
+        game_address: Address,
+        claimant: Address,
+    ) -> Result<bool> {
+        let game = OPSuccinctFaultDisputeGame::new(game_address, self.provider());
+        let claim_data = game.claimData().call().await?.claimData_;
+
+        // NOTE(fakedev9999): This is a redundant check with the is_game_finalized check below,
+        // but we keep it for better game state tracking.
+        if claim_data.status != ProposalStatus::Resolved {
+            tracing::info!("Game {:?} is not resolved yet", game_address);
+            return Ok(false);
+        }
+
+        // Game must be finalized before claiming credit.
+        if !self.is_game_finalized(game_type, game_address).await? {
+            tracing::info!("Game {:?} is resolved but not finalized", game_address);
+            return Ok(false);
+        }
+
+        // Claimant must have credit left to claim.
+        if game.credit(claimant).call().await?.credit_ == U256::ZERO {
+            tracing::info!(
+                "Claimant {:?} has no credit to claim from game {:?}",
+                claimant,
+                game_address
+            );
+            return Ok(false);
+        }
+
+        Ok(true)
     }
 
     async fn get_oldest_game_address<S, O>(
@@ -444,6 +527,44 @@ where
         .await
     }
 
+    /// Get the oldest game address with claimable bonds.
+    ///
+    /// Claimable games are games that have been finalized and have a determined bond distribution mode.
+    /// We check if the game is finalized by checking if it's not in progress (status is Resolved).
+    ///
+    /// This function checks a window of recent games, starting from
+    /// (latest_game_index - max_games_to_check_for_bond_claiming) up to latest_game_index.
+    async fn get_oldest_claimable_bond_game_address(
+        &self,
+        game_type: u32,
+        max_games_to_check_for_bond_claiming: u64,
+        claimant: Address,
+    ) -> Result<Option<Address>> {
+        let latest_game_index = match self.fetch_latest_game_index().await? {
+            Some(index) => index,
+            None => {
+                tracing::info!("No games exist yet");
+                return Ok(None);
+            }
+        };
+
+        let oldest_game_index =
+            latest_game_index.saturating_sub(U256::from(max_games_to_check_for_bond_claiming));
+        let games_to_check = latest_game_index
+            .min(U256::from(max_games_to_check_for_bond_claiming))
+            .to::<u64>();
+
+        for i in 0..games_to_check {
+            let index = oldest_game_index + U256::from(i);
+            let game_address = self.fetch_game_address_by_index(index).await?;
+            if self.is_claimable(game_type, game_address, claimant).await? {
+                return Ok(Some(game_address));
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Determines if we should attempt resolution or not. The `oldest_game_index` is configured
     /// to be `latest_game_index` - `max_games_to_check_for_resolution`.
     ///
@@ -545,7 +666,7 @@ where
             .get_receipt()
             .await?;
         tracing::info!(
-            "Successfully resolved challenged game {:?} at index {:?} with tx {:?}",
+            "\x1b[1mSuccessfully resolved game {:?} at index {:?} with tx {:?}\x1b[0m",
             game_address,
             index,
             receipt.transaction_hash
@@ -589,7 +710,7 @@ where
             }
         } else {
             tracing::info!(
-                "Oldest game {:?} at index {:?} is not resolved, not attempting resolution",
+                "Oldest game {:?} at index {:?} has unresolved parent, not attempting resolution",
                 game_address,
                 oldest_game_index
             );

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -200,7 +200,7 @@ where
     /// Get the oldest game address with claimable bonds.
     ///
     /// Claimable games are games that have been finalized and have a determined bond distribution mode.
-    /// We check if the game is finalized by checking if it's not in progress (status is Resolved).
+    /// Check if the game is finalized by checking if it's not in progress (status is Resolved).
     ///
     /// This function checks a window of recent games, starting from
     /// (latest_game_index - max_games_to_check_for_bond_claiming) up to latest_game_index.
@@ -211,7 +211,7 @@ where
         claimant: Address,
     ) -> Result<Option<Address>>;
 
-    /// Determines if we should attempt resolution or not. The `oldest_game_index` is configured
+    /// Determines whether to attempt resolution or not. The `oldest_game_index` is configured
     /// to be `latest_game_index` - `max_games_to_check_for_resolution`.
     ///
     /// If the oldest game has no parent (i.e., it's a first game), we always attempt resolution.
@@ -396,7 +396,7 @@ where
         let claim_data = game.claimData().call().await?.claimData_;
 
         // NOTE(fakedev9999): This is a redundant check with the is_game_finalized check below,
-        // but we keep it for better game state tracking.
+        // but is useful for better logging.
         if claim_data.status != ProposalStatus::Resolved {
             tracing::info!("Game {:?} is not resolved yet", game_address);
             return Ok(false);
@@ -530,7 +530,7 @@ where
     /// Get the oldest game address with claimable bonds.
     ///
     /// Claimable games are games that have been finalized and have a determined bond distribution mode.
-    /// We check if the game is finalized by checking if it's not in progress (status is Resolved).
+    /// Check if the game is finalized by checking if it's not in progress (status is Resolved).
     ///
     /// This function checks a window of recent games, starting from
     /// (latest_game_index - max_games_to_check_for_bond_claiming) up to latest_game_index.
@@ -565,7 +565,7 @@ where
         Ok(None)
     }
 
-    /// Determines if we should attempt resolution or not. The `oldest_game_index` is configured
+    /// Determines whether to attempt resolution or not. The `oldest_game_index` is configured
     /// to be `latest_game_index` - `max_games_to_check_for_resolution`.
     ///
     /// If the oldest game has no parent (i.e., it's a first game), we always attempt resolution.


### PR DESCRIPTION
Adds feature to fp proposer for bond claiming from games that:
- Are finalized (resolved and airgapped)
- Has credit left to claim

Claim Credit test transaction: [tx](https://sepolia.etherscan.io/tx/0x391b21c540f96fda207abfbce54e4fa1a6cc1ccfce0ff7d478b79bb05aa3e6c1)