### PR TITLE
build: move zkvm ELFs into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-succinct-elfs"
+version = "0.1.0"
+
+[[package]]
 name = "op-succinct-fees"
 version = "0.1.0"
 dependencies = [
@@ -4661,6 +4665,7 @@ dependencies = [
  "op-alloy-network",
  "op-alloy-rpc-types",
  "op-succinct-client-utils",
+ "op-succinct-elfs",
  "reqwest",
  "rkyv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }
 op-succinct-client-utils = { path = "utils/client" }
+op-succinct-elfs = { path = "utils/elfs" }
 op-succinct-host-utils = { path = "utils/host" }
 op-succinct-build-utils = { path = "utils/build" }
 op-succinct-validity = { path = "validity" }

--- a/utils/elfs/Cargo.toml
+++ b/utils/elfs/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "op-succinct-elfs"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true

--- a/utils/elfs/src/lib.rs
+++ b/utils/elfs/src/lib.rs
@@ -1,0 +1,11 @@
+//! The zkvm ELF binaries.
+
+pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
+pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
+
+// TODO: Update to Celestia Range ELF Embedded
+pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+
+// TODO: Update to EigenDA Range ELF Embedded
+pub const EIGENDA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -11,6 +11,7 @@ sp1-sdk.workspace = true
 
 # local
 op-succinct-client-utils.workspace = true
+op-succinct-elfs.workspace = true
 
 # op-alloy
 op-alloy-rpc-types.workspace = true

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -10,16 +10,7 @@ pub mod metrics;
 
 use clap::{Parser, ValueEnum};
 use strum_macros::EnumString;
-
-pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
-pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
-pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
-
-// TODO: Update to Celestia Range ELF Embedded
-pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
-
-// TODO: Update to EigenDA Range ELF Embedded
-pub const EIGENDA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+pub use op_succinct_elfs::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Parser, ValueEnum, EnumString)]
 /// The configuration for the DA provider.


### PR DESCRIPTION
Rationale:
* Unfortunately the `op-alloy-*` crates do not seem to properly follow the semver rules, causing all sorts of build failures if `op-succinct-host-utils` is pulled in as a dependency.
* It's nice to make dependencies lighter in general.