### PR TITLE
feat(utils/host): handle eip4844 txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "hana-blobstream"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.10#6ccd085e4a52ec8ad96e77fc36c4ec496440ba44"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "hana-celestia"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.10#6ccd085e4a52ec8ad96e77fc36c4ec496440ba44"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3229,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "hana-client"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.10#6ccd085e4a52ec8ad96e77fc36c4ec496440ba44"
 dependencies = [
  "alloy-consensus 0.12.6",
  "alloy-primitives",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "hana-host"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.10#6ccd085e4a52ec8ad96e77fc36c4ec496440ba44"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "hana-oracle"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.10#6ccd085e4a52ec8ad96e77fc36c4ec496440ba44"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "hana-proofs"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.9#2b7c7a50c4936a8be40678781e015e795c62d92d"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.10#6ccd085e4a52ec8ad96e77fc36c4ec496440ba44"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,10 @@ kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1
 kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
 
 # hana
-hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
-hana-celestia = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
-hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
-hana-client = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.9" }
+hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.10" }
+hana-celestia = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.10" }
+hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.10" }
+hana-client = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.10" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }


### PR DESCRIPTION
Handles EIP4844 transactions.

For batch transactions submitted with type3 transactions on Ethereum, it causes `index out of bounds` error.

Fixed to only parse the calldata and check version byte if it's a non-EIP4844 transaction.

Also a fix was made in hana: https://github.com/celestiaorg/hana/commit/6ccd085e4a52ec8ad96e77fc36c4ec496440ba44. Bumped hana from v0.1.0-beta.9 to v0.1.0-beta.10.

E2e tested. The first batcher transaction with EIP4844 transaction is https://sepolia.etherscan.io/tx/0x010b2e024a6ddd16c5b3bc9727ac80a0e772fddb801b035cb62176686175cbb0 on block [8138653](https://sepolia.etherscan.io/block/8138653)