### PR TITLE
feat(proposer): remove data dir + holocene warn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,6 +5416,7 @@ dependencies = [
  "sp1-sdk",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "tempfile",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ metrics-exporter-prometheus = "0.16.2"
 metrics-process = "2.4.0"
 strum = "0.27.1"
 strum_macros = "0.27.1"
+tempfile = "3.10.1"
 
 # kona
 kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16" }
@@ -124,10 +125,7 @@ sp1-zkvm = { version = "4.1.7", features = ["verify"] }
 sp1-build = { version = "4.1.7" }
 
 # kzg-rs
-kzg-rs = { version = "0.2.6", features = [
-    "rkyv",
-    "serde",
-] }
+kzg-rs = { version = "0.2.6", features = ["rkyv", "serde"] }
 
 [profile.release-client-lto]
 inherits = "release"

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -57,6 +57,7 @@ metrics.workspace = true
 metrics-process.workspace = true
 metrics-exporter-prometheus.workspace = true
 cfg-if.workspace = true
+tempfile.workspace = true
 
 kzg-rs.workspace = true
 c-kzg = "1.0.3"

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -450,17 +450,6 @@ impl OPSuccinctDataFetcher {
         Ok(headers)
     }
 
-    /// Get the data directory path. Note: This path is relative to the location from which the
-    /// program is run.
-    pub fn get_data_directory(
-        &self,
-        l2_chain_id: u64,
-        l2_start_block: u64,
-        l2_end_block: u64,
-    ) -> Result<String> {
-        Ok(format!("data/{}/{}-{}", l2_chain_id, l2_start_block, l2_end_block))
-    }
-
     pub async fn get_l2_output_at_block(&self, block_number: u64) -> Result<OutputResponse> {
         let block_number_hex = format!("0x{:x}", block_number);
         let l2_output_data: OutputResponse = self

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -18,9 +18,10 @@ use serde_json::{json, Value};
 use std::{
     cmp::{min, Ordering},
     env, fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     str::FromStr,
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use crate::L2Output;
@@ -111,6 +112,7 @@ impl OPSuccinctDataFetcher {
     }
 
     /// Initialize the fetcher with a rollup config.
+    #[tracing::instrument(skip_all, name = "OPSuccinctDataFetcher::new_with_rollup_config")]
     pub async fn new_with_rollup_config() -> Result<Self> {
         let rpc_config = get_rpcs();
 
@@ -119,6 +121,12 @@ impl OPSuccinctDataFetcher {
 
         let (rollup_config, rollup_config_path) =
             Self::fetch_and_save_rollup_config(&rpc_config).await?;
+
+        // Add warning if the chain is pre-Holocene, as derivation is significantly slower.
+        let unix_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        if !rollup_config.is_holocene_active(unix_timestamp) {
+            tracing::warn!("WARNING: Chain is not using Holocene hard fork. This will cause significant performance degradation compared to chains that have activated Holocene.");
+        }
 
         Ok(OPSuccinctDataFetcher {
             rpc_config,
@@ -615,7 +623,6 @@ impl OPSuccinctDataFetcher {
         if self.rollup_config.is_none() {
             return Err(anyhow::anyhow!("Rollup config not loaded."));
         }
-        let l2_chain_id = self.rollup_config.as_ref().unwrap().l2_chain_id;
 
         if l2_start_block >= l2_end_block {
             return Err(anyhow::anyhow!(
@@ -687,17 +694,6 @@ impl OPSuccinctDataFetcher {
             }
         };
 
-        // Get the workspace root, which is where the data directory is.
-        let data_directory = self.get_data_directory(l2_chain_id, l2_start_block, l2_end_block)?;
-
-        if Path::new(&data_directory).exists() {
-            fs::remove_dir_all(&data_directory)?;
-        }
-
-        // Creates the data directory if it doesn't exist, or no-ops if it does. Used to store the
-        // witness data.
-        fs::create_dir_all(&data_directory).expect("Failed to create data directory");
-
         Ok(SingleChainHost {
             l1_head: l1_head_hash,
             agreed_l2_output_root,
@@ -715,7 +711,7 @@ impl OPSuccinctDataFetcher {
             l1_beacon_address: Some(
                 self.rpc_config.l1_beacon_rpc.as_str().trim_end_matches('/').to_string(),
             ),
-            data_dir: Some(data_directory.into()),
+            data_dir: None, // Use in-memory key-value store.
             native: false,
             server: true,
             rollup_config_path: self.rollup_config_path.clone(),

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -112,7 +112,6 @@ impl OPSuccinctDataFetcher {
     }
 
     /// Initialize the fetcher with a rollup config.
-    #[tracing::instrument(skip_all, name = "OPSuccinctDataFetcher::new_with_rollup_config")]
     pub async fn new_with_rollup_config() -> Result<Self> {
         let rpc_config = get_rpcs();
 

--- a/utils/host/src/hosts/default.rs
+++ b/utils/host/src/hosts/default.rs
@@ -1,11 +1,10 @@
-use std::sync::Arc;
-
 use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use kona_host::single::SingleChainHost;
 use kona_preimage::BidirectionalChannel;
 use op_succinct_client_utils::witness::WitnessData;
+use std::sync::Arc;
 
 use crate::{fetcher::OPSuccinctDataFetcher, hosts::OPSuccinctHost};
 use anyhow::Result;


### PR DESCRIPTION
- Add warning if chain does not enable Holocene hardfork.
- Use in-memory KV store by default. This doesn't bloat witness generation time/CPU usage significantly (as the witness is pulled in-memory to create the witness data anyways).