### PR TITLE
feat: add mock mode support for fp proposer

### DIFF
--- a/book/fault_proofs/best_practices.md
+++ b/book/fault_proofs/best_practices.md
@@ -2,6 +2,12 @@
 
 This document covers best practices for OP Succinct Lite deployment setup.
 
+## Mock Mode
+
+When using mock mode, the proposer will not use the Succinct Prover Network to generate proofs. Instead, it will generate mock proofs using the public values from execution. This is useful for testing since it is much faster than generating real proofs from the Succinct Prover Network.
+
+To enable mock mode, set the `MOCK_MODE` environment variable to `true` in the `.env.proposer` file.
+
 ## SafeDB Configuration
 
 ### Enabling SafeDB in op-node

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -44,6 +44,7 @@ To get a whitelisted key on the Succinct Prover Network for OP Succinct, fill ou
 
 | Variable | Description | Default Value |
 |----------|-------------|---------------|
+| `MOCK_MODE` | Whether to use mock mode | `false` |
 | `FAST_FINALITY_MODE` | Whether to use fast finality mode | `false` |
 | `PROPOSAL_INTERVAL_IN_BLOCKS` | Number of L2 blocks between proposals | `1800` |
 | `FETCH_INTERVAL` | Polling interval in seconds | `30` |
@@ -66,6 +67,7 @@ GAME_TYPE=               # Type identifier for the dispute game (must match fact
 PRIVATE_KEY=             # Private key for transaction signing
 
 # Optional Configuration
+MOCK_MODE=false                          # Whether to use mock mode
 FAST_FINALITY_MODE=false                 # Whether to use fast finality mode
 PROPOSAL_INTERVAL_IN_BLOCKS=1800         # Number of L2 blocks between proposals
 FETCH_INTERVAL=30                        # Polling interval in seconds
@@ -99,6 +101,7 @@ The proposer will run indefinitely, creating new games and optionally resolving 
 - Computes L2 output roots for game proposals.
 - Ensures proper game sequencing with parent-child relationships.
 - Handles bond requirements for game creation.
+- Supports mock mode for testing without using the Succinct Prover Network. (Set `MOCK_MODE=true` in `.env.proposer`)
 - Supports fast finality mode with proofs. (Set `FAST_FINALITY_MODE=true` in `.env.proposer`)
 
 ### Game Defense
@@ -110,7 +113,7 @@ The proposer will run indefinitely, creating new games and optionally resolving 
   - Are within their proof submission window
   - Have valid output root claims
 - Generates and submits proofs using the Succinct Prover Network
-
+- Supports mock mode for testing without using the Succinct Prover Network. (Set `MOCK_MODE=true` in `.env.proposer`)
 ### Game Resolution
 When enabled (`ENABLE_GAME_RESOLUTION=true`), the proposer:
 - Monitors unchallenged games

--- a/book/fault_proofs/quick_start.md
+++ b/book/fault_proofs/quick_start.md
@@ -50,6 +50,7 @@ Save the output addresses, particularly the `FACTORY_ADDRESS` output as "Factory
 ## Step 2: Run the Proposer
 
 1. Create a `.env.proposer` file in the project root directory:
+
     ```env
     # Required Configuration
     L1_RPC=<YOUR_L1_RPC_URL>
@@ -57,7 +58,8 @@ Save the output addresses, particularly the `FACTORY_ADDRESS` output as "Factory
     FACTORY_ADDRESS=<FACTORY_ADDRESS_FROM_DEPLOYMENT>
     GAME_TYPE=42
     PRIVATE_KEY=<YOUR_PRIVATE_KEY>
-    NETWORK_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000001
+    NETWORK_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000001 # Dummy network private key for mock mode
+    MOCK_MODE=true # Set to true for mock mode
     ```
 
 2. Run the proposer:

--- a/book/fault_proofs/quick_start.md
+++ b/book/fault_proofs/quick_start.md
@@ -58,7 +58,6 @@ Save the output addresses, particularly the `FACTORY_ADDRESS` output as "Factory
     FACTORY_ADDRESS=<FACTORY_ADDRESS_FROM_DEPLOYMENT>
     GAME_TYPE=42
     PRIVATE_KEY=<YOUR_PRIVATE_KEY>
-    NETWORK_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000001 # Dummy network private key for mock mode
     MOCK_MODE=true # Set to true for mock mode
     ```
 

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -15,6 +15,9 @@ pub struct ProposerConfig {
     /// The address of the factory contract.
     pub factory_address: Address,
 
+    /// Whether to use mock mode.
+    pub mock_mode: bool,
+
     /// Whether to use fast finality mode.
     pub fast_finality_mode: bool,
 
@@ -61,6 +64,7 @@ impl ProposerConfig {
             l1_rpc: env::var("L1_RPC")?.parse().expect("L1_RPC not set"),
             l2_rpc: env::var("L2_RPC")?.parse().expect("L2_RPC not set"),
             factory_address: env::var("FACTORY_ADDRESS")?.parse().expect("FACTORY_ADDRESS not set"),
+            mock_mode: env::var("MOCK_MODE").unwrap_or("false".to_string()).parse()?,
             fast_finality_mode: env::var("FAST_FINALITY_MODE")
                 .unwrap_or("false".to_string())
                 .parse()?,

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -7,8 +7,8 @@ use alloy_provider::{fillers::TxFiller, Provider, ProviderBuilder};
 use alloy_sol_types::SolValue;
 use anyhow::{Context, Result};
 use sp1_sdk::{
-    network::FulfillmentStrategy, NetworkProver, Prover, ProverClient, SP1ProvingKey,
-    SP1VerifyingKey,
+    network::FulfillmentStrategy, NetworkProver, Prover, ProverClient, SP1ProofMode,
+    SP1ProofWithPublicValues, SP1ProvingKey, SP1VerifyingKey, SP1_CIRCUIT_VERSION,
 };
 use tokio::time;
 
@@ -21,8 +21,8 @@ use crate::{
 };
 use op_succinct_client_utils::boot::BootInfoStruct;
 use op_succinct_host_utils::{
-    fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, get_proof_stdin, hosts::OPSuccinctHost,
-    metrics::MetricsGauge, AGGREGATION_ELF, RANGE_ELF_EMBEDDED,
+    fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, get_proof_stdin, get_range_elf_embedded,
+    hosts::OPSuccinctHost, AGGREGATION_ELF,
 };
 
 struct SP1Prover {
@@ -76,7 +76,7 @@ where
 
         let network_prover =
             Arc::new(ProverClient::builder().network().private_key(&private_key).build());
-        let (range_pk, range_vk) = network_prover.setup(RANGE_ELF_EMBEDDED);
+        let (range_pk, range_vk) = network_prover.setup(get_range_elf_embedded());
         let (agg_pk, _) = network_prover.setup(AGGREGATION_ELF);
 
         Ok(Self {
@@ -134,16 +134,29 @@ where
         };
 
         tracing::info!("Generating Range Proof");
-        let range_proof = self
-            .prover
-            .network_prover
-            .prove(&self.prover.range_pk, &sp1_stdin)
-            .compressed()
-            .strategy(FulfillmentStrategy::Hosted)
-            .skip_simulation(true)
-            .cycle_limit(1_000_000_000_000)
-            .run_async()
-            .await?;
+        let range_proof = if self.config.mock_mode {
+            tracing::info!("Using mock mode for range proof generation");
+            let (public_values, _) =
+                self.prover.network_prover.execute(get_range_elf_embedded(), &sp1_stdin).run()?;
+
+            // Create a mock range proof with the public values.
+            SP1ProofWithPublicValues::create_mock_proof(
+                &self.prover.range_pk,
+                public_values,
+                SP1ProofMode::Compressed,
+                SP1_CIRCUIT_VERSION,
+            )
+        } else {
+            self.prover
+                .network_prover
+                .prove(&self.prover.range_pk, &sp1_stdin)
+                .compressed()
+                .strategy(FulfillmentStrategy::Hosted)
+                .skip_simulation(true)
+                .cycle_limit(1_000_000_000_000)
+                .run_async()
+                .await?
+        };
 
         tracing::info!("Preparing Stdin for Agg Proof");
         let proof = range_proof.proof.clone();
@@ -177,13 +190,30 @@ where
         };
 
         tracing::info!("Generating Agg Proof");
-        let agg_proof = self
-            .prover
-            .network_prover
-            .prove(&self.prover.agg_pk, &sp1_stdin)
-            .groth16()
-            .run_async()
-            .await?;
+        let agg_proof = if self.config.mock_mode {
+            tracing::info!("Using mock mode for aggregation proof generation");
+            let (public_values, _) = self
+                .prover
+                .network_prover
+                .execute(AGGREGATION_ELF, &sp1_stdin)
+                .deferred_proof_verification(false)
+                .run()?;
+
+            // Create a mock aggregation proof with the public values.
+            SP1ProofWithPublicValues::create_mock_proof(
+                &self.prover.agg_pk,
+                public_values,
+                SP1ProofMode::Groth16,
+                SP1_CIRCUIT_VERSION,
+            )
+        } else {
+            self.prover
+                .network_prover
+                .prove(&self.prover.agg_pk, &sp1_stdin)
+                .groth16()
+                .run_async()
+                .await?
+        };
 
         let receipt = game.prove(agg_proof.bytes().into()).send().await?.get_receipt().await?;
 

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -22,7 +22,7 @@ use crate::{
 use op_succinct_client_utils::boot::BootInfoStruct;
 use op_succinct_host_utils::{
     fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, get_proof_stdin, get_range_elf_embedded,
-    hosts::OPSuccinctHost, AGGREGATION_ELF,
+    hosts::OPSuccinctHost, metrics::MetricsGauge, AGGREGATION_ELF,
 };
 
 struct SP1Prover {


### PR DESCRIPTION
Adds mock mode support for OP Succinct Lite proposer.

This feature will be very useful for testing since it is much faster than generating real proofs from the Succinct Prover Network.

Test tx with fast finality mode: https://sepolia.etherscan.io/tx/0xa10cb5c1b02a2aa2824bf4bd56e022bb344fb980e3c3cdb783bded130f6d5aa5