### PR TITLE
feat(validity): handle proof request timeout

### DIFF
--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -313,6 +313,18 @@ where
                 .get_proof_status(B256::from_slice(proof_request_id))
                 .await?;
 
+            // Check if current time exceeds deadline. If so, the proof has timed out.
+            let current_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            if current_time > status.deadline {
+                return Err(anyhow!(
+                    "Proof request has timed out for request id: {:?}",
+                    proof_request_id
+                ));
+            }
+
             let execution_status = ExecutionStatus::try_from(status.execution_status)
                 .context("Failed to convert execution status to ExecutionStatus.")?;
             let fulfillment_status = FulfillmentStatus::try_from(status.fulfillment_status)

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -319,6 +319,10 @@ where
                 .unwrap()
                 .as_secs();
             if current_time > status.deadline {
+                self.proof_requester
+                    .retry_request(request.clone(), status.execution_status())
+                    .await?;
+
                 return Err(anyhow!(
                     "Proof request has timed out for request id: {:?}",
                     proof_request_id

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -323,10 +323,12 @@ where
                     .retry_request(request.clone(), status.execution_status())
                     .await?;
 
-                return Err(anyhow!(
+                tracing::error!(
                     "Proof request has timed out for request id: {:?}",
                     proof_request_id
-                ));
+                );
+
+                return Ok(());
             }
 
             // If the proof request has been fulfilled, update the request to status Complete and add the proof bytes to the database.


### PR DESCRIPTION
If the proof requests are made asynchronously to the prover network, timeout should be handled by checking the deadline of the proof request.
