### PR TITLE
feat: add `handle_bond_claiming` for fp challenger

### DIFF
--- a/book/fault_proofs/challenger.md
+++ b/book/fault_proofs/challenger.md
@@ -45,6 +45,7 @@ The challenger is configured through environment variables. Create a `.env.chall
 | `ENABLE_GAME_RESOLUTION` | Whether to enable automatic game resolution | `true` |
 | `MAX_GAMES_TO_CHECK_FOR_CHALLENGE` | Maximum number of games to scan for challenges | `100` |
 | `MAX_GAMES_TO_CHECK_FOR_RESOLUTION` | Maximum number of games to check for resolution | `100` |
+| `MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING` | Maximum number of games to check for bond claiming | `100` |
 | `CHALLENGER_METRICS_PORT` | The port to expose metrics on. Update prometheus.yml to use this port, if using docker compose. | `9001` |
 
 ```env
@@ -60,6 +61,7 @@ FETCH_INTERVAL=30                     # Polling interval in seconds
 ENABLE_GAME_RESOLUTION=true           # Whether to enable automatic game resolution
 MAX_GAMES_TO_CHECK_FOR_CHALLENGE=100  # Maximum number of games to scan for challenges
 MAX_GAMES_TO_CHECK_FOR_RESOLUTION=100 # Maximum number of games to check for resolution
+MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING=100 # Maximum number of games to check for bond claiming
 CHALLENGER_METRICS_PORT=9001          # The port to expose metrics on
 ```
 

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -119,6 +119,9 @@ pub struct ChallengerConfig {
     /// challenged up to `max_games_to_check_for_resolution` games behind the latest game.
     pub max_games_to_check_for_resolution: u64,
 
+    /// The maximum number of games to check for bond claiming.
+    pub max_games_to_check_for_bond_claiming: u64,
+
     /// The metrics port.
     pub metrics_port: u16,
 }
@@ -142,6 +145,9 @@ impl ChallengerConfig {
                 .unwrap_or("true".to_string())
                 .parse()?,
             max_games_to_check_for_resolution: env::var("MAX_GAMES_TO_CHECK_FOR_RESOLUTION")
+                .unwrap_or("100".to_string())
+                .parse()?,
+            max_games_to_check_for_bond_claiming: env::var("MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING")
                 .unwrap_or("100".to_string())
                 .parse()?,
             metrics_port: env::var("CHALLENGER_METRICS_PORT")

--- a/fault-proof/src/prometheus.rs
+++ b/fault-proof/src/prometheus.rs
@@ -60,6 +60,11 @@ pub enum ChallengerGauge {
         message = "Total number of games resolved by the challenger"
     )]
     GamesResolved,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_games_bonds_claimed",
+        message = "Total number of games that bonds were claimed by the challenger"
+    )]
+    GamesBondsClaimed,
     // Error metrics
     #[strum(
         serialize = "op_succinct_fp_challenger_errors",


### PR DESCRIPTION
Now OP Succinct Lite challengers can claim bonds for the games that they have successfully challenged.