### PR TITLE
feat(fault-proof): better error gauges for fp

### DIFF
--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -194,7 +194,7 @@ where
                 Ok(Action::Skipped) => {}
                 Err(e) => {
                     tracing::warn!("Failed to handle game challenging: {:?}", e);
-                    ChallengerGauge::Errors.increment(1.0);
+                    ChallengerGauge::GameChallengingError.increment(1.0);
                 }
             }
 
@@ -204,7 +204,7 @@ where
                 }
                 Err(e) => {
                     tracing::warn!("Failed to handle game resolution: {:?}", e);
-                    ChallengerGauge::Errors.increment(1.0);
+                    ChallengerGauge::GameResolutionError.increment(1.0);
                 }
             }
 
@@ -215,7 +215,7 @@ where
                 Ok(Action::Skipped) => {}
                 Err(e) => {
                     tracing::warn!("Failed to handle bond claiming: {:?}", e);
-                    ChallengerGauge::Errors.increment(1.0);
+                    ChallengerGauge::BondClaimingError.increment(1.0);
                 }
             }
         }

--- a/fault-proof/src/prometheus.rs
+++ b/fault-proof/src/prometheus.rs
@@ -38,10 +38,30 @@ pub enum ProposerGauge {
     GamesBondsClaimed,
     // Error metrics
     #[strum(
-        serialize = "op_succinct_fp_errors",
-        message = "Total number of errors encountered by the proposer"
+        serialize = "op_succinct_fp_game_creation_error",
+        message = "Total number of game creation errors encountered by the proposer"
     )]
-    Errors,
+    GameCreationError,
+    #[strum(
+        serialize = "op_succinct_fp_game_defense_error",
+        message = "Total number of game defense errors encountered by the proposer"
+    )]
+    GameDefenseError,
+    #[strum(
+        serialize = "op_succinct_fp_game_resolution_error",
+        message = "Total number of game resolution errors encountered by the proposer"
+    )]
+    GameResolutionError,
+    #[strum(
+        serialize = "op_succinct_fp_bond_claiming_error",
+        message = "Total number of bond claiming errors encountered by the proposer"
+    )]
+    BondClaimingError,
+    #[strum(
+        serialize = "op_succinct_fp_metrics_error",
+        message = "Total number of metrics errors encountered by the proposer"
+    )]
+    MetricsError,
 }
 
 impl MetricsGauge for ProposerGauge {}
@@ -67,10 +87,20 @@ pub enum ChallengerGauge {
     GamesBondsClaimed,
     // Error metrics
     #[strum(
-        serialize = "op_succinct_fp_challenger_errors",
-        message = "Total number of errors encountered by the challenger"
+        serialize = "op_succinct_fp_challenger_game_challenging_error",
+        message = "Total number of game challenging errors encountered by the challenger"
     )]
-    Errors,
+    GameChallengingError,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_game_resolution_error",
+        message = "Total number of game resolution errors encountered by the challenger"
+    )]
+    GameResolutionError,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_bond_claiming_error",
+        message = "Total number of bond claiming errors encountered by the challenger"
+    )]
+    BondClaimingError,
 }
 
 impl MetricsGauge for ChallengerGauge {}

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -454,21 +454,18 @@ where
                         Ok(None) => {}
                             Err(e) => {
                             tracing::warn!("Failed to handle game creation: {:?}", e);
-                            ProposerGauge::Errors.increment(1.0);
+                            ProposerGauge::GameCreationError.increment(1.0);
                         }
                     }
 
                     if let Err(e) = self.handle_game_defense().await {
                         tracing::warn!("Failed to handle game defense: {:?}", e);
-                        ProposerGauge::Errors.increment(1.0);
+                        ProposerGauge::GameDefenseError.increment(1.0);
                     }
 
-                    match self.handle_game_resolution().await {
-                        Ok(_) => {}
-                        Err(e) => {
-                            tracing::warn!("Failed to handle game resolution: {:?}", e);
-                            ProposerGauge::Errors.increment(1.0);
-                        }
+                    if let Err(e) = self.handle_game_resolution().await {
+                        tracing::warn!("Failed to handle game resolution: {:?}", e);
+                        ProposerGauge::GameResolutionError.increment(1.0);
                     }
 
                     match self.handle_bond_claiming().await {
@@ -478,14 +475,14 @@ where
                         Ok(Action::Skipped) => {}
                         Err(e) => {
                             tracing::warn!("Failed to handle bond claiming: {:?}", e);
-                            ProposerGauge::Errors.increment(1.0);
+                            ProposerGauge::BondClaimingError.increment(1.0);
                         }
                     }
                 }
                 _ = metrics_interval.tick() => {
                     if let Err(e) = self.fetch_proposer_metrics().await {
                         tracing::warn!("Failed to fetch metrics: {:?}", e);
-                        ProposerGauge::Errors.increment(1.0);
+                        ProposerGauge::MetricsError.increment(1.0);
                     }
                 }
             }


### PR DESCRIPTION
Instead of total error count gauges, there's an error gauge for each actions for proposer and challenger, so that it's easier to track down the source of issue.