### PR TITLE
build: move zkvm ELFs into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5340,6 +5340,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-succinct-elfs"
+version = "0.1.0"
+
+[[package]]
 name = "op-succinct-fp"
 version = "0.1.0"
 dependencies = [
@@ -5408,6 +5412,7 @@ dependencies = [
  "op-alloy-network",
  "op-alloy-rpc-types",
  "op-succinct-client-utils",
+ "op-succinct-elfs",
  "reqwest",
  "rkyv",
  "serde",
@@ -8934,6 +8939,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ op-succinct-prove = { path = "scripts/prove" }
 op-succinct-client-utils = { path = "utils/client" }
 op-succinct-host-utils = { path = "utils/host" }
 op-succinct-build-utils = { path = "utils/build" }
+op-succinct-elfs = { path = "utils/elfs" }
 op-succinct-validity = { path = "validity" }
 op-succinct-fp = { path = "fault-proof" }
 

--- a/utils/elfs/Cargo.toml
+++ b/utils/elfs/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "op-succinct-elfs"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true

--- a/utils/elfs/src/lib.rs
+++ b/utils/elfs/src/lib.rs
@@ -1,0 +1,5 @@
+//! The zkvm ELF binaries.
+
+pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
+pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -11,6 +11,7 @@ sp1-sdk.workspace = true
 
 # local
 op-succinct-client-utils.workspace = true
+op-succinct-elfs.workspace = true
 
 # op-alloy
 op-alloy-rpc-types.workspace = true

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -9,11 +9,18 @@ pub use proof::*;
 pub mod metrics;
 pub mod witness_generation;
 
+<<<<<<< HEAD
 pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
 pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
 pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
 pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] =
     include_bytes!("../../../elf/celestia-range-elf-embedded");
+=======
+pub use op_succinct_elfs::{AGGREGATION_ELF, RANGE_ELF_BUMP, RANGE_ELF_EMBEDDED};
+
+// TODO: Update to Celestia Range ELF Embedded
+pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+>>>>>>> 86f3e69 (build: move zkvm ELFs into a separate crate)
 
 // TODO: Update to EigenDA Range ELF Embedded
 pub const EIGENDA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");


### PR DESCRIPTION
This will make easier to depend on the ELFs from other repos with less dependencies.