### PR TITLE
feat: add `safe_db_fallback` flag

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -24,6 +24,7 @@
   - [Modifications to Original `L2OutputOracle`](./contracts/modifications.md)
 - [Fault Proofs](./fault_proofs/fault_proof_architecture.md)
   - [Quick Start](./fault_proofs/quick_start.md)
+  - [Best Practices](./fault_proofs/best_practices.md)
   - [Deploy FP Contracts](./fault_proofs/deploy.md)
   - [How to run the FP Proposer](./fault_proofs/proposer.md)
   - [How to run the FP Challenger](./fault_proofs/challenger.md)

--- a/book/advanced/proposer.md
+++ b/book/advanced/proposer.md
@@ -57,6 +57,8 @@ Before starting the proposer, ensure you have deployed the L2 Output Oracle and 
 | `PROVER_ADDRESS` | Address of the account that will be posting output roots to L1. This address is committed to when generating the aggregation proof to prevent front-running attacks. It can be different from the signing address if you want to separate these roles. Default: The address derived from the `PRIVATE_KEY` environment variable. |
 | `SIGNER_URL` | URL for the Web3Signer. Note: This takes precedence over the `PRIVATE_KEY` environment variable. |
 | `SIGNER_ADDRESS` | Address of the account that will be posting output roots to L1. Note: Only set this if the signer is a Web3Signer. Note: Required if `SIGNER_URL` is set. |
+| `NO_SAFE_DB` | Default: `true`. Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.  When `false`, proposer will panic if SafeDB is not available. |
+| `SAFE_DB_FALLBACK` | Default: `false`. Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.  When `false`, proposer will panic if SafeDB is not available. It is by default `false` since using the fallback mechanism will result in higher proving cost. |
 
 # Build the Proposer Service
 

--- a/book/advanced/proposer.md
+++ b/book/advanced/proposer.md
@@ -57,7 +57,6 @@ Before starting the proposer, ensure you have deployed the L2 Output Oracle and 
 | `PROVER_ADDRESS` | Address of the account that will be posting output roots to L1. This address is committed to when generating the aggregation proof to prevent front-running attacks. It can be different from the signing address if you want to separate these roles. Default: The address derived from the `PRIVATE_KEY` environment variable. |
 | `SIGNER_URL` | URL for the Web3Signer. Note: This takes precedence over the `PRIVATE_KEY` environment variable. |
 | `SIGNER_ADDRESS` | Address of the account that will be posting output roots to L1. Note: Only set this if the signer is a Web3Signer. Note: Required if `SIGNER_URL` is set. |
-| `NO_SAFE_DB` | Default: `true`. Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.  When `false`, proposer will panic if SafeDB is not available. |
 | `SAFE_DB_FALLBACK` | Default: `false`. Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.  When `false`, proposer will panic if SafeDB is not available. It is by default `false` since using the fallback mechanism will result in higher proving cost. |
 
 # Build the Proposer Service

--- a/book/fault_proofs/best_practices.md
+++ b/book/fault_proofs/best_practices.md
@@ -1,0 +1,16 @@
+# Best Practices
+
+This document covers best practices for OP Succinct Lite deployment setup.
+
+## SafeDB Configuration
+
+### Enabling SafeDB in op-node
+
+SafeDB is a critical component for efficient L1 head determination. When SafeDB is not enabled, the system falls back to timestamp-based L1 head estimation, which can lead to several issues:
+
+1. Less reliable derivation
+2. Potential cycle count blowup for derivation
+
+To enable SafeDB in your op-node, see [Consensus layer configuration options (op-node)](https://docs.optimism.io/operators/node-operators/configuration/consensus-config#safedbpath).
+
+This ensures that L1 head can be efficiently determined without relying on the more expensive fallback mechanism.

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -54,6 +54,7 @@ To get a whitelisted key on the Succinct Prover Network for OP Succinct, fill ou
 | `L1_BEACON_RPC` | L1 Beacon RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
 | `L2_NODE_RPC` | L2 Node RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
 | `PROVER_ADDRESS` | Address of the account that will be posting output roots to L1. This address is committed to when generating the aggregation proof to prevent front-running attacks. It can be different from the signing address if you want to separate these roles. Default: The address derived from the `PRIVATE_KEY` environment variable. | (Only used if `FAST_FINALITY_MODE` is `true`) |
+| `SAFE_DB_FALLBACK` | Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node. When `false`, proposer will return an error if SafeDB is not available. It is by default `false` since using the fallback mechanism will result in higher proving cost. | `false` |
 
 ```env
 # Required Configuration

--- a/book/fault_proofs/quick_start.md
+++ b/book/fault_proofs/quick_start.md
@@ -6,7 +6,7 @@ This guide provides the fastest path to try out OP Succinct fault dispute games 
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 - [Rust](https://www.rust-lang.org/tools/install) (latest stable version)
-- L1 and L2 archive node RPC endpoints
+- L1 and L2 archive node RPC endpoints. L2 node should be configured with SafeDB enabled. See [SafeDB Configuration](./best_practices.md#safe-db-configuration) for more details.
 - ETH on L1 for:
   - Contract deployment
   - Game bonds (configurable in factory)

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -46,6 +46,9 @@ pub struct ProposerConfig {
 
     /// The maximum number of games to check for bond claiming.
     pub max_games_to_check_for_bond_claiming: u64,
+
+    /// Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.
+    pub safe_db_fallback: bool,
 }
 
 impl ProposerConfig {
@@ -77,6 +80,9 @@ impl ProposerConfig {
                 .parse()?,
             max_games_to_check_for_bond_claiming: env::var("MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING")
                 .unwrap_or("100".to_string())
+                .parse()?,
+            safe_db_fallback: env::var("SAFE_DB_FALLBACK")
+                .unwrap_or("false".to_string())
                 .parse()?,
         })
     }

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -45,6 +45,7 @@ where
     pub l2_provider: L2Provider,
     pub factory: Arc<DisputeGameFactoryInstance<(), L1ProviderWithWallet<F, P>>>,
     pub init_bond: U256,
+    pub safe_db_fallback: bool,
     prover: SP1Prover,
     host: Arc<H>,
 }
@@ -74,6 +75,7 @@ where
             l2_provider: ProviderBuilder::default().on_http(config.l2_rpc),
             factory: Arc::new(factory.clone()),
             init_bond: factory.fetch_init_bond(config.game_type).await?,
+            safe_db_fallback: config.safe_db_fallback,
             prover: SP1Prover {
                 network_prover,
                 range_pk: Arc::new(range_pk),
@@ -105,6 +107,7 @@ where
                 l2_block_number.to::<u64>() - self.config.proposal_interval_in_blocks,
                 l2_block_number.to::<u64>(),
                 Some(l1_head_hash),
+                Some(self.config.safe_db_fallback),
             )
             .await
             .context("Failed to get host CLI args")?;

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -34,7 +34,14 @@ async fn main() -> Result<()> {
     let host = SingleChainOPSuccinctHost {
         fetcher: Arc::new(data_fetcher.clone()),
     };
-    let host_args = host.fetch(l2_start_block, l2_end_block, None).await?;
+    let host_args = host
+        .fetch(
+            l2_start_block,
+            l2_end_block,
+            None,
+            Some(args.safe_db_fallback),
+        )
+        .await?;
 
     debug!("Host args: {:?}", host_args);
 

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -27,7 +27,9 @@ async fn execute_batch() -> Result<()> {
         fetcher: Arc::new(data_fetcher.clone()),
     };
 
-    let host_args = host.fetch(l2_start_block, l2_end_block, None).await?;
+    let host_args = host
+        .fetch(l2_start_block, l2_end_block, None, Some(false))
+        .await?;
 
     let oracle = host.run(&host_args).await?;
 

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -223,7 +223,7 @@ async fn main() -> Result<()> {
     });
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            host.fetch(range.start, range.end, None)
+            host.fetch(range.start, range.end, None, Some(args.safe_db_fallback))
                 .await
                 .expect("Failed to get host CLI args")
         })

--- a/scripts/utils/bin/gen_sp1_test_artifacts.rs
+++ b/scripts/utils/bin/gen_sp1_test_artifacts.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     });
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            host.fetch(range.start, range.end, None)
+            host.fetch(range.start, range.end, None, Some(args.safe_db_fallback))
                 .await
                 .expect("Failed to get host CLI args")
         })

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -29,6 +29,9 @@ pub struct HostExecutorArgs {
     /// Whether to generate proofs.
     #[arg(long)]
     pub prove: bool,
+    /// Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.
+    #[clap(long)]
+    pub safe_db_fallback: bool,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -662,7 +662,7 @@ impl OPSuccinctDataFetcher {
 
     /// If the safeDB is activated, use it to fetch the L1 block where the batch including the data for the end L2 block was posted.
     /// If the safeDB is not activated:
-    ///   - If the `SAFE_DB_FALLBACK` flag is set to `true`, estimate the L1 head based on the L2 block timestamp.
+    ///   - If `safe_db_fallback` is `true`, estimate the L1 head based on the L2 block timestamp.
     ///   - Else, return an error.
     async fn get_l1_head(&self, l2_end_block: u64, safe_db_fallback: bool) -> Result<(B256, u64)> {
         if self.rollup_config.is_none() {

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -660,27 +660,38 @@ impl OPSuccinctDataFetcher {
         })
     }
 
-    /// If the safeDB is not activated, then  estimate the L1 head based on the timestamp of the L2 block and the finalized L1 block.
-    async fn get_l1_head(&self, l2_end_block: u64) -> Result<(B256, u64)> {
+    /// If the safeDB is activated, use it to fetch the L1 block where the batch including the data for the end L2 block was posted.
+    /// If the safeDB is not activated:
+    ///   - If the `SAFE_DB_FALLBACK` flag is set to `true`, estimate the L1 head based on the L2 block timestamp.
+    ///   - Else, return an error.
+    async fn get_l1_head(&self, l2_end_block: u64, safe_db_fallback: bool) -> Result<(B256, u64)> {
         if self.rollup_config.is_none() {
             return Err(anyhow::anyhow!("Rollup config not loaded."));
         }
 
         match self.get_safe_l1_block_for_l2_block(l2_end_block).await {
             Ok(safe_head) => Ok(safe_head),
-            Err(_) => {
-                tracing::warn!("SafeDB not activated - falling back to timestamp-based L1 head estimation. WARNING: This fallback method is more expensive and less reliable. Derivation may fail if the L2 block batch is posted after our estimated L1 head. Enable SafeDB on op-node to fix this.");
-                // Fallback: estimate L1 block based on timestamp
-                let max_batch_post_delay_minutes = 40;
-                let l2_block_timestamp = self.get_l2_header(l2_end_block.into()).await?.timestamp;
-                let finalized_l1_timestamp =
-                    self.get_l1_header(BlockId::finalized()).await?.timestamp;
+            Err(e) => {
+                if safe_db_fallback {
+                    tracing::warn!("SafeDB not activated - falling back to timestamp-based L1 head estimation. WARNING: This fallback method is more expensive and less reliable. Derivation may fail if the L2 block batch is posted after our estimated L1 head. Enable SafeDB on op-node to fix this.");
+                    // Fallback: estimate L1 block based on timestamp
+                    let max_batch_post_delay_minutes = 40;
+                    let l2_block_timestamp =
+                        self.get_l2_header(l2_end_block.into()).await?.timestamp;
+                    let finalized_l1_timestamp =
+                        self.get_l1_header(BlockId::finalized()).await?.timestamp;
 
-                let target_timestamp = min(
-                    l2_block_timestamp + (max_batch_post_delay_minutes * 60),
-                    finalized_l1_timestamp,
-                );
-                self.find_l1_block_by_timestamp(target_timestamp).await
+                    let target_timestamp = min(
+                        l2_block_timestamp + (max_batch_post_delay_minutes * 60),
+                        finalized_l1_timestamp,
+                    );
+                    self.find_l1_block_by_timestamp(target_timestamp).await
+                } else {
+                    Err(anyhow::anyhow!(
+                        "SafeDB is not activated on your op-node and the `SAFE_DB_FALLBACK` flag is set to false. Please enable the safeDB on your op-node to fix this, or set `SAFE_DB_FALLBACK` flag to true, which will be more expensive: {}",
+                        e
+                    ))
+                }
             }
         }
     }
@@ -740,6 +751,7 @@ impl OPSuccinctDataFetcher {
         l2_start_block: u64,
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
+        safe_db_fallback: bool,
     ) -> Result<SingleChainHost> {
         // If the rollup config is not already loaded, fetch and save it.
         if self.rollup_config.is_none() {
@@ -810,7 +822,7 @@ impl OPSuccinctDataFetcher {
         let l1_head_hash = match l1_head_hash {
             Some(l1_head_hash) => l1_head_hash,
             None => {
-                let (_, l1_head_number) = self.get_l1_head(l2_end_block).await?;
+                let (_, l1_head_number) = self.get_l1_head(l2_end_block, safe_db_fallback).await?;
 
                 // FIXME: Investigate requirement for L1 head offset beyond batch posting block with safe head > L2 end block.
                 let l1_head_number = l1_head_number + 20;

--- a/utils/host/src/hosts/default.rs
+++ b/utils/host/src/hosts/default.rs
@@ -37,10 +37,16 @@ impl OPSuccinctHost for SingleChainOPSuccinctHost {
         l2_start_block: u64,
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
+        safe_db_fallback: Option<bool>,
     ) -> Result<SingleChainHost> {
         let host = self
             .fetcher
-            .get_host_args(l2_start_block, l2_end_block, l1_head_hash)
+            .get_host_args(
+                l2_start_block,
+                l2_end_block,
+                l1_head_hash,
+                safe_db_fallback.expect("`safe_db_fallback` must be set"),
+            )
             .await?;
         Ok(host)
     }

--- a/utils/host/src/hosts/mod.rs
+++ b/utils/host/src/hosts/mod.rs
@@ -34,7 +34,7 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
         Ok(in_memory_oracle)
     }
 
-    /// Fetch the host arguments. Optionally supply an L1 block number which is used as the L1 origin.
+    /// Fetch the host arguments.
     ///
     /// Parameters:
     /// - `l2_start_block`: The starting L2 block number

--- a/utils/host/src/hosts/mod.rs
+++ b/utils/host/src/hosts/mod.rs
@@ -35,11 +35,19 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
     }
 
     /// Fetch the host arguments. Optionally supply an L1 block number which is used as the L1 origin.
+    ///
+    /// Parameters:
+    /// - `l2_start_block`: The starting L2 block number
+    /// - `l2_end_block`: The ending L2 block number
+    /// - `l1_head_hash`: Optionally supplied L1 head block hash used as the L1 origin.
+    /// - `safe_db_fallback`: Optionally supplied flag to indicate whether to fallback to timestamp-based L1 head estimation
+    ///   when SafeDB is not available. This is optional to support abstraction across different node implementations.
     async fn fetch(
         &self,
         l2_start_block: u64,
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
+        safe_db_fallback: Option<bool>,
     ) -> Result<Self::Args>;
 }
 

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<()> {
         submission_interval: env_config.submission_interval,
         mock: env_config.mock,
         prover_address: env_config.prover_address,
+        safe_db_fallback: env_config.safe_db_fallback,
     };
 
     // Read all config from env vars. If both signer_url and signer_address are provided, use Web3Signer.

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -26,6 +26,7 @@ pub struct EnvironmentConfig {
     pub mock: bool,
     pub signer_url: Option<Url>,
     pub signer_address: Option<Address>,
+    pub safe_db_fallback: bool,
 }
 
 /// Helper function to get environment variables with a default value and parse them.
@@ -109,6 +110,7 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         loop_interval,
         signer_url,
         signer_address,
+        safe_db_fallback: get_env_var("SAFE_DB_FALLBACK", Some(false))?,
     };
 
     Ok(config)

--- a/validity/src/proof_requester.rs
+++ b/validity/src/proof_requester.rs
@@ -28,6 +28,7 @@ pub struct OPSuccinctProofRequester<H: OPSuccinctHost> {
     pub range_strategy: FulfillmentStrategy,
     pub agg_strategy: FulfillmentStrategy,
     pub agg_mode: SP1ProofMode,
+    pub safe_db_fallback: bool,
 }
 
 impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
@@ -42,6 +43,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
         range_strategy: FulfillmentStrategy,
         agg_strategy: FulfillmentStrategy,
         agg_mode: SP1ProofMode,
+        safe_db_fallback: bool,
     ) -> Self {
         Self {
             host,
@@ -53,6 +55,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             range_strategy,
             agg_strategy,
             agg_mode,
+            safe_db_fallback,
         }
     }
 
@@ -60,7 +63,12 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
     pub async fn range_proof_witnessgen(&self, request: &OPSuccinctRequest) -> Result<SP1Stdin> {
         let host_args = self
             .host
-            .fetch(request.start_block as u64, request.end_block as u64, None)
+            .fetch(
+                request.start_block as u64,
+                request.end_block as u64,
+                None,
+                Some(self.safe_db_fallback),
+            )
             .await?;
         let mem_kv_store = self.host.run(&host_args).await?;
         let sp1_stdin = get_proof_stdin(mem_kv_store).context("Failed to get proof stdin")?;

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -73,6 +73,8 @@ pub struct RequesterConfig {
     pub agg_proof_strategy: FulfillmentStrategy,
     pub agg_proof_mode: SP1ProofMode,
     pub mock: bool,
+    /// Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node.
+    pub safe_db_fallback: bool,
 }
 
 /// Configuration for the driver.
@@ -153,6 +155,7 @@ where
             requester_config.range_proof_strategy,
             requester_config.agg_proof_strategy,
             requester_config.agg_proof_mode,
+            requester_config.safe_db_fallback,
         ));
 
         let l2oo_contract =


### PR DESCRIPTION
Adds `no_safe_db` flag.

This flag determines whether to fallback to timestamp-based L1 head estimation even though SafeDB is not activated for op-node. When set `false`, proposer will panic if SafeDB is not available.

SafeDB is a critical component for efficient L1 head determination. When SafeDB is not enabled, the system falls back to timestamp-based L1 head estimation, which can lead to several issues:

1. Less reliable derivation
2. Potential cycle count blowup for derivation