### PR TITLE
chore: bump hana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "hana-blobstream"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.8#47da5c02374ed8072fb41b37ee201924ca2bc5d5"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "hana-celestia"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.8#47da5c02374ed8072fb41b37ee201924ca2bc5d5"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3229,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "hana-client"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.8#47da5c02374ed8072fb41b37ee201924ca2bc5d5"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
 dependencies = [
  "alloy-consensus 0.12.6",
  "alloy-primitives",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "hana-host"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.8#47da5c02374ed8072fb41b37ee201924ca2bc5d5"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "hana-oracle"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.8#47da5c02374ed8072fb41b37ee201924ca2bc5d5"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "hana-proofs"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.8#47da5c02374ed8072fb41b37ee201924ca2bc5d5"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,10 @@ kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1
 kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
 
 # hana
-hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.8" }
-hana-celestia = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.8" }
-hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.8" }
-hana-client = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.8" }
+hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
+hana-celestia = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
+hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
+hana-client = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }


### PR DESCRIPTION
Bump hana from v0.1.0-beta.8 to v0.1.0-beta.9.

There was a fix in hana for DataAvailabilityProvider impl of CelestiaDADataSource to support ETH DA fallback.