### PR TITLE
Adds optimistic multiprover support to op succinct's contracts

### DIFF
--- a/contracts/script/validity/OPSuccinctDeployer.s.sol
+++ b/contracts/script/validity/OPSuccinctDeployer.s.sol
@@ -23,7 +23,7 @@ contract OPSuccinctDeployer is Script, Utils {
         // Set the implementation address if it is not already set.
         if (config.opSuccinctL2OutputOracleImpl == address(0)) {
             console.log("Deploying new OPSuccinctL2OutputOracle impl");
-            config.opSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle());
+            config.opSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle(address(0), bytes32(0), bytes32(0)));
         }
 
         // If the Admin PK is set, use it as the owner of the proxy.

--- a/contracts/script/validity/OPSuccinctUpgrader.s.sol
+++ b/contracts/script/validity/OPSuccinctUpgrader.s.sol
@@ -30,7 +30,7 @@ contract OPSuccinctUpgrader is Script, Utils {
 
         if (OPSuccinctL2OutputOracleImpl == address(0)) {
             console.log("Deploying new OPSuccinctL2OutputOracle impl");
-            OPSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle());
+            OPSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle(address(0), bytes32(0), bytes32(0)));
             cfg.opSuccinctL2OutputOracleImpl = OPSuccinctL2OutputOracleImpl;
         }
 

--- a/contracts/src/validity/FlatR0ImportV1.2.0.sol
+++ b/contracts/src/validity/FlatR0ImportV1.2.0.sol
@@ -1,0 +1,2667 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.15;
+
+// ../lib/openzeppelin-contracts/contracts/utils/cryptography/MerkleProof.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/cryptography/MerkleProof.sol)
+
+/**
+ * @dev These functions deal with verification of Merkle Tree proofs.
+ *
+ * The tree and the proofs can be generated using our
+ * https://github.com/OpenZeppelin/merkle-tree[JavaScript library].
+ * You will find a quickstart guide in the readme.
+ *
+ * WARNING: You should avoid using leaf values that are 64 bytes long prior to
+ * hashing, or use a hash function other than keccak256 for hashing leaves.
+ * This is because the concatenation of a sorted pair of internal nodes in
+ * the Merkle tree could be reinterpreted as a leaf value.
+ * OpenZeppelin's JavaScript library generates Merkle trees that are safe
+ * against this attack out of the box.
+ */
+library MerkleProof {
+    /**
+     * @dev The multiproof provided is not valid.
+     */
+    error MerkleProofInvalidMultiproof();
+
+    /**
+     * @dev Returns true if a `leaf` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     */
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+        return processProof(proof, leaf) == root;
+    }
+
+    /**
+     * @dev Calldata version of {verify}
+     */
+    function verifyCalldata(bytes32[] calldata proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+        return processProofCalldata(proof, leaf) == root;
+    }
+
+    /**
+     * @dev Returns the rebuilt hash obtained by traversing a Merkle tree up
+     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
+     * hash matches the root of the tree. When processing the proof, the pairs
+     * of leafs & pre-images are assumed to be sorted.
+     */
+    function processProof(bytes32[] memory proof, bytes32 leaf) internal pure returns (bytes32) {
+        bytes32 computedHash = leaf;
+        for (uint256 i = 0; i < proof.length; i++) {
+            computedHash = _hashPair(computedHash, proof[i]);
+        }
+        return computedHash;
+    }
+
+    /**
+     * @dev Calldata version of {processProof}
+     */
+    function processProofCalldata(bytes32[] calldata proof, bytes32 leaf) internal pure returns (bytes32) {
+        bytes32 computedHash = leaf;
+        for (uint256 i = 0; i < proof.length; i++) {
+            computedHash = _hashPair(computedHash, proof[i]);
+        }
+        return computedHash;
+    }
+
+    /**
+     * @dev Returns true if the `leaves` can be simultaneously proven to be a part of a Merkle tree defined by
+     * `root`, according to `proof` and `proofFlags` as described in {processMultiProof}.
+     *
+     * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     */
+    function multiProofVerify(bytes32[] memory proof, bool[] memory proofFlags, bytes32 root, bytes32[] memory leaves)
+        internal
+        pure
+        returns (bool)
+    {
+        return processMultiProof(proof, proofFlags, leaves) == root;
+    }
+
+    /**
+     * @dev Calldata version of {multiProofVerify}
+     *
+     * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     */
+    function multiProofVerifyCalldata(
+        bytes32[] calldata proof,
+        bool[] calldata proofFlags,
+        bytes32 root,
+        bytes32[] memory leaves
+    ) internal pure returns (bool) {
+        return processMultiProofCalldata(proof, proofFlags, leaves) == root;
+    }
+
+    /**
+     * @dev Returns the root of a tree reconstructed from `leaves` and sibling nodes in `proof`. The reconstruction
+     * proceeds by incrementally reconstructing all inner nodes by combining a leaf/inner node with either another
+     * leaf/inner node or a proof sibling node, depending on whether each `proofFlags` item is true or false
+     * respectively.
+     *
+     * CAUTION: Not all Merkle trees admit multiproofs. To use multiproofs, it is sufficient to ensure that: 1) the tree
+     * is complete (but not necessarily perfect), 2) the leaves to be proven are in the opposite order they are in the
+     * tree (i.e., as seen from right to left starting at the deepest layer and continuing at the next layer).
+     */
+    function processMultiProof(bytes32[] memory proof, bool[] memory proofFlags, bytes32[] memory leaves)
+        internal
+        pure
+        returns (bytes32 merkleRoot)
+    {
+        // This function rebuilds the root hash by traversing the tree up from the leaves. The root is rebuilt by
+        // consuming and producing values on a queue. The queue starts with the `leaves` array, then goes onto the
+        // `hashes` array. At the end of the process, the last hash in the `hashes` array should contain the root of
+        // the Merkle tree.
+        uint256 leavesLen = leaves.length;
+        uint256 proofLen = proof.length;
+        uint256 totalHashes = proofFlags.length;
+
+        // Check proof validity.
+        if (leavesLen + proofLen != totalHashes + 1) {
+            revert MerkleProofInvalidMultiproof();
+        }
+
+        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+        // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
+        bytes32[] memory hashes = new bytes32[](totalHashes);
+        uint256 leafPos = 0;
+        uint256 hashPos = 0;
+        uint256 proofPos = 0;
+        // At each step, we compute the next hash using two values:
+        // - a value from the "main queue". If not all leaves have been consumed, we get the next leaf, otherwise we
+        //   get the next hash.
+        // - depending on the flag, either another value from the "main queue" (merging branches) or an element from the
+        //   `proof` array.
+        for (uint256 i = 0; i < totalHashes; i++) {
+            bytes32 a = leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++];
+            bytes32 b =
+                proofFlags[i] ? (leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++]) : proof[proofPos++];
+            hashes[i] = _hashPair(a, b);
+        }
+
+        if (totalHashes > 0) {
+            if (proofPos != proofLen) {
+                revert MerkleProofInvalidMultiproof();
+            }
+            unchecked {
+                return hashes[totalHashes - 1];
+            }
+        } else if (leavesLen > 0) {
+            return leaves[0];
+        } else {
+            return proof[0];
+        }
+    }
+
+    /**
+     * @dev Calldata version of {processMultiProof}.
+     *
+     * CAUTION: Not all Merkle trees admit multiproofs. See {processMultiProof} for details.
+     */
+    function processMultiProofCalldata(bytes32[] calldata proof, bool[] calldata proofFlags, bytes32[] memory leaves)
+        internal
+        pure
+        returns (bytes32 merkleRoot)
+    {
+        // This function rebuilds the root hash by traversing the tree up from the leaves. The root is rebuilt by
+        // consuming and producing values on a queue. The queue starts with the `leaves` array, then goes onto the
+        // `hashes` array. At the end of the process, the last hash in the `hashes` array should contain the root of
+        // the Merkle tree.
+        uint256 leavesLen = leaves.length;
+        uint256 proofLen = proof.length;
+        uint256 totalHashes = proofFlags.length;
+
+        // Check proof validity.
+        if (leavesLen + proofLen != totalHashes + 1) {
+            revert MerkleProofInvalidMultiproof();
+        }
+
+        // The xxxPos values are "pointers" to the next value to consume in each array. All accesses are done using
+        // `xxx[xxxPos++]`, which return the current value and increment the pointer, thus mimicking a queue's "pop".
+        bytes32[] memory hashes = new bytes32[](totalHashes);
+        uint256 leafPos = 0;
+        uint256 hashPos = 0;
+        uint256 proofPos = 0;
+        // At each step, we compute the next hash using two values:
+        // - a value from the "main queue". If not all leaves have been consumed, we get the next leaf, otherwise we
+        //   get the next hash.
+        // - depending on the flag, either another value from the "main queue" (merging branches) or an element from the
+        //   `proof` array.
+        for (uint256 i = 0; i < totalHashes; i++) {
+            bytes32 a = leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++];
+            bytes32 b =
+                proofFlags[i] ? (leafPos < leavesLen ? leaves[leafPos++] : hashes[hashPos++]) : proof[proofPos++];
+            hashes[i] = _hashPair(a, b);
+        }
+
+        if (totalHashes > 0) {
+            if (proofPos != proofLen) {
+                revert MerkleProofInvalidMultiproof();
+            }
+            unchecked {
+                return hashes[totalHashes - 1];
+            }
+        } else if (leavesLen > 0) {
+            return leaves[0];
+        } else {
+            return proof[0];
+        }
+    }
+
+    /**
+     * @dev Sorts the pair (a, b) and hashes the result.
+     */
+    function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
+        return a < b ? _efficientHash(a, b) : _efficientHash(b, a);
+    }
+
+    /**
+     * @dev Implementation of keccak256(abi.encode(a, b)) that doesn't allocate or expand memory.
+     */
+    function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            value := keccak256(0x00, 0x40)
+        }
+    }
+}
+
+// ../lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/math/SafeCast.sol)
+// This file was procedurally generated from scripts/generate/templates/SafeCast.js.
+
+/**
+ * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow
+ * checks.
+ *
+ * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can
+ * easily result in undesired exploitation or bugs, since developers usually
+ * assume that overflows raise errors. `SafeCast` restores this intuition by
+ * reverting the transaction when such an operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeCast {
+    /**
+     * @dev Value doesn't fit in an uint of `bits` size.
+     */
+    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
+
+    /**
+     * @dev An int value doesn't fit in an uint of `bits` size.
+     */
+    error SafeCastOverflowedIntToUint(int256 value);
+
+    /**
+     * @dev Value doesn't fit in an int of `bits` size.
+     */
+    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);
+
+    /**
+     * @dev An uint value doesn't fit in an int of `bits` size.
+     */
+    error SafeCastOverflowedUintToInt(uint256 value);
+
+    /**
+     * @dev Returns the downcasted uint248 from uint256, reverting on
+     * overflow (when the input is greater than largest uint248).
+     *
+     * Counterpart to Solidity's `uint248` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 248 bits
+     */
+    function toUint248(uint256 value) internal pure returns (uint248) {
+        if (value > type(uint248).max) {
+            revert SafeCastOverflowedUintDowncast(248, value);
+        }
+        return uint248(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint240 from uint256, reverting on
+     * overflow (when the input is greater than largest uint240).
+     *
+     * Counterpart to Solidity's `uint240` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 240 bits
+     */
+    function toUint240(uint256 value) internal pure returns (uint240) {
+        if (value > type(uint240).max) {
+            revert SafeCastOverflowedUintDowncast(240, value);
+        }
+        return uint240(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint232 from uint256, reverting on
+     * overflow (when the input is greater than largest uint232).
+     *
+     * Counterpart to Solidity's `uint232` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 232 bits
+     */
+    function toUint232(uint256 value) internal pure returns (uint232) {
+        if (value > type(uint232).max) {
+            revert SafeCastOverflowedUintDowncast(232, value);
+        }
+        return uint232(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint224 from uint256, reverting on
+     * overflow (when the input is greater than largest uint224).
+     *
+     * Counterpart to Solidity's `uint224` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 224 bits
+     */
+    function toUint224(uint256 value) internal pure returns (uint224) {
+        if (value > type(uint224).max) {
+            revert SafeCastOverflowedUintDowncast(224, value);
+        }
+        return uint224(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint216 from uint256, reverting on
+     * overflow (when the input is greater than largest uint216).
+     *
+     * Counterpart to Solidity's `uint216` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 216 bits
+     */
+    function toUint216(uint256 value) internal pure returns (uint216) {
+        if (value > type(uint216).max) {
+            revert SafeCastOverflowedUintDowncast(216, value);
+        }
+        return uint216(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint208 from uint256, reverting on
+     * overflow (when the input is greater than largest uint208).
+     *
+     * Counterpart to Solidity's `uint208` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 208 bits
+     */
+    function toUint208(uint256 value) internal pure returns (uint208) {
+        if (value > type(uint208).max) {
+            revert SafeCastOverflowedUintDowncast(208, value);
+        }
+        return uint208(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint200 from uint256, reverting on
+     * overflow (when the input is greater than largest uint200).
+     *
+     * Counterpart to Solidity's `uint200` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 200 bits
+     */
+    function toUint200(uint256 value) internal pure returns (uint200) {
+        if (value > type(uint200).max) {
+            revert SafeCastOverflowedUintDowncast(200, value);
+        }
+        return uint200(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint192 from uint256, reverting on
+     * overflow (when the input is greater than largest uint192).
+     *
+     * Counterpart to Solidity's `uint192` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 192 bits
+     */
+    function toUint192(uint256 value) internal pure returns (uint192) {
+        if (value > type(uint192).max) {
+            revert SafeCastOverflowedUintDowncast(192, value);
+        }
+        return uint192(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint184 from uint256, reverting on
+     * overflow (when the input is greater than largest uint184).
+     *
+     * Counterpart to Solidity's `uint184` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 184 bits
+     */
+    function toUint184(uint256 value) internal pure returns (uint184) {
+        if (value > type(uint184).max) {
+            revert SafeCastOverflowedUintDowncast(184, value);
+        }
+        return uint184(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint176 from uint256, reverting on
+     * overflow (when the input is greater than largest uint176).
+     *
+     * Counterpart to Solidity's `uint176` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 176 bits
+     */
+    function toUint176(uint256 value) internal pure returns (uint176) {
+        if (value > type(uint176).max) {
+            revert SafeCastOverflowedUintDowncast(176, value);
+        }
+        return uint176(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint168 from uint256, reverting on
+     * overflow (when the input is greater than largest uint168).
+     *
+     * Counterpart to Solidity's `uint168` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 168 bits
+     */
+    function toUint168(uint256 value) internal pure returns (uint168) {
+        if (value > type(uint168).max) {
+            revert SafeCastOverflowedUintDowncast(168, value);
+        }
+        return uint168(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint160 from uint256, reverting on
+     * overflow (when the input is greater than largest uint160).
+     *
+     * Counterpart to Solidity's `uint160` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 160 bits
+     */
+    function toUint160(uint256 value) internal pure returns (uint160) {
+        if (value > type(uint160).max) {
+            revert SafeCastOverflowedUintDowncast(160, value);
+        }
+        return uint160(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint152 from uint256, reverting on
+     * overflow (when the input is greater than largest uint152).
+     *
+     * Counterpart to Solidity's `uint152` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 152 bits
+     */
+    function toUint152(uint256 value) internal pure returns (uint152) {
+        if (value > type(uint152).max) {
+            revert SafeCastOverflowedUintDowncast(152, value);
+        }
+        return uint152(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint144 from uint256, reverting on
+     * overflow (when the input is greater than largest uint144).
+     *
+     * Counterpart to Solidity's `uint144` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 144 bits
+     */
+    function toUint144(uint256 value) internal pure returns (uint144) {
+        if (value > type(uint144).max) {
+            revert SafeCastOverflowedUintDowncast(144, value);
+        }
+        return uint144(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint136 from uint256, reverting on
+     * overflow (when the input is greater than largest uint136).
+     *
+     * Counterpart to Solidity's `uint136` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 136 bits
+     */
+    function toUint136(uint256 value) internal pure returns (uint136) {
+        if (value > type(uint136).max) {
+            revert SafeCastOverflowedUintDowncast(136, value);
+        }
+        return uint136(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint128 from uint256, reverting on
+     * overflow (when the input is greater than largest uint128).
+     *
+     * Counterpart to Solidity's `uint128` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 128 bits
+     */
+    function toUint128(uint256 value) internal pure returns (uint128) {
+        if (value > type(uint128).max) {
+            revert SafeCastOverflowedUintDowncast(128, value);
+        }
+        return uint128(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint120 from uint256, reverting on
+     * overflow (when the input is greater than largest uint120).
+     *
+     * Counterpart to Solidity's `uint120` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 120 bits
+     */
+    function toUint120(uint256 value) internal pure returns (uint120) {
+        if (value > type(uint120).max) {
+            revert SafeCastOverflowedUintDowncast(120, value);
+        }
+        return uint120(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint112 from uint256, reverting on
+     * overflow (when the input is greater than largest uint112).
+     *
+     * Counterpart to Solidity's `uint112` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 112 bits
+     */
+    function toUint112(uint256 value) internal pure returns (uint112) {
+        if (value > type(uint112).max) {
+            revert SafeCastOverflowedUintDowncast(112, value);
+        }
+        return uint112(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint104 from uint256, reverting on
+     * overflow (when the input is greater than largest uint104).
+     *
+     * Counterpart to Solidity's `uint104` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 104 bits
+     */
+    function toUint104(uint256 value) internal pure returns (uint104) {
+        if (value > type(uint104).max) {
+            revert SafeCastOverflowedUintDowncast(104, value);
+        }
+        return uint104(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint96 from uint256, reverting on
+     * overflow (when the input is greater than largest uint96).
+     *
+     * Counterpart to Solidity's `uint96` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 96 bits
+     */
+    function toUint96(uint256 value) internal pure returns (uint96) {
+        if (value > type(uint96).max) {
+            revert SafeCastOverflowedUintDowncast(96, value);
+        }
+        return uint96(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint88 from uint256, reverting on
+     * overflow (when the input is greater than largest uint88).
+     *
+     * Counterpart to Solidity's `uint88` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 88 bits
+     */
+    function toUint88(uint256 value) internal pure returns (uint88) {
+        if (value > type(uint88).max) {
+            revert SafeCastOverflowedUintDowncast(88, value);
+        }
+        return uint88(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint80 from uint256, reverting on
+     * overflow (when the input is greater than largest uint80).
+     *
+     * Counterpart to Solidity's `uint80` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 80 bits
+     */
+    function toUint80(uint256 value) internal pure returns (uint80) {
+        if (value > type(uint80).max) {
+            revert SafeCastOverflowedUintDowncast(80, value);
+        }
+        return uint80(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint72 from uint256, reverting on
+     * overflow (when the input is greater than largest uint72).
+     *
+     * Counterpart to Solidity's `uint72` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 72 bits
+     */
+    function toUint72(uint256 value) internal pure returns (uint72) {
+        if (value > type(uint72).max) {
+            revert SafeCastOverflowedUintDowncast(72, value);
+        }
+        return uint72(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint64 from uint256, reverting on
+     * overflow (when the input is greater than largest uint64).
+     *
+     * Counterpart to Solidity's `uint64` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 64 bits
+     */
+    function toUint64(uint256 value) internal pure returns (uint64) {
+        if (value > type(uint64).max) {
+            revert SafeCastOverflowedUintDowncast(64, value);
+        }
+        return uint64(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint56 from uint256, reverting on
+     * overflow (when the input is greater than largest uint56).
+     *
+     * Counterpart to Solidity's `uint56` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 56 bits
+     */
+    function toUint56(uint256 value) internal pure returns (uint56) {
+        if (value > type(uint56).max) {
+            revert SafeCastOverflowedUintDowncast(56, value);
+        }
+        return uint56(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint48 from uint256, reverting on
+     * overflow (when the input is greater than largest uint48).
+     *
+     * Counterpart to Solidity's `uint48` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 48 bits
+     */
+    function toUint48(uint256 value) internal pure returns (uint48) {
+        if (value > type(uint48).max) {
+            revert SafeCastOverflowedUintDowncast(48, value);
+        }
+        return uint48(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint40 from uint256, reverting on
+     * overflow (when the input is greater than largest uint40).
+     *
+     * Counterpart to Solidity's `uint40` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 40 bits
+     */
+    function toUint40(uint256 value) internal pure returns (uint40) {
+        if (value > type(uint40).max) {
+            revert SafeCastOverflowedUintDowncast(40, value);
+        }
+        return uint40(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint32 from uint256, reverting on
+     * overflow (when the input is greater than largest uint32).
+     *
+     * Counterpart to Solidity's `uint32` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 32 bits
+     */
+    function toUint32(uint256 value) internal pure returns (uint32) {
+        if (value > type(uint32).max) {
+            revert SafeCastOverflowedUintDowncast(32, value);
+        }
+        return uint32(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint24 from uint256, reverting on
+     * overflow (when the input is greater than largest uint24).
+     *
+     * Counterpart to Solidity's `uint24` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 24 bits
+     */
+    function toUint24(uint256 value) internal pure returns (uint24) {
+        if (value > type(uint24).max) {
+            revert SafeCastOverflowedUintDowncast(24, value);
+        }
+        return uint24(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint16 from uint256, reverting on
+     * overflow (when the input is greater than largest uint16).
+     *
+     * Counterpart to Solidity's `uint16` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 16 bits
+     */
+    function toUint16(uint256 value) internal pure returns (uint16) {
+        if (value > type(uint16).max) {
+            revert SafeCastOverflowedUintDowncast(16, value);
+        }
+        return uint16(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint8 from uint256, reverting on
+     * overflow (when the input is greater than largest uint8).
+     *
+     * Counterpart to Solidity's `uint8` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 8 bits
+     */
+    function toUint8(uint256 value) internal pure returns (uint8) {
+        if (value > type(uint8).max) {
+            revert SafeCastOverflowedUintDowncast(8, value);
+        }
+        return uint8(value);
+    }
+
+    /**
+     * @dev Converts a signed int256 into an unsigned uint256.
+     *
+     * Requirements:
+     *
+     * - input must be greater than or equal to 0.
+     */
+    function toUint256(int256 value) internal pure returns (uint256) {
+        if (value < 0) {
+            revert SafeCastOverflowedIntToUint(value);
+        }
+        return uint256(value);
+    }
+
+    /**
+     * @dev Returns the downcasted int248 from int256, reverting on
+     * overflow (when the input is less than smallest int248 or
+     * greater than largest int248).
+     *
+     * Counterpart to Solidity's `int248` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 248 bits
+     */
+    function toInt248(int256 value) internal pure returns (int248 downcasted) {
+        downcasted = int248(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(248, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int240 from int256, reverting on
+     * overflow (when the input is less than smallest int240 or
+     * greater than largest int240).
+     *
+     * Counterpart to Solidity's `int240` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 240 bits
+     */
+    function toInt240(int256 value) internal pure returns (int240 downcasted) {
+        downcasted = int240(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(240, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int232 from int256, reverting on
+     * overflow (when the input is less than smallest int232 or
+     * greater than largest int232).
+     *
+     * Counterpart to Solidity's `int232` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 232 bits
+     */
+    function toInt232(int256 value) internal pure returns (int232 downcasted) {
+        downcasted = int232(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(232, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int224 from int256, reverting on
+     * overflow (when the input is less than smallest int224 or
+     * greater than largest int224).
+     *
+     * Counterpart to Solidity's `int224` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 224 bits
+     */
+    function toInt224(int256 value) internal pure returns (int224 downcasted) {
+        downcasted = int224(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(224, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int216 from int256, reverting on
+     * overflow (when the input is less than smallest int216 or
+     * greater than largest int216).
+     *
+     * Counterpart to Solidity's `int216` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 216 bits
+     */
+    function toInt216(int256 value) internal pure returns (int216 downcasted) {
+        downcasted = int216(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(216, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int208 from int256, reverting on
+     * overflow (when the input is less than smallest int208 or
+     * greater than largest int208).
+     *
+     * Counterpart to Solidity's `int208` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 208 bits
+     */
+    function toInt208(int256 value) internal pure returns (int208 downcasted) {
+        downcasted = int208(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(208, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int200 from int256, reverting on
+     * overflow (when the input is less than smallest int200 or
+     * greater than largest int200).
+     *
+     * Counterpart to Solidity's `int200` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 200 bits
+     */
+    function toInt200(int256 value) internal pure returns (int200 downcasted) {
+        downcasted = int200(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(200, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int192 from int256, reverting on
+     * overflow (when the input is less than smallest int192 or
+     * greater than largest int192).
+     *
+     * Counterpart to Solidity's `int192` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 192 bits
+     */
+    function toInt192(int256 value) internal pure returns (int192 downcasted) {
+        downcasted = int192(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(192, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int184 from int256, reverting on
+     * overflow (when the input is less than smallest int184 or
+     * greater than largest int184).
+     *
+     * Counterpart to Solidity's `int184` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 184 bits
+     */
+    function toInt184(int256 value) internal pure returns (int184 downcasted) {
+        downcasted = int184(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(184, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int176 from int256, reverting on
+     * overflow (when the input is less than smallest int176 or
+     * greater than largest int176).
+     *
+     * Counterpart to Solidity's `int176` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 176 bits
+     */
+    function toInt176(int256 value) internal pure returns (int176 downcasted) {
+        downcasted = int176(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(176, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int168 from int256, reverting on
+     * overflow (when the input is less than smallest int168 or
+     * greater than largest int168).
+     *
+     * Counterpart to Solidity's `int168` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 168 bits
+     */
+    function toInt168(int256 value) internal pure returns (int168 downcasted) {
+        downcasted = int168(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(168, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int160 from int256, reverting on
+     * overflow (when the input is less than smallest int160 or
+     * greater than largest int160).
+     *
+     * Counterpart to Solidity's `int160` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 160 bits
+     */
+    function toInt160(int256 value) internal pure returns (int160 downcasted) {
+        downcasted = int160(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(160, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int152 from int256, reverting on
+     * overflow (when the input is less than smallest int152 or
+     * greater than largest int152).
+     *
+     * Counterpart to Solidity's `int152` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 152 bits
+     */
+    function toInt152(int256 value) internal pure returns (int152 downcasted) {
+        downcasted = int152(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(152, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int144 from int256, reverting on
+     * overflow (when the input is less than smallest int144 or
+     * greater than largest int144).
+     *
+     * Counterpart to Solidity's `int144` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 144 bits
+     */
+    function toInt144(int256 value) internal pure returns (int144 downcasted) {
+        downcasted = int144(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(144, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int136 from int256, reverting on
+     * overflow (when the input is less than smallest int136 or
+     * greater than largest int136).
+     *
+     * Counterpart to Solidity's `int136` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 136 bits
+     */
+    function toInt136(int256 value) internal pure returns (int136 downcasted) {
+        downcasted = int136(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(136, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int128 from int256, reverting on
+     * overflow (when the input is less than smallest int128 or
+     * greater than largest int128).
+     *
+     * Counterpart to Solidity's `int128` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 128 bits
+     */
+    function toInt128(int256 value) internal pure returns (int128 downcasted) {
+        downcasted = int128(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(128, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int120 from int256, reverting on
+     * overflow (when the input is less than smallest int120 or
+     * greater than largest int120).
+     *
+     * Counterpart to Solidity's `int120` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 120 bits
+     */
+    function toInt120(int256 value) internal pure returns (int120 downcasted) {
+        downcasted = int120(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(120, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int112 from int256, reverting on
+     * overflow (when the input is less than smallest int112 or
+     * greater than largest int112).
+     *
+     * Counterpart to Solidity's `int112` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 112 bits
+     */
+    function toInt112(int256 value) internal pure returns (int112 downcasted) {
+        downcasted = int112(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(112, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int104 from int256, reverting on
+     * overflow (when the input is less than smallest int104 or
+     * greater than largest int104).
+     *
+     * Counterpart to Solidity's `int104` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 104 bits
+     */
+    function toInt104(int256 value) internal pure returns (int104 downcasted) {
+        downcasted = int104(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(104, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int96 from int256, reverting on
+     * overflow (when the input is less than smallest int96 or
+     * greater than largest int96).
+     *
+     * Counterpart to Solidity's `int96` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 96 bits
+     */
+    function toInt96(int256 value) internal pure returns (int96 downcasted) {
+        downcasted = int96(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(96, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int88 from int256, reverting on
+     * overflow (when the input is less than smallest int88 or
+     * greater than largest int88).
+     *
+     * Counterpart to Solidity's `int88` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 88 bits
+     */
+    function toInt88(int256 value) internal pure returns (int88 downcasted) {
+        downcasted = int88(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(88, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int80 from int256, reverting on
+     * overflow (when the input is less than smallest int80 or
+     * greater than largest int80).
+     *
+     * Counterpart to Solidity's `int80` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 80 bits
+     */
+    function toInt80(int256 value) internal pure returns (int80 downcasted) {
+        downcasted = int80(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(80, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int72 from int256, reverting on
+     * overflow (when the input is less than smallest int72 or
+     * greater than largest int72).
+     *
+     * Counterpart to Solidity's `int72` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 72 bits
+     */
+    function toInt72(int256 value) internal pure returns (int72 downcasted) {
+        downcasted = int72(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(72, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int64 from int256, reverting on
+     * overflow (when the input is less than smallest int64 or
+     * greater than largest int64).
+     *
+     * Counterpart to Solidity's `int64` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 64 bits
+     */
+    function toInt64(int256 value) internal pure returns (int64 downcasted) {
+        downcasted = int64(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(64, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int56 from int256, reverting on
+     * overflow (when the input is less than smallest int56 or
+     * greater than largest int56).
+     *
+     * Counterpart to Solidity's `int56` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 56 bits
+     */
+    function toInt56(int256 value) internal pure returns (int56 downcasted) {
+        downcasted = int56(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(56, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int48 from int256, reverting on
+     * overflow (when the input is less than smallest int48 or
+     * greater than largest int48).
+     *
+     * Counterpart to Solidity's `int48` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 48 bits
+     */
+    function toInt48(int256 value) internal pure returns (int48 downcasted) {
+        downcasted = int48(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(48, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int40 from int256, reverting on
+     * overflow (when the input is less than smallest int40 or
+     * greater than largest int40).
+     *
+     * Counterpart to Solidity's `int40` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 40 bits
+     */
+    function toInt40(int256 value) internal pure returns (int40 downcasted) {
+        downcasted = int40(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(40, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int32 from int256, reverting on
+     * overflow (when the input is less than smallest int32 or
+     * greater than largest int32).
+     *
+     * Counterpart to Solidity's `int32` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 32 bits
+     */
+    function toInt32(int256 value) internal pure returns (int32 downcasted) {
+        downcasted = int32(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(32, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int24 from int256, reverting on
+     * overflow (when the input is less than smallest int24 or
+     * greater than largest int24).
+     *
+     * Counterpart to Solidity's `int24` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 24 bits
+     */
+    function toInt24(int256 value) internal pure returns (int24 downcasted) {
+        downcasted = int24(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(24, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int16 from int256, reverting on
+     * overflow (when the input is less than smallest int16 or
+     * greater than largest int16).
+     *
+     * Counterpart to Solidity's `int16` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 16 bits
+     */
+    function toInt16(int256 value) internal pure returns (int16 downcasted) {
+        downcasted = int16(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(16, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int8 from int256, reverting on
+     * overflow (when the input is less than smallest int8 or
+     * greater than largest int8).
+     *
+     * Counterpart to Solidity's `int8` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 8 bits
+     */
+    function toInt8(int256 value) internal pure returns (int8 downcasted) {
+        downcasted = int8(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(8, value);
+        }
+    }
+
+    /**
+     * @dev Converts an unsigned uint256 into a signed int256.
+     *
+     * Requirements:
+     *
+     * - input must be less than or equal to maxInt256.
+     */
+    function toInt256(uint256 value) internal pure returns (int256) {
+        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive
+        if (value > uint256(type(int256).max)) {
+            revert SafeCastOverflowedUintToInt(value);
+        }
+        return int256(value);
+    }
+}
+
+// src/IRiscZeroSelectable.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// @notice Selectable interface for RISC Zero verifier.
+interface IRiscZeroSelectable {
+    /// @notice A short key attached to the seal to select the correct verifier implementation.
+    /// @dev The selector is taken from the hash of the verifier parameters If two
+    ///      receipts have different selectors (i.e. different verifier parameters), then it can
+    ///      generally be assumed that they need distinct verifier implementations. This is used as
+    ///      part of the RISC Zero versioning mechanism.
+    ///
+    ///      A selector is not intended to be collision resistant, in that it is possible to find
+    ///      two preimages that result in the same selector. This is acceptable since it's purpose
+    ///      to a route a request among a set of trusted verifiers, and to make errors of sending a
+    ///      receipt to a mismatching verifiers easier to debug. It is analogous to the ABI
+    ///      function selectors.
+    function SELECTOR() external view returns (bytes4);
+}
+
+// src/Util.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// @notice reverse the byte order of the uint256 value.
+/// @dev Solidity uses a big-endian ABI encoding. Reversing the byte order before encoding
+/// ensure that the encoded value will be little-endian.
+/// Written by k06a. https://ethereum.stackexchange.com/a/83627
+function reverseByteOrderUint256(uint256 input) pure returns (uint256 v) {
+    v = input;
+
+    // swap bytes
+    v = ((v & 0xFF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00) >> 8)
+        | ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+
+    // swap 2-byte long pairs
+    v = ((v & 0xFFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000) >> 16)
+        | ((v & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+
+    // swap 4-byte long pairs
+    v = ((v & 0xFFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000) >> 32)
+        | ((v & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
+
+    // swap 8-byte long pairs
+    v = ((v & 0xFFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF0000000000000000) >> 64)
+        | ((v & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
+
+    // swap 16-byte long pairs
+    v = (v >> 128) | (v << 128);
+}
+
+/// @notice reverse the byte order of the uint32 value.
+/// @dev Solidity uses a big-endian ABI encoding. Reversing the byte order before encoding
+/// ensure that the encoded value will be little-endian.
+/// Written by k06a. https://ethereum.stackexchange.com/a/83627
+function reverseByteOrderUint32(uint32 input) pure returns (uint32 v) {
+    v = input;
+
+    // swap bytes
+    v = ((v & 0xFF00FF00) >> 8) | ((v & 0x00FF00FF) << 8);
+
+    // swap 2-byte long pairs
+    v = (v >> 16) | (v << 16);
+}
+
+/// @notice reverse the byte order of the uint16 value.
+/// @dev Solidity uses a big-endian ABI encoding. Reversing the byte order before encoding
+/// ensure that the encoded value will be little-endian.
+/// Written by k06a. https://ethereum.stackexchange.com/a/83627
+function reverseByteOrderUint16(uint16 input) pure returns (uint16 v) {
+    v = input;
+
+    // swap bytes
+    v = (v >> 8) | ((v & 0x00FF) << 8);
+}
+
+// src/groth16/ControlID.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// This file is automatically generated by:
+// cargo xtask bootstrap-groth16
+
+library ControlID {
+    bytes32 public constant CONTROL_ROOT = hex"8cdad9242664be3112aba377c5425a4df735eb1c6966472b561d2855932c0469";
+    // NOTE: This has the opposite byte order to the value in the risc0 repository.
+    bytes32 public constant BN254_CONTROL_ID = hex"04446e66d300eb7fb45c9726bb53c793dda407a62e9601618bb43c5c14657ac0";
+}
+
+// src/groth16/Groth16Verifier.sol
+
+/*
+    Copyright 2021 0KIMS association.
+
+    This file is generated with [snarkJS](https://github.com/iden3/snarkjs).
+
+    snarkJS is a free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    snarkJS is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with snarkJS. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+contract Groth16Verifier {
+    // Scalar field size
+    uint256 constant r = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    // Base field size
+    uint256 constant q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    // Verification Key data
+    uint256 constant alphax = 20491192805390485299153009773594534940189261866228447918068658471970481763042;
+    uint256 constant alphay = 9383485363053290200918347156157836566562967994039712273449902621266178545958;
+    uint256 constant betax1 = 4252822878758300859123897981450591353533073413197771768651442665752259397132;
+    uint256 constant betax2 = 6375614351688725206403948262868962793625744043794305715222011528459656738731;
+    uint256 constant betay1 = 21847035105528745403288232691147584728191162732299865338377159692350059136679;
+    uint256 constant betay2 = 10505242626370262277552901082094356697409835680220590971873171140371331206856;
+    uint256 constant gammax1 = 11559732032986387107991004021392285783925812861821192530917403151452391805634;
+    uint256 constant gammax2 = 10857046999023057135944570762232829481370756359578518086990519993285655852781;
+    uint256 constant gammay1 = 4082367875863433681332203403145435568316851327593401208105741076214120093531;
+    uint256 constant gammay2 = 8495653923123431417604973247489272438418190587263600148770280649306958101930;
+    uint256 constant deltax1 = 1668323501672964604911431804142266013250380587483576094566949227275849579036;
+    uint256 constant deltax2 = 12043754404802191763554326994664886008979042643626290185762540825416902247219;
+    uint256 constant deltay1 = 7710631539206257456743780535472368339139328733484942210876916214502466455394;
+    uint256 constant deltay2 = 13740680757317479711909903993315946540841369848973133181051452051592786724563;
+
+    uint256 constant IC0x = 8446592859352799428420270221449902464741693648963397251242447530457567083492;
+    uint256 constant IC0y = 1064796367193003797175961162477173481551615790032213185848276823815288302804;
+
+    uint256 constant IC1x = 3179835575189816632597428042194253779818690147323192973511715175294048485951;
+    uint256 constant IC1y = 20895841676865356752879376687052266198216014795822152491318012491767775979074;
+
+    uint256 constant IC2x = 5332723250224941161709478398807683311971555792614491788690328996478511465287;
+    uint256 constant IC2y = 21199491073419440416471372042641226693637837098357067793586556692319371762571;
+
+    uint256 constant IC3x = 12457994489566736295787256452575216703923664299075106359829199968023158780583;
+    uint256 constant IC3y = 19706766271952591897761291684837117091856807401404423804318744964752784280790;
+
+    uint256 constant IC4x = 19617808913178163826953378459323299110911217259216006187355745713323154132237;
+    uint256 constant IC4y = 21663537384585072695701846972542344484111393047775983928357046779215877070466;
+
+    uint256 constant IC5x = 6834578911681792552110317589222010969491336870276623105249474534788043166867;
+    uint256 constant IC5y = 15060583660288623605191393599883223885678013570733629274538391874953353488393;
+
+    // Memory data
+    uint16 constant pVk = 0;
+    uint16 constant pPairing = 128;
+
+    uint16 constant pLastMem = 896;
+
+    function verifyProof(
+        uint256[2] calldata _pA,
+        uint256[2][2] calldata _pB,
+        uint256[2] calldata _pC,
+        uint256[5] calldata _pubSignals
+    ) public view returns (bool) {
+        assembly {
+            function checkField(v) {
+                if iszero(lt(v, r)) {
+                    mstore(0, 0)
+                    return(0, 0x20)
+                }
+            }
+
+            // G1 function to multiply a G1 value(x,y) to value in an address
+            function g1_mulAccC(pR, x, y, s) {
+                let success
+                let mIn := mload(0x40)
+                mstore(mIn, x)
+                mstore(add(mIn, 32), y)
+                mstore(add(mIn, 64), s)
+
+                success := staticcall(sub(gas(), 2000), 7, mIn, 96, mIn, 64)
+
+                if iszero(success) {
+                    mstore(0, 0)
+                    return(0, 0x20)
+                }
+
+                mstore(add(mIn, 64), mload(pR))
+                mstore(add(mIn, 96), mload(add(pR, 32)))
+
+                success := staticcall(sub(gas(), 2000), 6, mIn, 128, pR, 64)
+
+                if iszero(success) {
+                    mstore(0, 0)
+                    return(0, 0x20)
+                }
+            }
+
+            function checkPairing(pA, pB, pC, pubSignals, pMem) -> isOk {
+                let _pPairing := add(pMem, pPairing)
+                let _pVk := add(pMem, pVk)
+
+                mstore(_pVk, IC0x)
+                mstore(add(_pVk, 32), IC0y)
+
+                // Compute the linear combination vk_x
+
+                g1_mulAccC(_pVk, IC1x, IC1y, calldataload(add(pubSignals, 0)))
+
+                g1_mulAccC(_pVk, IC2x, IC2y, calldataload(add(pubSignals, 32)))
+
+                g1_mulAccC(_pVk, IC3x, IC3y, calldataload(add(pubSignals, 64)))
+
+                g1_mulAccC(_pVk, IC4x, IC4y, calldataload(add(pubSignals, 96)))
+
+                g1_mulAccC(_pVk, IC5x, IC5y, calldataload(add(pubSignals, 128)))
+
+                // -A
+                mstore(_pPairing, calldataload(pA))
+                mstore(add(_pPairing, 32), mod(sub(q, calldataload(add(pA, 32))), q))
+
+                // B
+                mstore(add(_pPairing, 64), calldataload(pB))
+                mstore(add(_pPairing, 96), calldataload(add(pB, 32)))
+                mstore(add(_pPairing, 128), calldataload(add(pB, 64)))
+                mstore(add(_pPairing, 160), calldataload(add(pB, 96)))
+
+                // alpha1
+                mstore(add(_pPairing, 192), alphax)
+                mstore(add(_pPairing, 224), alphay)
+
+                // beta2
+                mstore(add(_pPairing, 256), betax1)
+                mstore(add(_pPairing, 288), betax2)
+                mstore(add(_pPairing, 320), betay1)
+                mstore(add(_pPairing, 352), betay2)
+
+                // vk_x
+                mstore(add(_pPairing, 384), mload(add(pMem, pVk)))
+                mstore(add(_pPairing, 416), mload(add(pMem, add(pVk, 32))))
+
+                // gamma2
+                mstore(add(_pPairing, 448), gammax1)
+                mstore(add(_pPairing, 480), gammax2)
+                mstore(add(_pPairing, 512), gammay1)
+                mstore(add(_pPairing, 544), gammay2)
+
+                // C
+                mstore(add(_pPairing, 576), calldataload(pC))
+                mstore(add(_pPairing, 608), calldataload(add(pC, 32)))
+
+                // delta2
+                mstore(add(_pPairing, 640), deltax1)
+                mstore(add(_pPairing, 672), deltax2)
+                mstore(add(_pPairing, 704), deltay1)
+                mstore(add(_pPairing, 736), deltay2)
+
+                let success := staticcall(sub(gas(), 2000), 8, _pPairing, 768, _pPairing, 0x20)
+
+                isOk := and(success, mload(_pPairing))
+            }
+
+            let pMem := mload(0x40)
+            mstore(0x40, add(pMem, pLastMem))
+
+            // Validate that all evaluations ∈ F
+
+            checkField(calldataload(add(_pubSignals, 0)))
+
+            checkField(calldataload(add(_pubSignals, 32)))
+
+            checkField(calldataload(add(_pubSignals, 64)))
+
+            checkField(calldataload(add(_pubSignals, 96)))
+
+            checkField(calldataload(add(_pubSignals, 128)))
+
+            checkField(calldataload(add(_pubSignals, 160)))
+
+            // Validate all evaluations
+            let isValid := checkPairing(_pA, _pB, _pC, _pubSignals, pMem)
+
+            mstore(0, isValid)
+            return(0, 0x20)
+        }
+    }
+}
+
+// /Users/ramikhalil/risczero/risc0-ethereum/lib/openzeppelin-contracts/contracts/utils/Context.sol
+
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}
+
+// src/IRiscZeroVerifier.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// @notice A receipt attesting to the execution of a guest program.
+/// @dev A receipt contains two parts: a seal and a claim. The seal is a zero-knowledge proof
+/// attesting to knowledge of a zkVM execution resulting in the claim. The claim is a set of public
+/// outputs for the execution. Crucially, the claim includes the journal and the image ID. The
+/// image ID identifies the program that was executed, and the journal is the public data written
+/// by the program. Note that this struct only contains the claim digest, as can be obtained with
+/// the `digest()` function on `ReceiptClaimLib`.
+struct Receipt {
+    bytes seal;
+    bytes32 claimDigest;
+}
+
+/// @notice Public claims about a zkVM guest execution, such as the journal committed to by the guest.
+/// @dev Also includes important information such as the exit code and the starting and ending system
+/// state (i.e. the state of memory). `ReceiptClaim` is a "Merkle-ized struct" supporting
+/// partial openings of the underlying fields from a hash commitment to the full structure.
+struct ReceiptClaim {
+    /// @notice Digest of the SystemState just before execution has begun.
+    bytes32 preStateDigest;
+    /// @notice Digest of the SystemState just after execution has completed.
+    bytes32 postStateDigest;
+    /// @notice The exit code for the execution.
+    ExitCode exitCode;
+    /// @notice A digest of the input to the guest.
+    /// @dev This field is currently unused and must be set to the zero digest.
+    bytes32 input;
+    /// @notice Digest of the Output of the guest, including the journal
+    /// and assumptions set during execution.
+    bytes32 output;
+}
+
+library ReceiptClaimLib {
+    using OutputLib for Output;
+    using SystemStateLib for SystemState;
+
+    bytes32 constant TAG_DIGEST = sha256("risc0.ReceiptClaim");
+
+    // Define a constant to ensure hashing is done at compile time. Can't use the
+    // SystemStateLib.digest method here because the Solidity compiler complains.
+    bytes32 constant SYSTEM_STATE_ZERO_DIGEST = 0xa3acc27117418996340b84e5a90f3ef4c49d22c79e44aad822ec9c313e1eb8e2;
+
+    /// @notice Construct a ReceiptClaim from the given imageId and journalDigest.
+    ///         Returned ReceiptClaim will represent a successful execution of the zkVM, running
+    ///         the program committed by imageId and resulting in the journal specified by
+    ///         journalDigest.
+    /// @param imageId The identifier for the guest program.
+    /// @param journalDigest The SHA-256 digest of the journal bytes.
+    /// @dev Input hash and postStateDigest are set to all-zeros (i.e. no committed input, or
+    ///      final memory state), the exit code is (Halted, 0), and there are no assumptions
+    ///      (i.e. the receipt is unconditional).
+    function ok(bytes32 imageId, bytes32 journalDigest) internal pure returns (ReceiptClaim memory) {
+        return ReceiptClaim(
+            imageId,
+            SYSTEM_STATE_ZERO_DIGEST,
+            ExitCode(SystemExitCode.Halted, 0),
+            bytes32(0),
+            Output(journalDigest, bytes32(0)).digest()
+        );
+    }
+
+    function digest(ReceiptClaim memory claim) internal pure returns (bytes32) {
+        return sha256(
+            abi.encodePacked(
+                TAG_DIGEST,
+                // down
+                claim.input,
+                claim.preStateDigest,
+                claim.postStateDigest,
+                claim.output,
+                // data
+                uint32(claim.exitCode.system) << 24,
+                uint32(claim.exitCode.user) << 24,
+                // down.length
+                uint16(4) << 8
+            )
+        );
+    }
+}
+
+/// @notice Commitment to the memory state and program counter (pc) of the zkVM.
+/// @dev The "pre" and "post" fields of the ReceiptClaim are digests of the system state at the
+///      start are stop of execution. Programs are loaded into the zkVM by creating a memory image
+///      of the loaded program, and creating a system state for initializing the zkVM. This is
+///      known as the "image ID".
+struct SystemState {
+    /// @notice Program counter.
+    uint32 pc;
+    /// @notice Root hash of a merkle tree which confirms the integrity of the memory image.
+    bytes32 merkle_root;
+}
+
+library SystemStateLib {
+    bytes32 constant TAG_DIGEST = sha256("risc0.SystemState");
+
+    function digest(SystemState memory state) internal pure returns (bytes32) {
+        return sha256(
+            abi.encodePacked(
+                TAG_DIGEST,
+                // down
+                state.merkle_root,
+                // data
+                reverseByteOrderUint32(state.pc),
+                // down.length
+                uint16(1) << 8
+            )
+        );
+    }
+}
+
+/// @notice Exit condition indicated by the zkVM at the end of the guest execution.
+/// @dev Exit codes have a "system" part and a "user" part. Semantically, the system part is set to
+/// indicate the type of exit (e.g. halt, pause, or system split) and is directly controlled by the
+/// zkVM. The user part is an exit code, similar to exit codes used in Linux, chosen by the guest
+/// program to indicate additional information (e.g. 0 to indicate success or 1 to indicate an
+/// error).
+struct ExitCode {
+    SystemExitCode system;
+    uint8 user;
+}
+
+/// @notice Exit condition indicated by the zkVM at the end of the execution covered by this proof.
+/// @dev
+/// `Halted` indicates normal termination of a program with an interior exit code returned from the
+/// guest program. A halted program cannot be resumed.
+///
+/// `Paused` indicates the execution ended in a paused state with an interior exit code set by the
+/// guest program. A paused program can be resumed such that execution picks up where it left
+/// of, with the same memory state.
+///
+/// `SystemSplit` indicates the execution ended on a host-initiated system split. System split is
+/// mechanism by which the host can temporarily stop execution of the execution ended in a system
+/// split has no output and no conclusions can be drawn about whether the program will eventually
+/// halt. System split is used in continuations to split execution into individually provable segments.
+enum SystemExitCode {
+    Halted,
+    Paused,
+    SystemSplit
+}
+
+/// @notice Output field in the `ReceiptClaim`, committing to a claimed journal and assumptions list.
+struct Output {
+    /// @notice Digest of the journal committed to by the guest execution.
+    bytes32 journalDigest;
+    /// @notice Digest of the ordered list of `ReceiptClaim` digests corresponding to the
+    /// calls to `env::verify` and `env::verify_integrity`.
+    /// @dev Verifying the integrity of a `Receipt` corresponding to a `ReceiptClaim` with a
+    /// non-empty assumptions list does not guarantee unconditionally any of the claims over the
+    /// guest execution (i.e. if the assumptions list is non-empty, then the journal digest cannot
+    /// be trusted to correspond to a genuine execution). The claims can be checked by additional
+    /// verifying a `Receipt` for every digest in the assumptions list.
+    bytes32 assumptionsDigest;
+}
+
+library OutputLib {
+    bytes32 constant TAG_DIGEST = sha256("risc0.Output");
+
+    function digest(Output memory output) internal pure returns (bytes32) {
+        return sha256(
+            abi.encodePacked(
+                TAG_DIGEST,
+                // down
+                output.journalDigest,
+                output.assumptionsDigest,
+                // down.length
+                uint16(2) << 8
+            )
+        );
+    }
+}
+
+// 0x439cc0cd
+/// @notice Error raised when cryptographic verification of the zero-knowledge proof fails.
+error VerificationFailed();
+
+/// @notice Verifier interface for RISC Zero receipts of execution.
+interface IRiscZeroVerifier {
+    /// @notice Verify that the given seal is a valid RISC Zero proof of execution with the
+    ///     given image ID and journal digest. Reverts on failure.
+    /// @dev This method additionally ensures that the input hash is all-zeros (i.e. no
+    /// committed input), the exit code is (Halted, 0), and there are no assumptions (i.e. the
+    /// receipt is unconditional).
+    /// @param seal The encoded cryptographic proof (i.e. SNARK).
+    /// @param imageId The identifier for the guest program.
+    /// @param journalDigest The SHA-256 digest of the journal bytes.
+    function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) external view;
+
+    /// @notice Verify that the given receipt is a valid RISC Zero receipt, ensuring the `seal` is
+    /// valid a cryptographic proof of the execution with the given `claim`. Reverts on failure.
+    /// @param receipt The receipt to be verified.
+    function verifyIntegrity(Receipt calldata receipt) external view;
+}
+
+// /Users/ramikhalil/risczero/risc0-ethereum/lib/openzeppelin-contracts/contracts/access/Ownable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is set to the address provided by the deployer. This can
+ * later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error OwnableUnauthorizedAccount(address account);
+
+    /**
+     * @dev The owner is not a valid owner account. (eg. `address(0)`)
+     */
+    error OwnableInvalidOwner(address owner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(initialOwner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        if (owner() != _msgSender()) {
+            revert OwnableUnauthorizedAccount(_msgSender());
+        }
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby disabling any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        if (newOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}
+
+// ../lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable2Step.sol)
+
+/**
+ * @dev Contract module which provides access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is specified at deployment time in the constructor for `Ownable`. This
+ * can later be changed with {transferOwnership} and {acceptOwnership}.
+ *
+ * This module is used through inheritance. It will make available all functions
+ * from parent (Ownable).
+ */
+abstract contract Ownable2Step is Ownable {
+    address private _pendingOwner;
+
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Returns the address of the pending owner.
+     */
+    function pendingOwner() public view virtual returns (address) {
+        return _pendingOwner;
+    }
+
+    /**
+     * @dev Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one.
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        _pendingOwner = newOwner;
+        emit OwnershipTransferStarted(owner(), newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`) and deletes any pending owner.
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual override {
+        delete _pendingOwner;
+        super._transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev The new owner accepts the ownership transfer.
+     */
+    function acceptOwnership() public virtual {
+        address sender = _msgSender();
+        if (pendingOwner() != sender) {
+            revert OwnableUnauthorizedAccount(sender);
+        }
+        _transferOwnership(sender);
+    }
+}
+
+// src/IRiscZeroSetVerifier.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// Seal of the SetInclusionReceipt.
+struct Seal_0 {
+    /// Merkle path to the leaf.
+    bytes32[] path;
+    /// Root seal.
+    bytes rootSeal;
+}
+
+interface IRiscZeroSetVerifier is IRiscZeroVerifier {
+    /// A new root has been added to the set.
+    event VerifiedRoot(bytes32 root);
+
+    /// Publishes a new root of a proof aggregation.
+    function submitMerkleRoot(bytes32 root, bytes calldata seal) external;
+
+    /// Returns whether `root` has been submitted.
+    function containsRoot(bytes32 root) external view returns (bool);
+
+    /// Returns the set builder imageId and its url.
+    function imageInfo() external view returns (bytes32, string memory);
+}
+
+// src/StructHash.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// @notice Structural hashing routines used for RISC Zero data structures.
+/// @dev
+/// StructHash implements hashing for structs, incorporating type tags for domain separation.
+/// The goals of this library are:
+/// * Collision resistance: it should not be possible to find two semantically distinct values that
+///   produce the same digest.
+/// * Simplicity: implementations should be simple to understand and write, as these methods must
+///   be implemented in multiple languages and environments, including zkSNARK circuits.
+/// * Incremental openings: it should be possible to incrementally open a nested struct without
+///   needing to open (very many) extra fields (i.e. the struct should be "Merkle-ized").
+library StructHash {
+    using SafeCast for uint256;
+
+    // @notice Compute the struct digest with the given tag digest and digest fields down.
+    function taggedStruct(bytes32 tagDigest, bytes32[] memory down) internal pure returns (bytes32) {
+        bytes memory data = new bytes(0);
+        return taggedStruct(tagDigest, down, data);
+    }
+
+    // @notice Compute the struct digest with the given tag digest, digest fields down, and data.
+    function taggedStruct(bytes32 tagDigest, bytes32[] memory down, bytes memory data)
+        internal
+        pure
+        returns (bytes32)
+    {
+        uint16 downLen = down.length.toUint16();
+        // swap the byte order to encode as little-endian.
+        bytes2 downLenLE = bytes2((downLen << 8) | (downLen >> 8));
+        return sha256(abi.encodePacked(tagDigest, down, data, downLenLE));
+    }
+
+    // @notice Add an element (head) to the incremental hash of a list (tail).
+    function taggedListCons(bytes32 tagDigest, bytes32 head, bytes32 tail) internal pure returns (bytes32) {
+        bytes32[] memory down = new bytes32[](2);
+        down[0] = head;
+        down[1] = tail;
+        return taggedStruct(tagDigest, down);
+    }
+
+    // @notice Hash the list by using taggedListCons to repeatedly add to the head of the list.
+    function taggedList(bytes32 tagDigest, bytes32[] memory list) internal pure returns (bytes32) {
+        bytes32 curr = bytes32(0x0000000000000000000000000000000000000000000000000000000000000000);
+        for (uint256 i = 0; i < list.length; i++) {
+            curr = taggedListCons(tagDigest, list[list.length - 1 - i], curr);
+        }
+        return curr;
+    }
+}
+
+// src/test/RiscZeroMockVerifier.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//0xb8b38d4c
+/// @notice Error raised when this verifier receives a receipt with a selector that does not match
+///         its own. The selector value is calculated from the verifier parameters, and so this
+///         usually indicates a mismatch between the version of the prover and this verifier.
+error SelectorMismatch(bytes4 received, bytes4 expected);
+
+/// @notice Mock verifier contract for RISC Zero receipts of execution.
+contract RiscZeroMockVerifier is IRiscZeroVerifier {
+    using ReceiptClaimLib for ReceiptClaim;
+    using OutputLib for Output;
+
+    /// @notice A short key attached to the seal to select the correct verifier implementation.
+    /// @dev A selector is not intended to be collision resistant, in that it is possible to find
+    ///      two preimages that result in the same selector. This is acceptable since it's purpose
+    ///      to a route a request among a set of trusted verifiers, and to make errors of sending a
+    ///      receipt to a mismatching verifiers easier to debug. It is analogous to the ABI
+    ///      function selectors.
+    bytes4 public immutable SELECTOR;
+
+    constructor(bytes4 selector) {
+        SELECTOR = selector;
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) public view {
+        _verifyIntegrity(seal, ReceiptClaimLib.ok(imageId, journalDigest).digest());
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verifyIntegrity(Receipt calldata receipt) public view {
+        _verifyIntegrity(receipt.seal, receipt.claimDigest);
+    }
+
+    /// @notice internal implementation of verifyIntegrity, factored to avoid copying calldata bytes to memory.
+    function _verifyIntegrity(bytes calldata seal, bytes32 claimDigest) internal view {
+        // Check that the seal has a matching selector. Mismatch generally  indicates that the
+        // prover and this verifier are using different parameters, and so the verification
+        // will not succeed.
+        if (SELECTOR != bytes4(seal[:4])) {
+            revert SelectorMismatch({received: bytes4(seal[:4]), expected: SELECTOR});
+        }
+
+        // Require that the rest of the seal be exactly equal to the claim digest.
+        if (keccak256(seal[4:]) != keccak256(abi.encodePacked(claimDigest))) {
+            revert VerificationFailed();
+        }
+    }
+
+    /// @notice Construct a mock receipt for the given image ID and journal.
+    function mockProve(bytes32 imageId, bytes32 journalDigest) public view returns (Receipt memory) {
+        return mockProve(ReceiptClaimLib.ok(imageId, journalDigest).digest());
+    }
+
+    /// @notice Construct a mock receipt for the given claim digest.
+    /// @dev You can calculate the claimDigest from a ReceiptClaim by using ReceiptClaimLib.
+    function mockProve(bytes32 claimDigest) public view returns (Receipt memory) {
+        return Receipt(abi.encodePacked(SELECTOR, claimDigest), claimDigest);
+    }
+}
+
+// src/RiscZeroSetVerifier.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+library RiscZeroSetVerifierLib {
+    function selector(bytes32 imageId) internal pure returns (bytes4) {
+        return bytes4(
+            sha256(
+                abi.encodePacked(
+                    // tag
+                    sha256("risc0.SetInclusionReceiptVerifierParameters"),
+                    // down
+                    imageId,
+                    // down length
+                    uint16(1) << 8
+                )
+            )
+        );
+    }
+}
+
+/// @notice RiscZeroSetVerifier verifier contract for RISC Zero receipts of execution.
+contract RiscZeroSetVerifier is IRiscZeroSetVerifier {
+    using ReceiptClaimLib for ReceiptClaim;
+
+    /// Semantic version of the the RISC Zero Set Verifier.
+    string public constant VERSION = "0.1.0";
+
+    IRiscZeroVerifier public immutable VERIFIER;
+
+    /// @notice A short key attached to the seal to select the correct verifier implementation.
+    /// @dev The selector is taken from the hash of the verifier parameters including the Groth16
+    ///      verification key and the control IDs that commit to the RISC Zero circuits. If two
+    ///      receipts have different selectors (i.e. different verifier parameters), then it can
+    ///      generally be assumed that they need distinct verifier implementations. This is used as
+    ///      part of the RISC Zero versioning mechanism.
+    ///
+    ///      A selector is not intended to be collision resistant, in that it is possible to find
+    ///      two preimages that result in the same selector. This is acceptable since it's purpose
+    ///      to a route a request among a set of trusted verifiers, and to make errors of sending a
+    ///      receipt to a mismatching verifiers easier to debug. It is analogous to the ABI
+    ///      function selectors.
+    bytes4 public immutable SELECTOR;
+
+    bytes32 private immutable IMAGE_ID;
+    string private imageUrl;
+
+    mapping(bytes32 => bool) private merkleRoots;
+
+    constructor(IRiscZeroVerifier verifier, bytes32 imageId, string memory _imageUrl) {
+        VERIFIER = verifier;
+        IMAGE_ID = imageId;
+        imageUrl = _imageUrl;
+
+        SELECTOR = RiscZeroSetVerifierLib.selector(imageId);
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) public view {
+        _verifyIntegrity(seal, ReceiptClaimLib.ok(imageId, journalDigest).digest());
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verifyIntegrity(Receipt calldata receipt) public view {
+        _verifyIntegrity(receipt.seal, receipt.claimDigest);
+    }
+
+    /// @notice internal implementation of verifyIntegrity, factored to avoid copying calldata bytes to memory.
+    function _verifyIntegrity(bytes calldata seal, bytes32 claimDigest) internal view {
+        Seal_0 memory setVerifierSeal;
+
+        // Check that the seal has a matching selector. Mismatch generally  indicates that the
+        // prover and this verifier are using different parameters, and so the verification
+        // will not succeed.
+        if (SELECTOR != bytes4(seal[:4])) {
+            revert SelectorMismatch({received: bytes4(seal[:4]), expected: SELECTOR});
+        }
+
+        // Check if the seal is not empty and decode it, otherwise use an empty array
+        // TODO(victor): Can we verify the Merkle inclusion without abi decoding into memory?
+        if (seal.length > 4) {
+            setVerifierSeal = abi.decode(seal[4:], (Seal_0));
+        }
+
+        // Compute the root and verify it against the stored Merkle roots if a
+        // root seal was not provided, or validate the root seal.
+        // NOTE: If an invalid root seal was provided, the verify will fail
+        // even if the root was already verified earlier and stored in state.
+        bytes32 root = MerkleProof.processProof(setVerifierSeal.path, claimDigest);
+        if (setVerifierSeal.rootSeal.length > 0) {
+            VERIFIER.verify(setVerifierSeal.rootSeal, IMAGE_ID, sha256(abi.encode(IMAGE_ID, root)));
+        } else if (!merkleRoots[root]) {
+            revert VerificationFailed();
+        }
+    }
+
+    function submitMerkleRoot(bytes32 root, bytes calldata seal) external {
+        VERIFIER.verify(seal, IMAGE_ID, sha256(abi.encode(IMAGE_ID, root)));
+        merkleRoots[root] = true;
+
+        emit VerifiedRoot(root);
+    }
+
+    function containsRoot(bytes32 root) external view returns (bool) {
+        return merkleRoots[root];
+    }
+
+    function imageInfo() external view returns (bytes32, string memory) {
+        return (IMAGE_ID, imageUrl);
+    }
+}
+
+// src/RiscZeroVerifierRouter.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// @notice Router for IRiscZeroVerifier, allowing multiple implementations to be accessible behind a single address.
+contract RiscZeroVerifierRouter is IRiscZeroVerifier, Ownable2Step {
+    /// @notice Mapping from 4-byte verifier selector to verifier contracts.
+    ///         Used to route receipts to verifiers that are able to check the receipt.
+    mapping(bytes4 => IRiscZeroVerifier) public verifiers;
+
+    /// @notice Value of an entry that has never been set.
+    IRiscZeroVerifier internal constant UNSET = IRiscZeroVerifier(address(0));
+    /// @notice A "tombstone" value used to mark verifier entries that have been removed from the mapping.
+    IRiscZeroVerifier internal constant TOMBSTONE = IRiscZeroVerifier(address(1));
+
+    //0xe4ea6542
+    /// @notice Error raised when attempting to verify a receipt with a selector that is not
+    ///         registered on this router. Generally, this indicates a version mismatch where the
+    ///         prover generated a receipt with version of the zkVM that does not match any
+    ///         registered version on this router contract.
+    error SelectorUnknown(bytes4 selector);
+    /// @notice Error raised when attempting to add a verifier for a selector that is already registered.
+    error SelectorInUse(bytes4 selector);
+    /// @notice Error raised when attempting to verify a receipt with a selector that has been
+    ///         removed, or attempting to add a new verifier with a selector that was previously
+    ///         registered and then removed.
+    error SelectorRemoved(bytes4 selector);
+
+    constructor(address admin) Ownable(admin) {}
+
+    /// @notice Adds a verifier to the router, such that it can receive receipt verification calls.
+    function addVerifier(bytes4 selector, IRiscZeroVerifier verifier) external onlyOwner {
+        if (verifiers[selector] == TOMBSTONE) {
+            revert SelectorRemoved({selector: selector});
+        }
+        if (verifiers[selector] != UNSET) {
+            revert SelectorInUse({selector: selector});
+        }
+        verifiers[selector] = verifier;
+    }
+
+    /// @notice Removes verifier from the router, such that it can not receive verification calls.
+    ///         Removing a selector sets it to the tombstone value. It can never be set to any
+    ///         other value, and can never be reused for a new verifier, in order to enforce the
+    ///         property that each selector maps to at most one implementation across time.
+    function removeVerifier(bytes4 selector) external onlyOwner {
+        // Simple check to reduce the chance of accidents.
+        // NOTE: If there ever _is_ a reason to remove a selector that has never been set, the owner
+        // can call addVerifier with the tombstone address.
+        if (verifiers[selector] == UNSET) {
+            revert SelectorUnknown({selector: selector});
+        }
+        verifiers[selector] = TOMBSTONE;
+    }
+
+    /// @notice Get the associatied verifier, reverting if the selector is unknown or removed.
+    function getVerifier(bytes4 selector) public view returns (IRiscZeroVerifier) {
+        IRiscZeroVerifier verifier = verifiers[selector];
+        if (verifier == UNSET) {
+            revert SelectorUnknown({selector: selector});
+        }
+        if (verifier == TOMBSTONE) {
+            revert SelectorRemoved({selector: selector});
+        }
+        return verifier;
+    }
+
+    /// @notice Get the associatied verifier, reverting if the selector is unknown or removed.
+    function getVerifier(bytes calldata seal) public view returns (IRiscZeroVerifier) {
+        // Use the first 4 bytes of the seal at the selector to look up in the mapping.
+        return getVerifier(bytes4(seal[0:4]));
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) external view {
+        getVerifier(seal).verify(seal, imageId, journalDigest);
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verifyIntegrity(Receipt calldata receipt) external view {
+        getVerifier(receipt.seal).verifyIntegrity(receipt);
+    }
+}
+
+// src/groth16/RiscZeroGroth16Verifier.sol
+// Copyright 2024 RISC Zero, Inc.
+//
+// The RiscZeroGroth16Verifier is a free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The RiscZeroGroth16Verifier is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// the RiscZeroGroth16Verifier. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/// @notice A Groth16 seal over the claimed receipt claim.
+struct Seal_1 {
+    uint256[2] a;
+    uint256[2][2] b;
+    uint256[2] c;
+}
+
+/// @notice Groth16 verifier contract for RISC Zero receipts of execution.
+contract RiscZeroGroth16Verifier is IRiscZeroVerifier, IRiscZeroSelectable, Groth16Verifier {
+    using ReceiptClaimLib for ReceiptClaim;
+    using OutputLib for Output;
+    using SafeCast for uint256;
+
+    /// Semantic version of the the RISC Zero system of which this contract is part.
+    string public constant VERSION = "1.2.0";
+
+    /// @notice Control root hash binding the set of circuits in the RISC Zero system.
+    /// @dev This value controls what set of recursion programs (e.g. lift, join, resolve), and
+    /// therefore what version of the zkVM circuit, will be accepted by this contract. Each
+    /// instance of this verifier contract will accept a single release of the RISC Zero circuits.
+    ///
+    /// New releases of RISC Zero's zkVM require updating these values. These values can be
+    /// calculated from the [risc0 monorepo][1] using: `cargo xtask bootstrap`.
+    ///
+    /// [1]: https://github.com/risc0/risc0
+    bytes16 public immutable CONTROL_ROOT_0;
+    bytes16 public immutable CONTROL_ROOT_1;
+    bytes32 public immutable BN254_CONTROL_ID;
+
+    /// @notice A short key attached to the seal to select the correct verifier implementation.
+    /// @dev The selector is taken from the hash of the verifier parameters including the Groth16
+    ///      verification key and the control IDs that commit to the RISC Zero circuits. If two
+    ///      receipts have different selectors (i.e. different verifier parameters), then it can
+    ///      generally be assumed that they need distinct verifier implementations. This is used as
+    ///      part of the RISC Zero versioning mechanism.
+    ///
+    ///      A selector is not intended to be collision resistant, in that it is possible to find
+    ///      two preimages that result in the same selector. This is acceptable since it's purpose
+    ///      to a route a request among a set of trusted verifiers, and to make errors of sending a
+    ///      receipt to a mismatching verifiers easier to debug. It is analogous to the ABI
+    ///      function selectors.
+    bytes4 public immutable SELECTOR;
+
+    /// @notice Identifier for the Groth16 verification key encoded into the base contract.
+    /// @dev This value is computed at compile time.
+    function verifier_key_digest() internal pure returns (bytes32) {
+        bytes32[] memory ic_digests = new bytes32[](6);
+        ic_digests[0] = sha256(abi.encodePacked(IC0x, IC0y));
+        ic_digests[1] = sha256(abi.encodePacked(IC1x, IC1y));
+        ic_digests[2] = sha256(abi.encodePacked(IC2x, IC2y));
+        ic_digests[3] = sha256(abi.encodePacked(IC3x, IC3y));
+        ic_digests[4] = sha256(abi.encodePacked(IC4x, IC4y));
+        ic_digests[5] = sha256(abi.encodePacked(IC5x, IC5y));
+
+        return sha256(
+            abi.encodePacked(
+                // tag
+                sha256("risc0_groth16.VerifyingKey"),
+                // down
+                sha256(abi.encodePacked(alphax, alphay)),
+                sha256(abi.encodePacked(betax1, betax2, betay1, betay2)),
+                sha256(abi.encodePacked(gammax1, gammax2, gammay1, gammay2)),
+                sha256(abi.encodePacked(deltax1, deltax2, deltay1, deltay2)),
+                StructHash.taggedList(sha256("risc0_groth16.VerifyingKey.IC"), ic_digests),
+                // down length
+                uint16(5) << 8
+            )
+        );
+    }
+
+    constructor(bytes32 control_root, bytes32 bn254_control_id) {
+        (CONTROL_ROOT_0, CONTROL_ROOT_1) = splitDigest(control_root);
+        BN254_CONTROL_ID = bn254_control_id;
+
+        SELECTOR = bytes4(
+            sha256(
+                abi.encodePacked(
+                    // tag
+                    sha256("risc0.Groth16ReceiptVerifierParameters"),
+                    // down
+                    control_root,
+                    reverseByteOrderUint256(uint256(bn254_control_id)),
+                    verifier_key_digest(),
+                    // down length
+                    uint16(3) << 8
+                )
+            )
+        );
+    }
+
+    /// @notice splits a digest into two 128-bit halves to use as public signal inputs.
+    /// @dev RISC Zero's Circom verifier circuit takes each of two hash digests in two 128-bit
+    /// chunks. These values can be derived from the digest by splitting the digest in half and
+    /// then reversing the bytes of each.
+    function splitDigest(bytes32 digest) internal pure returns (bytes16, bytes16) {
+        uint256 reversed = reverseByteOrderUint256(uint256(digest));
+        return (bytes16(uint128(reversed)), bytes16(uint128(reversed >> 128)));
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) external view {
+        _verifyIntegrity(seal, ReceiptClaimLib.ok(imageId, journalDigest).digest());
+    }
+
+    /// @inheritdoc IRiscZeroVerifier
+    function verifyIntegrity(Receipt calldata receipt) external view {
+        return _verifyIntegrity(receipt.seal, receipt.claimDigest);
+    }
+
+    /// @notice internal implementation of verifyIntegrity, factored to avoid copying calldata bytes to memory.
+    function _verifyIntegrity(bytes calldata seal, bytes32 claimDigest) internal view {
+        // Check that the seal has a matching selector. Mismatch generally indicates that the
+        // prover and this verifier are using different parameters, and so the verification
+        // will not succeed.
+        if (SELECTOR != bytes4(seal[:4])) {
+            revert SelectorMismatch({received: bytes4(seal[:4]), expected: SELECTOR});
+        }
+
+        // Run the Groth16 verify procedure.
+        (bytes16 claim0, bytes16 claim1) = splitDigest(claimDigest);
+        Seal_1 memory decodedSeal = abi.decode(seal[4:], (Seal_1));
+        bool verified = this.verifyProof(
+            decodedSeal.a,
+            decodedSeal.b,
+            decodedSeal.c,
+            [
+                uint256(uint128(CONTROL_ROOT_0)),
+                uint256(uint128(CONTROL_ROOT_1)),
+                uint256(uint128(claim0)),
+                uint256(uint128(claim1)),
+                uint256(BN254_CONTROL_ID)
+            ]
+        );
+
+        // Revert is verification failed.
+        if (!verified) {
+            revert VerificationFailed();
+        }
+    }
+}

--- a/contracts/test/helpers/Utils.sol
+++ b/contracts/test/helpers/Utils.sol
@@ -11,7 +11,7 @@ import {OPSuccinctL2OutputOracle} from "../../src/validity/OPSuccinctL2OutputOra
 contract Utils is Test, JSONDecoder {
     function deployWithConfig(Config memory cfg) public returns (address) {
         if (cfg.opSuccinctL2OutputOracleImpl == address(0)) {
-            cfg.opSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle());
+            cfg.opSuccinctL2OutputOracleImpl = address(new OPSuccinctL2OutputOracle(address(0), bytes32(0), bytes32(0)));
         }
 
         Proxy l2OutputOracleProxy = new Proxy(msg.sender);

--- a/contracts/test/validity/OPSuccinctDisputeGame.t.sol
+++ b/contracts/test/validity/OPSuccinctDisputeGame.t.sol
@@ -86,7 +86,7 @@ contract OPSuccinctDisputeGameTest is Test {
             abi.encodeWithSelector(OPSuccinctL2OutputOracle.initialize.selector, initParams);
 
         Proxy l2OutputOracleProxy = new Proxy(address(this));
-        l2OutputOracleProxy.upgradeToAndCall(address(new OPSuccinctL2OutputOracle()), initializationParams);
+        l2OutputOracleProxy.upgradeToAndCall(address(new OPSuccinctL2OutputOracle(address(0), bytes32(0), bytes32(0))), initializationParams);
 
         l2OutputOracle = OPSuccinctL2OutputOracle(address(l2OutputOracleProxy));
 
@@ -136,9 +136,6 @@ contract OPSuccinctDisputeGameTest is Test {
         assertEq(game.gameCreator(), proposer);
         assertEq(game.rootClaim().raw(), rootClaim.raw());
         assertEq(game.l2BlockNumber(), l2BlockNumber);
-        assertEq(game.l1BlockNumber(), l1BlockNumber);
-        assertEq(game.proverAddress(), proposer);
-        assertEq(keccak256(game.proof()), keccak256(bytes("")));
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
     }
 

--- a/contracts/test/validity/OPSuccinctL2OutputOracle.t.sol
+++ b/contracts/test/validity/OPSuccinctL2OutputOracle.t.sol
@@ -28,6 +28,6 @@ contract OPSuccinctL2OutputOracleTest is Test, Utils {
         l2oo = OPSuccinctL2OutputOracle(0x5f0c7178CF4d7520f347d1334e5fc219da9b8Da4);
         l2oo.checkpointBlockHash(checkpointedL1BlockNum);
         vm.prank(OWNER);
-        l2oo.proposeL2Output(claimedOutputRoot, claimedL2BlockNum, checkpointedL1BlockNum, proof, proverAddress);
+        l2oo.proposeL2Output(claimedOutputRoot, claimedL2BlockNum, checkpointedL1BlockNum, proof);
     }
 }


### PR DESCRIPTION
The multiprover has the following features:

1. Changes the op succinct dispute game to wait for the l2 oracle to confirm time passing since submission
2. Changes the op succinct l2 output oracle to allow challenges when anyone produces a proof of a different un-proposed root.
3.  Changes the op succinct l2 output oracle to allow trustless proving after the proposer(s) has been offline for a set period.
4. Adds a visible circuit breaker field to l2output oracle which is true only if a challenge has passed, this means there must be a bug in either succinct's prover, op kona, or risc0's prover. 

This breaks compatibility with upstream op succinct.