### PR TITLE
feat: Add `OPSuccinctHost` trait

### DIFF
--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           # Build the binaries
           cd programs/range
-          ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-bump --docker --tag v4.1.2 --output-directory ../../elf
-          ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-embedded --docker --tag v4.1.2 --output-directory ../../elf --features embedded
+          ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-bump --docker --tag v4.1.3 --output-directory ../../elf
+          ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-embedded --docker --tag v4.1.3 --output-directory ../../elf --features embedded
           cd ../aggregation
-          ~/.sp1/bin/cargo-prove prove build --elf-name aggregation-elf --docker --tag v4.1.2 --output-directory ../../elf
+          ~/.sp1/bin/cargo-prove prove build --elf-name aggregation-elf --docker --tag v4.1.3 --output-directory ../../elf
           cd ../../
 
           # Check for any changes in the elf directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4643,6 +4643,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "async-trait",
+ "clap",
  "futures",
  "kona-genesis",
  "kona-host",
@@ -4660,6 +4661,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sp1-sdk",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4642,6 +4642,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-sol-types",
  "anyhow",
+ "async-trait",
  "futures",
  "kona-genesis",
  "kona-host",

--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -22,7 +22,7 @@ use fault_proof::{
 
 #[derive(Parser)]
 struct Args {
-    #[clap(long, default_value = ".env.challenger")]
+    #[arg(long, default_value = ".env.challenger")]
     env_file: String,
 }
 

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -1,24 +1,27 @@
-use std::env;
+use std::{env, sync::Arc};
 
 use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_transport_http::reqwest::Url;
+use anyhow::Result;
 use clap::Parser;
-use op_alloy_network::EthereumWallet;
-
 use fault_proof::{
     contract::DisputeGameFactory, proposer::OPSuccinctProposer, utils::setup_logging,
+};
+use op_alloy_network::EthereumWallet;
+use op_succinct_host_utils::{
+    fetcher::OPSuccinctDataFetcher, hosts::default::SingleChainOPSuccinctHost,
 };
 
 #[derive(Parser)]
 struct Args {
-    #[clap(long, default_value = ".env.proposer")]
+    #[arg(long, default_value = ".env.proposer")]
     env_file: String,
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     setup_logging();
 
     let args = Args::parse();
@@ -49,8 +52,18 @@ async fn main() {
         .and_then(|addr| addr.parse::<Address>().ok())
         .unwrap_or_else(|| wallet.default_signer().address());
 
-    let proposer = OPSuccinctProposer::new(prover_address, l1_provider_with_wallet, factory)
-        .await
-        .unwrap();
-    proposer.run().await.expect("Runs in an infinite loop");
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+    let proposer = OPSuccinctProposer::new(
+        prover_address,
+        l1_provider_with_wallet,
+        factory,
+        Arc::new(SingleChainOPSuccinctHost {
+            fetcher: Arc::new(fetcher),
+        }),
+    )
+    .await
+    .unwrap();
+    proposer.run().await?;
+
+    Ok(())
 }

--- a/fault-proof/tests/integration.rs
+++ b/fault-proof/tests/integration.rs
@@ -7,6 +7,7 @@ use alloy_transport_http::reqwest::Url;
 use anyhow::Context;
 use anyhow::Result;
 use op_alloy_network::EthereumWallet;
+use op_succinct_host_utils::hosts::default::SingleChainOPSuccinctHost;
 use tokio::time::Duration;
 
 use fault_proof::{
@@ -46,6 +47,7 @@ async fn test_proposer_defends_successfully() -> Result<()> {
         wallet.default_signer().address(),
         l1_provider_with_wallet.clone(),
         factory.clone(),
+        SingleChainOPSuccinctHost { fetcher },
     )
     .await
     .unwrap();

--- a/fault-proof/tests/integration.rs
+++ b/fault-proof/tests/integration.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::sync::Arc;
 
 use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
@@ -7,6 +8,7 @@ use alloy_transport_http::reqwest::Url;
 use anyhow::Context;
 use anyhow::Result;
 use op_alloy_network::EthereumWallet;
+use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
 use op_succinct_host_utils::hosts::default::SingleChainOPSuccinctHost;
 use tokio::time::Duration;
 
@@ -43,11 +45,14 @@ async fn test_proposer_defends_successfully() -> Result<()> {
         l1_provider_with_wallet.clone(),
     );
 
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
     let proposer = OPSuccinctProposer::new(
         wallet.default_signer().address(),
         l1_provider_with_wallet.clone(),
         factory.clone(),
-        SingleChainOPSuccinctHost { fetcher },
+        Arc::new(SingleChainOPSuccinctHost {
+            fetcher: Arc::new(fetcher),
+        }),
     )
     .await
     .unwrap();

--- a/scripts/fees/bin/l1_fee_scalar.rs
+++ b/scripts/fees/bin/l1_fee_scalar.rs
@@ -8,13 +8,13 @@ use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
 
 #[derive(Parser)]
 struct Args {
-    #[clap(long)]
+    #[arg(long)]
     start: u64,
-    #[clap(long)]
+    #[arg(long)]
     end: u64,
-    #[clap(long, default_value = None)]
+    #[arg(long, default_value = None)]
     l1_fee_scalar: Option<U256>,
-    #[clap(long, default_value = ".env")]
+    #[arg(long, default_value = ".env")]
     env_file: String,
 }
 

--- a/scripts/utils/bin/block_data.rs
+++ b/scripts/utils/bin/block_data.rs
@@ -12,13 +12,13 @@ use std::{
 #[derive(Debug, Clone, Parser)]
 struct BlockDataArgs {
     /// The start block of the range to execute.
-    #[clap(long)]
+    #[arg(long)]
     start: u64,
     /// The end block of the range to execute.
-    #[clap(long)]
+    #[arg(long)]
     end: u64,
     /// The environment file to use.
-    #[clap(long, default_value = ".env")]
+    #[arg(long, default_value = ".env")]
     env_file: PathBuf,
 }
 

--- a/scripts/utils/bin/gen_sp1_test_artifacts.rs
+++ b/scripts/utils/bin/gen_sp1_test_artifacts.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
 
     let mut successful_ranges = Vec::new();
     for (range, host_args) in split_ranges.iter().zip(host_args.iter()) {
-        let oracle = host.run(&host_args).await.unwrap();
+        let oracle = host.run(host_args).await.unwrap();
         let sp1_stdin = get_proof_stdin(oracle).unwrap();
         successful_ranges.push((sp1_stdin, range.clone()));
     }

--- a/scripts/utils/bin/gen_sp1_test_artifacts.rs
+++ b/scripts/utils/bin/gen_sp1_test_artifacts.rs
@@ -4,14 +4,17 @@ use futures::StreamExt;
 use log::info;
 use op_succinct_host_utils::{
     block_range::{get_validated_block_range, split_range_basic},
-    fetcher::{CacheMode, OPSuccinctDataFetcher},
-    get_proof_stdin, start_server_and_native_client, RANGE_ELF_EMBEDDED,
+    fetcher::OPSuccinctDataFetcher,
+    get_proof_stdin,
+    hosts::{default::SingleChainOPSuccinctHost, OPSuccinctHost},
+    RANGE_ELF_EMBEDDED,
 };
 use op_succinct_scripts::HostExecutorArgs;
 use sp1_sdk::utils;
 use std::{
     fs::{self},
     path::PathBuf,
+    sync::Arc,
 };
 
 #[tokio::main]
@@ -34,17 +37,13 @@ async fn main() -> Result<()> {
         split_ranges
     );
 
-    let cache_mode = if args.use_cache {
-        CacheMode::KeepCache
-    } else {
-        CacheMode::DeleteCache
-    };
-
     // Get the host CLIs in order, in parallel.
+    let host = Arc::new(SingleChainOPSuccinctHost {
+        fetcher: Arc::new(data_fetcher),
+    });
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            data_fetcher
-                .get_host_args(range.start, range.end, None, cache_mode)
+            host.fetch(range.start, range.end, None)
                 .await
                 .expect("Failed to get host CLI args")
         })
@@ -54,9 +53,7 @@ async fn main() -> Result<()> {
 
     let mut successful_ranges = Vec::new();
     for (range, host_args) in split_ranges.iter().zip(host_args.iter()) {
-        let oracle = start_server_and_native_client(host_args.clone())
-            .await
-            .unwrap();
+        let oracle = host.run(&host_args).await.unwrap();
         let sp1_stdin = get_proof_stdin(oracle).unwrap();
         successful_ranges.push((sp1_stdin, range.clone()));
     }

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -1,38 +1,42 @@
 use clap::Parser;
+use op_succinct_host_utils::DAConfig;
 use std::path::PathBuf;
 
 /// The arguments for the host executable.
 #[derive(Debug, Clone, Parser)]
 pub struct HostExecutorArgs {
     /// The start block of the range to execute.
-    #[clap(long)]
+    #[arg(long)]
     pub start: Option<u64>,
     /// The end block of the range to execute.
-    #[clap(long)]
+    #[arg(long)]
     pub end: Option<u64>,
     /// The number of blocks to execute in a single batch.
-    #[clap(long, default_value = "10")]
+    #[arg(long, default_value = "10")]
     pub batch_size: u64,
     /// Use cached witness generation.
-    #[clap(long)]
+    #[arg(long)]
     pub use_cache: bool,
     /// Use a fixed recent range.
-    #[clap(long)]
+    #[arg(long)]
     pub rolling: bool,
     /// The number of blocks to use for the default range.
-    #[clap(long, default_value = "5")]
+    #[arg(long, default_value = "5")]
     pub default_range: u64,
     /// The environment file to use.
-    #[clap(long, default_value = ".env")]
+    #[arg(long, default_value = ".env")]
     pub env_file: PathBuf,
     /// Whether to generate proofs.
-    #[clap(long)]
+    #[arg(long)]
     pub prove: bool,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ConfigArgs {
     /// The environment file to use.
-    #[clap(long)]
+    #[arg(long)]
     pub env_file: Option<PathBuf>,
+    /// The DA configuration to use.
+    #[arg(long, value_enum, default_value_t = DAConfig::Default)]
+    pub da_config: DAConfig,
 }

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -32,7 +32,11 @@ fn build_program(program_name: &str, elf_name: &str, features: Option<Vec<String
 /// Build all the native programs and the native host runner. Optional flag to build the zkVM
 /// programs.
 pub fn build_all() {
-    // build_program("aggregation", "aggregation-elf", None);
-    // build_program("range", "range-elf-bump", None);
-    // build_program("range", "range-elf-embedded", Some(vec!["embedded".to_string()]));
+    build_program("aggregation", "aggregation-elf", None);
+    build_program("range", "range-elf-bump", None);
+    build_program(
+        "range",
+        "range-elf-embedded",
+        Some(vec!["embedded".to_string()]),
+    );
 }

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -1,46 +1,40 @@
-#[allow(unused)]
 use sp1_build::{build_program_with_args, BuildArgs};
+
+#[allow(unused)]
+fn build_program(program_name: &str, elf_name: &str, features: Option<Vec<String>>) {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("Failed to get cargo metadata");
+
+    let mut build_args = BuildArgs {
+        elf_name: Some(elf_name.to_string()),
+        output_directory: Some("../../elf".to_string()),
+        docker: true,
+        tag: "v4.1.3".to_string(),
+        workspace_directory: Some("../../".to_string()),
+        ..Default::default()
+    };
+
+    if let Some(features) = features {
+        build_args.features = features;
+    }
+
+    build_program_with_args(
+        &format!(
+            "{}/{}",
+            metadata.workspace_root.join("programs"),
+            program_name
+        ),
+        build_args,
+    );
+}
 
 /// Build all the native programs and the native host runner. Optional flag to build the zkVM
 /// programs.
 pub fn build_all() {
-    // let metadata = cargo_metadata::MetadataCommand::new()
-    //     .exec()
-    //     .expect("Failed to get cargo metadata");
-    // build_program_with_args(
-    //     &format!("{}/{}", metadata.workspace_root.join("programs"), "aggregation"),
-    //     BuildArgs {
-    //         elf_name: Some("aggregation-elf".to_string()),
-    //         output_directory: Some("../../elf".to_string()),
-    //         docker: true,
-    //         tag: "v4.1.3".to_string(),
-    //         workspace_directory: Some("../../".to_string()),
-    //         ..Default::default()
-    //     },
-    // );
-
-    // build_program_with_args(
-    //     &format!("{}/{}", metadata.workspace_root.join("programs"), "range"),
-    //     BuildArgs {
-    //         elf_name: Some("range-elf-bump".to_string()),
-    //         output_directory: Some("../../elf".to_string()),
-    //         docker: true,
-    //         tag: "v4.1.3".to_string(),
-    //         workspace_directory: Some("../../".to_string()),
-    //         ..Default::default()
-    //     },
-    // );
-
-    // build_program_with_args(
-    //     &format!("{}/{}", metadata.workspace_root.join("programs"), "range"),
-    //     BuildArgs {
-    //         elf_name: Some("range-elf-embedded".to_string()),
-    //         output_directory: Some("../../elf".to_string()),
-    //         docker: true,
-    //         tag: "v4.1.3".to_string(),
-    //         workspace_directory: Some("../../".to_string()),
-    //         features: vec!["embedded".to_string()],
-    //         ..Default::default()
-    //     },
-    // );
+    // build_program("aggregation", "aggregation-elf", None);
+    // build_program("range", "range-elf-bump", None);
+    // build_program("range", "range-elf-embedded", Some(vec!["embedded".to_string()]));
+    // build_program("range", "celestia-range-elf-embedded", Some(vec!["embedded".to_string(), "celestia".to_string()]));
+    // build_program("range", "eigenda-range-elf-embedded", Some(vec!["embedded".to_string(), "eigenda".to_string()]));
 }

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -32,11 +32,11 @@ fn build_program(program_name: &str, elf_name: &str, features: Option<Vec<String
 /// Build all the native programs and the native host runner. Optional flag to build the zkVM
 /// programs.
 pub fn build_all() {
-    build_program("aggregation", "aggregation-elf", None);
-    build_program("range", "range-elf-bump", None);
-    build_program(
-        "range",
-        "range-elf-embedded",
-        Some(vec!["embedded".to_string()]),
-    );
+    // build_program("aggregation", "aggregation-elf", None);
+    // build_program("range", "range-elf-bump", None);
+    // build_program(
+    //     "range",
+    //     "range-elf-embedded",
+    //     Some(vec!["embedded".to_string()]),
+    // );
 }

--- a/utils/build/src/lib.rs
+++ b/utils/build/src/lib.rs
@@ -35,6 +35,4 @@ pub fn build_all() {
     // build_program("aggregation", "aggregation-elf", None);
     // build_program("range", "range-elf-bump", None);
     // build_program("range", "range-elf-embedded", Some(vec!["embedded".to_string()]));
-    // build_program("range", "celestia-range-elf-embedded", Some(vec!["embedded".to_string(), "celestia".to_string()]));
-    // build_program("range", "eigenda-range-elf-embedded", Some(vec!["embedded".to_string(), "eigenda".to_string()]));
 }

--- a/utils/client/src/client.rs
+++ b/utils/client/src/client.rs
@@ -155,7 +155,6 @@ where
         output_root = output_root
     );
 
-    // Only need to forget resources on non-zkvm targets
     #[cfg(target_os = "zkvm")]
     {
         std::mem::forget(driver);

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 # sp1
 sp1-sdk.workspace = true
+async-trait.workspace = true
 
 # local
 op-succinct-client-utils.workspace = true

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -50,5 +50,3 @@ strum_macros = "0.27.1"
 strum = "0.27.1"
 
 [features]
-celestia = []
-eigenda = []

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 
 # sp1
 sp1-sdk.workspace = true
-async-trait.workspace = true
 
 # local
 op-succinct-client-utils.workspace = true
@@ -45,3 +44,11 @@ num-format.workspace = true
 serde.workspace = true
 reqwest.workspace = true
 tracing.workspace = true
+async-trait.workspace = true
+clap.workspace = true
+strum_macros = "0.27.1"
+strum = "0.27.1"
+
+[features]
+celestia = []
+eigenda = []

--- a/utils/host/src/hosts/default.rs
+++ b/utils/host/src/hosts/default.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use kona_host::single::SingleChainHost;
+use kona_preimage::BidirectionalChannel;
 use op_succinct_client_utils::InMemoryOracle;
 
 use crate::fetcher::OPSuccinctDataFetcher;
 use crate::hosts::OPSuccinctHost;
 use anyhow::Result;
-use kona_preimage::BidirectionalChannel;
 
 #[derive(Clone)]
 pub struct SingleChainOPSuccinctHost {
@@ -19,9 +19,6 @@ pub struct SingleChainOPSuccinctHost {
 impl OPSuccinctHost for SingleChainOPSuccinctHost {
     type Args = SingleChainHost;
 
-    /// Run the host and client program.
-    ///
-    /// Returns the in-memory oracle which can be supplied to the zkVM.
     async fn run(&self, args: &Self::Args) -> Result<InMemoryOracle> {
         let hint = BidirectionalChannel::new()?;
         let preimage = BidirectionalChannel::new()?;
@@ -40,10 +37,12 @@ impl OPSuccinctHost for SingleChainOPSuccinctHost {
         l2_start_block: u64,
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
-    ) -> Result<Self::Args> {
-        self.fetcher
+    ) -> Result<SingleChainHost> {
+        let host = self
+            .fetcher
             .get_host_args(l2_start_block, l2_end_block, l1_head_hash)
-            .await
+            .await?;
+        Ok(host)
     }
 }
 

--- a/utils/host/src/hosts/default.rs
+++ b/utils/host/src/hosts/default.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use async_trait::async_trait;
+use kona_host::single::SingleChainHost;
+use op_succinct_client_utils::InMemoryOracle;
+
+use crate::fetcher::OPSuccinctDataFetcher;
+use crate::hosts::OPSuccinctHost;
+use anyhow::Result;
+use kona_preimage::BidirectionalChannel;
+
+#[derive(Clone)]
+pub struct SingleChainOPSuccinctHost {
+    pub fetcher: Arc<OPSuccinctDataFetcher>,
+}
+
+#[async_trait]
+impl OPSuccinctHost for SingleChainOPSuccinctHost {
+    type Args = SingleChainHost;
+
+    /// Run the host and client program.
+    ///
+    /// Returns the in-memory oracle which can be supplied to the zkVM.
+    async fn run(&self, args: &Self::Args) -> Result<InMemoryOracle> {
+        let hint = BidirectionalChannel::new()?;
+        let preimage = BidirectionalChannel::new()?;
+
+        let server_task = args.start_server(hint.host, preimage.host).await?;
+
+        let in_memory_oracle = Self::run_witnessgen_client(preimage.client, hint.client).await?;
+        // Unlike the upstream, manually abort the server task, as it will hang if you wait for both tasks to complete.
+        server_task.abort();
+
+        Ok(in_memory_oracle)
+    }
+
+    async fn fetch(
+        &self,
+        l2_start_block: u64,
+        l2_end_block: u64,
+        l1_head_hash: Option<B256>,
+    ) -> Result<Self::Args> {
+        self.fetcher
+            .get_host_args(l2_start_block, l2_end_block, l1_head_hash)
+            .await
+    }
+}
+
+impl SingleChainOPSuccinctHost {
+    pub fn new(fetcher: Arc<OPSuccinctDataFetcher>) -> Self {
+        Self { fetcher }
+    }
+}

--- a/utils/host/src/hosts/mod.rs
+++ b/utils/host/src/hosts/mod.rs
@@ -1,0 +1,43 @@
+pub mod celestia;
+pub mod default;
+
+use alloy_primitives::B256;
+use anyhow::Result;
+use async_trait::async_trait;
+use kona_preimage::{HintWriter, NativeChannel, OracleReader};
+use op_succinct_client_utils::client::run_opsuccinct_client;
+use op_succinct_client_utils::precompiles::zkvm_handle_register;
+use op_succinct_client_utils::{InMemoryOracle, StoreOracle};
+use std::sync::Arc;
+
+#[async_trait]
+pub trait OPSuccinctHost: Send + Sync + 'static {
+    type Args: Clone + Sync + Send + 'static;
+
+    /// Run the host and client program.
+    ///
+    /// Returns the in-memory oracle which can be supplied to the zkVM.
+    async fn run(&self, args: &Self::Args) -> Result<InMemoryOracle>;
+
+    /// Run the witness generation client.
+    async fn run_witnessgen_client(
+        preimage_chan: NativeChannel,
+        hint_chan: NativeChannel,
+    ) -> Result<InMemoryOracle> {
+        let oracle = Arc::new(StoreOracle::new(
+            OracleReader::new(preimage_chan),
+            HintWriter::new(hint_chan),
+        ));
+        run_opsuccinct_client(oracle.clone(), Some(zkvm_handle_register)).await?;
+        let in_memory_oracle = InMemoryOracle::populate_from_store(oracle.as_ref())?;
+        Ok(in_memory_oracle)
+    }
+
+    /// Fetch the host arguments. Optionally supply an L1 block number which is used as the L1 origin.
+    async fn fetch(
+        &self,
+        l2_start_block: u64,
+        l2_end_block: u64,
+        l1_head_hash: Option<B256>,
+    ) -> Result<Self::Args>;
+}

--- a/utils/host/src/hosts/mod.rs
+++ b/utils/host/src/hosts/mod.rs
@@ -44,7 +44,7 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
 }
 
 /// Initialize the host.
-/// 
+///
 /// In the future, there will be a feature gated function to initialize the host (ex. for Alt-DA).
 pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<SingleChainOPSuccinctHost> {
     Arc::new(SingleChainOPSuccinctHost::new(fetcher))

--- a/utils/host/src/hosts/mod.rs
+++ b/utils/host/src/hosts/mod.rs
@@ -1,6 +1,4 @@
-pub mod celestia;
 pub mod default;
-pub mod eigenda;
 
 use crate::fetcher::OPSuccinctDataFetcher;
 use alloy_primitives::B256;
@@ -45,17 +43,9 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
     ) -> Result<Self::Args>;
 }
 
-#[cfg(feature = "celestia")]
-pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<CelestiaChainHost> {
-    todo!()
-}
-
-#[cfg(feature = "eigenda")]
-pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<EigenDAChainHost> {
-    todo!()
-}
-
-#[cfg(not(any(feature = "celestia", feature = "eigenda")))]
+/// Initialize the host.
+/// 
+/// In the future, there will be a feature gated function to initialize the host (ex. for Alt-DA).
 pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<SingleChainOPSuccinctHost> {
     Arc::new(SingleChainOPSuccinctHost::new(fetcher))
 }

--- a/utils/host/src/hosts/mod.rs
+++ b/utils/host/src/hosts/mod.rs
@@ -1,9 +1,12 @@
 pub mod celestia;
 pub mod default;
+pub mod eigenda;
 
+use crate::fetcher::OPSuccinctDataFetcher;
 use alloy_primitives::B256;
 use anyhow::Result;
 use async_trait::async_trait;
+use default::SingleChainOPSuccinctHost;
 use kona_preimage::{HintWriter, NativeChannel, OracleReader};
 use op_succinct_client_utils::client::run_opsuccinct_client;
 use op_succinct_client_utils::precompiles::zkvm_handle_register;
@@ -12,7 +15,7 @@ use std::sync::Arc;
 
 #[async_trait]
 pub trait OPSuccinctHost: Send + Sync + 'static {
-    type Args: Clone + Sync + Send + 'static;
+    type Args: Send + Sync + 'static + Clone;
 
     /// Run the host and client program.
     ///
@@ -40,4 +43,19 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
     ) -> Result<Self::Args>;
+}
+
+#[cfg(feature = "celestia")]
+pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<CelestiaChainHost> {
+    todo!()
+}
+
+#[cfg(feature = "eigenda")]
+pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<EigenDAChainHost> {
+    todo!()
+}
+
+#[cfg(not(any(feature = "celestia", feature = "eigenda")))]
+pub fn initialize_host(fetcher: Arc<OPSuccinctDataFetcher>) -> Arc<SingleChainOPSuccinctHost> {
+    Arc::new(SingleChainOPSuccinctHost::new(fetcher))
 }

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -1,118 +1,12 @@
 pub mod block_range;
 mod contract;
 pub mod fetcher;
+pub mod hosts;
+mod proof;
 pub mod stats;
 pub use contract::*;
-
-use alloy_consensus::Header;
-use alloy_primitives::{Address, B256};
-use anyhow::Result;
-use kona_host::single::SingleChainHost;
-use kona_preimage::{BidirectionalChannel, HintWriter, NativeChannel, OracleReader};
-use op_succinct_client_utils::client::run_opsuccinct_client;
-use op_succinct_client_utils::precompiles::zkvm_handle_register;
-use op_succinct_client_utils::{boot::BootInfoStruct, types::AggregationInputs};
-use op_succinct_client_utils::{InMemoryOracle, StoreOracle};
-use rkyv::to_bytes;
-use sp1_sdk::{HashableKey, SP1Proof, SP1Stdin};
-use std::sync::Arc;
+pub use proof::*;
 
 pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
 pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
 pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
-
-#[derive(Debug, Clone)]
-pub struct OPSuccinctHost {
-    pub kona_args: SingleChainHost,
-}
-
-/// Get the stdin to generate a proof for the given L2 claim.
-pub fn get_proof_stdin(oracle: InMemoryOracle) -> Result<SP1Stdin> {
-    let mut stdin = SP1Stdin::new();
-
-    // Serialize the underlying KV store.
-    let buffer = to_bytes::<rkyv::rancor::Error>(&oracle)?;
-
-    let kv_store_bytes = buffer.into_vec();
-    stdin.write_slice(&kv_store_bytes);
-
-    Ok(stdin)
-}
-
-/// Get the stdin for the aggregation proof.
-pub fn get_agg_proof_stdin(
-    proofs: Vec<SP1Proof>,
-    boot_infos: Vec<BootInfoStruct>,
-    headers: Vec<Header>,
-    multi_block_vkey: &sp1_sdk::SP1VerifyingKey,
-    latest_checkpoint_head: B256,
-    prover_address: Address,
-) -> Result<SP1Stdin> {
-    let mut stdin = SP1Stdin::new();
-    for proof in proofs {
-        let SP1Proof::Compressed(compressed_proof) = proof else {
-            return Err(anyhow::anyhow!("Invalid proof passed as compressed proof!"));
-        };
-        stdin.write_proof(*compressed_proof, multi_block_vkey.vk.clone());
-    }
-
-    // Write the aggregation inputs to the stdin.
-    stdin.write(&AggregationInputs {
-        boot_infos,
-        latest_l1_checkpoint_head: latest_checkpoint_head,
-        multi_block_vkey: multi_block_vkey.hash_u32(),
-        prover_address,
-    });
-    // The headers have issues serializing with bincode, so use serde_json instead.
-    let headers_bytes = serde_cbor::to_vec(&headers).unwrap();
-    stdin.write_vec(headers_bytes);
-
-    Ok(stdin)
-}
-
-/// Start the server and native client. Each server is tied to a single client.
-pub async fn start_server_and_native_client(
-    cfg: OPSuccinctHost,
-) -> Result<InMemoryOracle, anyhow::Error> {
-    let in_memory_oracle = cfg.run().await?;
-
-    Ok(in_memory_oracle)
-}
-
-impl OPSuccinctHost {
-    /// Run the host and client program.
-    ///
-    /// Returns the in-memory oracle which can be supplied to the zkVM.
-    pub async fn run(&self) -> Result<InMemoryOracle> {
-        let hint = BidirectionalChannel::new()?;
-        let preimage = BidirectionalChannel::new()?;
-
-        let server_task = self
-            .kona_args
-            .start_server(hint.host, preimage.host)
-            .await?;
-
-        let in_memory_oracle = self
-            .run_witnessgen_client(preimage.client, hint.client)
-            .await?;
-        // Unlike the upstream, manually abort the server task, as it will hang if you wait for both tasks to complete.
-        server_task.abort();
-
-        Ok(in_memory_oracle)
-    }
-
-    /// Run the witness generation client.
-    pub async fn run_witnessgen_client(
-        &self,
-        preimage_chan: NativeChannel,
-        hint_chan: NativeChannel,
-    ) -> Result<InMemoryOracle> {
-        let oracle = Arc::new(StoreOracle::new(
-            OracleReader::new(preimage_chan),
-            HintWriter::new(hint_chan),
-        ));
-        let _ = run_opsuccinct_client(oracle.clone(), Some(zkvm_handle_register)).await?;
-        let in_memory_oracle = InMemoryOracle::populate_from_store(oracle.as_ref())?;
-        Ok(in_memory_oracle)
-    }
-}

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -7,6 +7,26 @@ pub mod stats;
 pub use contract::*;
 pub use proof::*;
 
+use clap::{Parser, ValueEnum};
+use strum_macros::EnumString;
+
 pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
 pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
 pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
+
+// TODO: Update to Celestia Range ELF Embedded
+pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+
+// TODO: Update to EigenDA Range ELF Embedded
+pub const EIGENDA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Parser, ValueEnum, EnumString)]
+/// The configuration for the DA provider.
+pub enum DAConfig {
+    /// The default DA configuration.
+    Default,
+    /// The Celestia DA configuration.
+    Celestia,
+    /// The EigenDA DA configuration.
+    EigenDA,
+}

--- a/utils/host/src/proof.rs
+++ b/utils/host/src/proof.rs
@@ -1,0 +1,50 @@
+use alloy_consensus::Header;
+use alloy_primitives::{Address, B256};
+use anyhow::Result;
+use op_succinct_client_utils::{boot::BootInfoStruct, types::AggregationInputs, InMemoryOracle};
+use rkyv::to_bytes;
+use sp1_sdk::{HashableKey, SP1Proof, SP1Stdin};
+
+/// Get the stdin to generate a proof for the given L2 claim.
+pub fn get_proof_stdin(oracle: InMemoryOracle) -> Result<SP1Stdin> {
+    let mut stdin = SP1Stdin::new();
+
+    // Serialize the underlying KV store.
+    let buffer = to_bytes::<rkyv::rancor::Error>(&oracle)?;
+
+    let kv_store_bytes = buffer.into_vec();
+    stdin.write_slice(&kv_store_bytes);
+
+    Ok(stdin)
+}
+
+/// Get the stdin for the aggregation proof.
+pub fn get_agg_proof_stdin(
+    proofs: Vec<SP1Proof>,
+    boot_infos: Vec<BootInfoStruct>,
+    headers: Vec<Header>,
+    multi_block_vkey: &sp1_sdk::SP1VerifyingKey,
+    latest_checkpoint_head: B256,
+    prover_address: Address,
+) -> Result<SP1Stdin> {
+    let mut stdin = SP1Stdin::new();
+    for proof in proofs {
+        let SP1Proof::Compressed(compressed_proof) = proof else {
+            return Err(anyhow::anyhow!("Invalid proof passed as compressed proof!"));
+        };
+        stdin.write_proof(*compressed_proof, multi_block_vkey.vk.clone());
+    }
+
+    // Write the aggregation inputs to the stdin.
+    stdin.write(&AggregationInputs {
+        boot_infos,
+        latest_l1_checkpoint_head: latest_checkpoint_head,
+        multi_block_vkey: multi_block_vkey.hash_u32(),
+        prover_address,
+    });
+    // The headers have issues serializing with bincode, so use serde_json instead.
+    let headers_bytes = serde_cbor::to_vec(&headers).unwrap();
+    stdin.write_vec(headers_bytes);
+
+    Ok(stdin)
+}

--- a/validity/Cargo.toml
+++ b/validity/Cargo.toml
@@ -59,3 +59,7 @@ rustls = "0.23.23"
 
 [build-dependencies]
 op-succinct-build-utils.workspace = true
+
+[features]
+celestia = ["op-succinct-host-utils/celestia"]
+eigenda = ["op-succinct-host-utils/eigenda"]

--- a/validity/Cargo.toml
+++ b/validity/Cargo.toml
@@ -59,7 +59,3 @@ rustls = "0.23.23"
 
 [build-dependencies]
 op-succinct-build-utils.workspace = true
-
-[features]
-celestia = ["op-succinct-host-utils/celestia"]
-eigenda = ["op-succinct-host-utils/eigenda"]

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -1,10 +1,6 @@
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
 use anyhow::Result;
-use op_succinct_host_utils::{
-    fetcher::OPSuccinctDataFetcher,
-    hosts::{default::SingleChainOPSuccinctHost, initialize_host, OPSuccinctHost},
-    DAConfig,
-};
+use op_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, hosts::initialize_host};
 use op_succinct_validity::{
     read_proposer_env, setup_proposer_logger, DriverDBClient, Proposer, RequesterConfig,
 };

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -1,7 +1,9 @@
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
 use anyhow::Result;
 use op_succinct_host_utils::{
-    fetcher::OPSuccinctDataFetcher, hosts::default::SingleChainOPSuccinctHost,
+    fetcher::OPSuccinctDataFetcher,
+    hosts::{default::SingleChainOPSuccinctHost, initialize_host, OPSuccinctHost},
+    DAConfig,
 };
 use op_succinct_validity::{
     read_proposer_env, setup_proposer_logger, DriverDBClient, Proposer, RequesterConfig,
@@ -64,14 +66,12 @@ async fn main() -> Result<()> {
         .wallet(signer.clone())
         .on_http(env_config.l1_rpc.parse().expect("Failed to parse L1_RPC"));
 
-    // TODO: Add handling logic for Alt-DA.
-    let fetcher = Arc::new(fetcher);
-    let host = Arc::new(SingleChainOPSuccinctHost::new(fetcher.clone()));
+    let host = initialize_host(fetcher.clone().into());
 
     let proposer = Proposer::new(
         l1_provider,
         db_client.clone(),
-        fetcher.clone(),
+        fetcher.into(),
         proposer_config,
         env_config.loop_interval,
         host,

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -1,6 +1,8 @@
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
 use anyhow::Result;
-use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
+use op_succinct_host_utils::{
+    fetcher::OPSuccinctDataFetcher, hosts::default::SingleChainOPSuccinctHost,
+};
 use op_succinct_validity::{
     read_proposer_env, setup_proposer_logger, DriverDBClient, Proposer, RequesterConfig,
 };
@@ -62,12 +64,17 @@ async fn main() -> Result<()> {
         .wallet(signer.clone())
         .on_http(env_config.l1_rpc.parse().expect("Failed to parse L1_RPC"));
 
+    // TODO: Add handling logic for Alt-DA.
+    let fetcher = Arc::new(fetcher);
+    let host = Arc::new(SingleChainOPSuccinctHost::new(fetcher.clone()));
+
     let proposer = Proposer::new(
         l1_provider,
         db_client.clone(),
-        Arc::new(fetcher),
+        fetcher.clone(),
         proposer_config,
         env_config.loop_interval,
+        host,
     )
     .await?;
 

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -23,7 +23,6 @@ pub struct EnvironmentConfig {
     pub max_concurrent_proof_requests: u64,
     pub submission_interval: u64,
     pub mock: bool,
-    pub da_config: DAConfig,
 }
 
 /// Helper function to get environment variables with a default value and parse them.
@@ -80,9 +79,6 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         .ok()
         .map(|v| v.parse::<u64>().expect("Failed to parse LOOP_INTERVAL"));
 
-    // Parse DA config
-    let da_config = get_env_var("DA_CONFIG", Some(DAConfig::Default))?;
-
     let config = EnvironmentConfig {
         metrics_port: get_env_var("METRICS_PORT", Some(8080))?,
         l1_rpc: get_env_var("L1_RPC", None)?,
@@ -100,7 +96,6 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         submission_interval: get_env_var("SUBMISSION_INTERVAL", Some(1800))?,
         mock: get_env_var("OP_SUCCINCT_MOCK", Some(false))?,
         loop_interval,
-        da_config,
     };
 
     Ok(config)

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -3,7 +3,6 @@ use std::env;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::Result;
-use op_succinct_host_utils::DAConfig;
 use sp1_sdk::{network::FulfillmentStrategy, SP1ProofMode};
 
 pub struct EnvironmentConfig {

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -3,6 +3,7 @@ use std::env;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::Result;
+use op_succinct_host_utils::DAConfig;
 use sp1_sdk::{network::FulfillmentStrategy, SP1ProofMode};
 
 pub struct EnvironmentConfig {
@@ -22,6 +23,7 @@ pub struct EnvironmentConfig {
     pub max_concurrent_proof_requests: u64,
     pub submission_interval: u64,
     pub mock: bool,
+    pub da_config: DAConfig,
 }
 
 /// Helper function to get environment variables with a default value and parse them.
@@ -78,6 +80,9 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         .ok()
         .map(|v| v.parse::<u64>().expect("Failed to parse LOOP_INTERVAL"));
 
+    // Parse DA config
+    let da_config = get_env_var("DA_CONFIG", Some(DAConfig::Default))?;
+
     let config = EnvironmentConfig {
         metrics_port: get_env_var("METRICS_PORT", Some(8080))?,
         l1_rpc: get_env_var("L1_RPC", None)?,
@@ -95,6 +100,7 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         submission_interval: get_env_var("SUBMISSION_INTERVAL", Some(1800))?,
         mock: get_env_var("OP_SUCCINCT_MOCK", Some(false))?,
         loop_interval,
+        da_config,
     };
 
     Ok(config)

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -12,7 +12,7 @@ use futures_util::{stream, StreamExt, TryStreamExt};
 use metrics::gauge;
 use op_succinct_client_utils::{boot::hash_rollup_config, types::u32_to_u8};
 use op_succinct_host_utils::{
-    fetcher::OPSuccinctDataFetcher,
+    fetcher::OPSuccinctDataFetcher, hosts::OPSuccinctHost,
     DisputeGameFactory::DisputeGameFactoryInstance as DisputeGameFactoryContract,
     OPSuccinctL2OutputOracle::OPSuccinctL2OutputOracleInstance as OPSuccinctL2OOContract,
     ValidityDisputeGameExtraData, AGGREGATION_ELF, RANGE_ELF_EMBEDDED,
@@ -87,7 +87,7 @@ pub struct DriverConfig {
 pub type TaskMap =
     HashMap<tokio::task::Id, (tokio::task::JoinHandle<Result<()>>, OPSuccinctRequest)>;
 
-pub struct Proposer<P, N>
+pub struct Proposer<P, N, H: OPSuccinctHost>
 where
     P: Provider<N> + 'static,
     N: Network,
@@ -96,7 +96,7 @@ where
     contract_config: ContractConfig<P, N>,
     program_config: ProgramConfig,
     requester_config: RequesterConfig,
-    proof_requester: Arc<OPSuccinctProofRequester>,
+    proof_requester: Arc<OPSuccinctProofRequester<H>>,
     tasks: Arc<Mutex<TaskMap>>,
 }
 
@@ -107,7 +107,7 @@ const TIMEOUT: u64 = 120;
 /// Task completion handler interval.
 const TASK_COMPLETION_HANDLER_INTERVAL: u64 = 1;
 
-impl<P, N> Proposer<P, N>
+impl<P, N, H: OPSuccinctHost> Proposer<P, N, H>
 where
     P: Provider<N> + 'static + Clone,
     N: Network,
@@ -118,6 +118,7 @@ where
         fetcher: Arc<OPSuccinctDataFetcher>,
         requester_config: RequesterConfig,
         loop_interval_seconds: Option<u64>,
+        host: Arc<H>,
     ) -> Result<Self> {
         let network_prover = Arc::new(ProverClient::builder().network().build());
         let (range_pk, range_vk) = network_prover.setup(RANGE_ELF_EMBEDDED);
@@ -143,6 +144,7 @@ where
 
         // Initialize the proof requester.
         let proof_requester = Arc::new(OPSuccinctProofRequester::new(
+            host,
             network_prover.clone(),
             fetcher.clone(),
             db_client.clone(),


### PR DESCRIPTION
# Overview
- Create an `OPSuccinctHost` trait for Alt-DA providers to implement.
- In the host, provide separate images and binaries for Alt-DA.
- In the client, feature gate the use of the oracle pipeline.

# Misc
- Remove `CacheMode`. Always delete the data directory.
- Fix deprecated clap attribute.