### PR TITLE
refactor: move zkvm ELFs into a separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ op-succinct-prove = { path = "scripts/prove" }
 op-succinct-client-utils = { path = "utils/client" }
 op-succinct-host-utils = { path = "utils/host" }
 op-succinct-build-utils = { path = "utils/build" }
+op-succinct-elfs = { path = "utils/elfs" }
 op-succinct-validity = { path = "validity" }
 op-succinct-fp = { path = "fault-proof" }
 

--- a/utils/elfs/Cargo.toml
+++ b/utils/elfs/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "op-succinct-elfs"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true

--- a/utils/elfs/src/lib.rs
+++ b/utils/elfs/src/lib.rs
@@ -1,0 +1,11 @@
+//! The zkvm ELF binaries.
+
+pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
+
+pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
+pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] =
+    include_bytes!("../../../elf/celestia-range-elf-embedded");
+
+// TODO: Update to EigenDA Range ELF Embedded
+pub const EIGENDA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -11,6 +11,7 @@ sp1-sdk.workspace = true
 
 # local
 op-succinct-client-utils.workspace = true
+op-succinct-elfs.workspace = true
 
 # op-alloy
 op-alloy-rpc-types.workspace = true

--- a/utils/host/src/lib.rs
+++ b/utils/host/src/lib.rs
@@ -9,14 +9,10 @@ pub use proof::*;
 pub mod metrics;
 pub mod witness_generation;
 
-pub const RANGE_ELF_BUMP: &[u8] = include_bytes!("../../../elf/range-elf-bump");
-pub const RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
-pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
-pub const CELESTIA_RANGE_ELF_EMBEDDED: &[u8] =
-    include_bytes!("../../../elf/celestia-range-elf-embedded");
-
-// TODO: Update to EigenDA Range ELF Embedded
-pub const EIGENDA_RANGE_ELF_EMBEDDED: &[u8] = include_bytes!("../../../elf/range-elf-embedded");
+pub use op_succinct_elfs::{
+    AGGREGATION_ELF, CELESTIA_RANGE_ELF_EMBEDDED, EIGENDA_RANGE_ELF_EMBEDDED, RANGE_ELF_BUMP,
+    RANGE_ELF_EMBEDDED,
+};
 
 /// Get the range ELF depending on the feature flag.
 pub fn get_range_elf_embedded() -> &'static [u8] {


### PR DESCRIPTION
This makes it easier for third party software to use the zkvm ELF binary data (e.g. for the purpose of calculating the verification keys) without having to involve the heavy dependencies of `op-succinct-host-utils`.