### PR TITLE
feat(contracts): output upgrade calldata on dry run

### DIFF
--- a/fault-proof/justfile
+++ b/fault-proof/justfile
@@ -20,8 +20,6 @@ upgrade-fault-dispute-game:
             --etherscan-api-key $ETHERSCAN_API_KEY \
             --broadcast
     else
-        forge script script/fp/UpgradeOPSuccinctFDG.s.sol:UpgradeOPSuccinctFDG \
-            --rpc-url $L1_RPC \
-            --private-key $PRIVATE_KEY \
-            --etherscan-api-key $ETHERSCAN_API_KEY
+        forge script UpgradeOPSuccinctFDG --sig "getUpgradeCalldata()" \
+            --private-key $PRIVATE_KEY
     fi


### PR DESCRIPTION
Now the upgrade script outputs upgrade calldata on dry run.

As mentioned in #450, most chains in production have a multi-sig or something similar and need the calldata to be outputted explicitly to upgrade.

