### PR TITLE
feat: remove deprecated #[clap] attribute

### DIFF
--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -22,7 +22,7 @@ use fault_proof::{
 
 #[derive(Parser)]
 struct Args {
-    #[clap(long, default_value = ".env.challenger")]
+    #[arg(long, default_value = ".env.challenger")]
     env_file: String,
 }
 

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -13,7 +13,7 @@ use fault_proof::{
 
 #[derive(Parser)]
 struct Args {
-    #[clap(long, default_value = ".env.proposer")]
+    #[arg(long, default_value = ".env.proposer")]
     env_file: String,
 }
 


### PR DESCRIPTION
updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.