### PR TITLE
feat: update contract deployment script for fp

### DIFF
--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -122,6 +122,10 @@ The deployment script deploys the contract with the following parameters:
 |----------|-------------|---------|
 | `INITIAL_BOND_WEI` | Initial bond for the game. | 1_000_000_000_000_000 (for 0.001 ETH) |
 | `CHALLENGER_BOND_WEI` | Challenger bond for the game. | 1_000_000_000_000_000 (for 0.001 ETH) |
+| `OPTIMISM_PORTAL2_ADDRESS` | Address of an existing OptimismPortal2 contract. If not provided, a mock will be deployed. | `0x...` |
+| `PERMISSIONLESS_MODE` | If set to true, anyone can propose or challenge games. | `true` or `false` |
+| `PROPOSER_ADDRESSES` | Comma-separated list of addresses allowed to propose games. Ignored if PERMISSIONLESS_MODE is true. | `0x123...,0x456...` |
+| `CHALLENGER_ADDRESSES` | Comma-separated list of addresses allowed to challenge games. Ignored if PERMISSIONLESS_MODE is true. | `0x123...,0x456...` |
 
 Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 


### PR DESCRIPTION
Updates contract deployment script for OP Succinct Lite.

1. Support usage of real OptimismPortal2 contract for the AnchorStateRegistry. If not provided, deploy mock OptimismPortal2 for testing.
2. Support permissioned game environment. If comma-separated list for `PROPOSER_ADDRESSES` and `CHALLENGER_ADDRESSES` are provided, only the given addresses are given permission in the AccessManager.