### PR TITLE
chore: improve validity quick-start devex

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+[tools]
+cast = { version = "latest", exe = "cast" }
+forge = { version = "latest", exe = "forge" }
+just = "latest"
+rust = "1.85"
+
+# System Dependencies (need to be installed manually outside of mise)
+# for `just deploy-oracle`: cc, openssl, pkg-config, clang, libclang-dev


### PR DESCRIPTION
Partly Fixes #480 

Used mise.toml to pin the dependencies that you guys have in https://succinctlabs.github.io/op-succinct/validity/quick-start.html. Made it a separate commit such that it can be reverted if you guys don't want to rely on mise.toml. OP uses it everywhere and its pretty simple so I think its a nice to have. Plus its totally optional.

Also made some small improvements to the justfile commands such as automatically parsing the deployment files and populating the .env with the deployed contract addresses. Also some minor bash mistakes like not using quotes around some values which created errors when they were not part of .env file (like ETHERSCAN_API_KEY)