### PR TITLE
chore: bump hana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "hana-blobstream"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.15.10",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "hana-celestia"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "hana-client"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
 dependencies = [
  "alloy-consensus 0.15.10",
  "alloy-evm",
@@ -4005,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "hana-host"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "hana-oracle"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "hana-proofs"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
+source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "hana-blobstream"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
+source = "git+https://github.com/celestiaorg/hana?rev=904f086fd7335986e87a0f0432b1f07fe997f690#904f086fd7335986e87a0f0432b1f07fe997f690"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.15.10",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "hana-celestia"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
+source = "git+https://github.com/celestiaorg/hana?rev=904f086fd7335986e87a0f0432b1f07fe997f690#904f086fd7335986e87a0f0432b1f07fe997f690"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "hana-client"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
+source = "git+https://github.com/celestiaorg/hana?rev=904f086fd7335986e87a0f0432b1f07fe997f690#904f086fd7335986e87a0f0432b1f07fe997f690"
 dependencies = [
  "alloy-consensus 0.15.10",
  "alloy-evm",
@@ -4005,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "hana-host"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
+source = "git+https://github.com/celestiaorg/hana?rev=904f086fd7335986e87a0f0432b1f07fe997f690#904f086fd7335986e87a0f0432b1f07fe997f690"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "hana-oracle"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
+source = "git+https://github.com/celestiaorg/hana?rev=904f086fd7335986e87a0f0432b1f07fe997f690#904f086fd7335986e87a0f0432b1f07fe997f690"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "hana-proofs"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?tag=v0.1.0-beta.13#0bfe5157a4f4c22340c25591e643d9c4986dc4ea"
+source = "git+https://github.com/celestiaorg/hana?rev=904f086fd7335986e87a0f0432b1f07fe997f690#904f086fd7335986e87a0f0432b1f07fe997f690"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,15 +3949,16 @@ dependencies = [
 [[package]]
 name = "hana-blobstream"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=a6077b794d1c00fc2af129fb28cbb0151f8c81b9#a6077b794d1c00fc2af129fb28cbb0151f8c81b9"
+source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
 dependencies = [
  "alloy-chains",
+ "alloy-consensus 0.15.10",
  "alloy-contract",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 0.15.10",
  "alloy-sol-types",
  "alloy-trie",
+ "anyhow",
  "bincode",
  "celestia-types",
  "serde",
@@ -3966,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "hana-celestia"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=a6077b794d1c00fc2af129fb28cbb0151f8c81b9#a6077b794d1c00fc2af129fb28cbb0151f8c81b9"
+source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3979,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "hana-client"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=a6077b794d1c00fc2af129fb28cbb0151f8c81b9#a6077b794d1c00fc2af129fb28cbb0151f8c81b9"
+source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
 dependencies = [
  "alloy-consensus 0.15.10",
  "alloy-evm",
@@ -4004,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "hana-host"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=a6077b794d1c00fc2af129fb28cbb0151f8c81b9#a6077b794d1c00fc2af129fb28cbb0151f8c81b9"
+source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4035,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "hana-oracle"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=a6077b794d1c00fc2af129fb28cbb0151f8c81b9#a6077b794d1c00fc2af129fb28cbb0151f8c81b9"
+source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4052,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "hana-proofs"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=a6077b794d1c00fc2af129fb28cbb0151f8c81b9#a6077b794d1c00fc2af129fb28cbb0151f8c81b9"
+source = "git+https://github.com/celestiaorg/hana?rev=3f49cc6#3f49cc6a278c9a41b53abcb28ca3b257956cee7c"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,11 +80,10 @@ kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0
 kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # hana
-# NOTE(fakedev9999): https://github.com/celestiaorg/hana/pull/20.
-hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
-hana-celestia = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
-hana-host = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
-hana-oracle = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
+hana-blobstream = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
+hana-celestia = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
+hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
+hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,11 @@ kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0
 kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # hana
-hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "a6077b794d1c00fc2af129fb28cbb0151f8c81b9" }
-hana-celestia = { git = "https://github.com/celestiaorg/hana", rev = "a6077b794d1c00fc2af129fb28cbb0151f8c81b9" }
-hana-host = { git = "https://github.com/celestiaorg/hana", rev = "a6077b794d1c00fc2af129fb28cbb0151f8c81b9" }
-hana-oracle = { git = "https://github.com/celestiaorg/hana", rev = "a6077b794d1c00fc2af129fb28cbb0151f8c81b9" }
+# NOTE(fakedev9999): https://github.com/celestiaorg/hana/pull/20.
+hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
+hana-celestia = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
+hana-host = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
+hana-oracle = { git = "https://github.com/celestiaorg/hana", rev = "3f49cc6" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,10 @@ kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0
 kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # hana
-hana-blobstream = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
-hana-celestia = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
-hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
-hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v0.1.0-beta.13" }
+hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "904f086fd7335986e87a0f0432b1f07fe997f690" }
+hana-celestia = { git = "https://github.com/celestiaorg/hana", rev = "904f086fd7335986e87a0f0432b1f07fe997f690" }
+hana-host = { git = "https://github.com/celestiaorg/hana", rev = "904f086fd7335986e87a0f0432b1f07fe997f690" }
+hana-oracle = { git = "https://github.com/celestiaorg/hana", rev = "904f086fd7335986e87a0f0432b1f07fe997f690" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -28,7 +28,7 @@ Failed to validate L2 block #<block_number> with output root <hash>
 ```
 
 **Cause:**
-This error occurs when the L1 head block selected is too close to the batch posting block, causing the derivation process to fail. The L2 node may have an inconsistent view of the safe head state, requiring additional L1 blocks to properly derive and validate the L2 blocks.
+This error occurs when the L1 head block selected for ETH DA is too close to the batch posting block, causing the derivation process to fail. The L2 node may have an inconsistent view of the safe head state, requiring additional L1 blocks to properly derive and validate the L2 blocks.
 
 **Solution:**
 1. Increase the L1 head offset buffer in the derivation process. The code currently adds a buffer of 20 blocks after the batch posting block, but you can increase this to for example 100 blocks:

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -123,7 +123,7 @@ where
                 l2_block_number.to::<u64>() - self.config.proposal_interval_in_blocks,
                 l2_block_number.to::<u64>(),
                 Some(l1_head_hash.into()),
-                Some(self.config.safe_db_fallback),
+                self.config.safe_db_fallback,
             )
             .await
             .context("Failed to get host CLI args")?;

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -28,8 +28,7 @@ async fn main() -> Result<()> {
         get_validated_block_range(&data_fetcher, args.start, args.end, DEFAULT_RANGE).await?;
 
     let host = initialize_host(Arc::new(data_fetcher.clone()));
-    let host_args =
-        host.fetch(l2_start_block, l2_end_block, None, Some(args.safe_db_fallback)).await?;
+    let host_args = host.fetch(l2_start_block, l2_end_block, None, args.safe_db_fallback).await?;
 
     debug!("Host args: {:?}", host_args);
 

--- a/scripts/prove/tests/cycle_count_diff.rs
+++ b/scripts/prove/tests/cycle_count_diff.rs
@@ -125,7 +125,7 @@ async fn test_cycle_count_diff() -> Result<()> {
         }
     };
 
-    let host_args = host.fetch(l2_start_block, l2_end_block, None, Some(false)).await?;
+    let host_args = host.fetch(l2_start_block, l2_end_block, None, false).await?;
 
     let witness_data = host.run(&host_args).await?;
     let sp1_stdin = host.witness_generator().get_sp1_stdin(witness_data)?;

--- a/scripts/prove/tests/multi.rs
+++ b/scripts/prove/tests/multi.rs
@@ -26,7 +26,7 @@ async fn execute_batch() -> Result<()> {
 
     let host = initialize_host(Arc::new(data_fetcher.clone()));
 
-    let host_args = host.fetch(l2_start_block, l2_end_block, None, Some(false)).await?;
+    let host_args = host.fetch(l2_start_block, l2_end_block, None, false).await?;
 
     let witness_data = host.run(&host_args).await?;
 

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -217,7 +217,7 @@ async fn main() -> Result<()> {
 
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            host.fetch(range.start, range.end, None, Some(args.safe_db_fallback))
+            host.fetch(range.start, range.end, None, args.safe_db_fallback)
                 .await
                 .expect("Failed to get host CLI args")
         })

--- a/scripts/utils/bin/gen_sp1_test_artifacts.rs
+++ b/scripts/utils/bin/gen_sp1_test_artifacts.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     let host = Arc::new(initialize_host(Arc::new(data_fetcher)));
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            host.fetch(range.start, range.end, None, Some(args.safe_db_fallback))
+            host.fetch(range.start, range.end, None, args.safe_db_fallback)
                 .await
                 .expect("Failed to get host CLI args")
         })

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -1,0 +1,155 @@
+use alloy_consensus::Transaction;
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use alloy_provider::Provider;
+use alloy_rpc_types::eth::Transaction as EthTransaction;
+use anyhow::{anyhow, bail, Result};
+use hana_blobstream::blobstream::{blostream_address, SP1Blobstream};
+use kona_rpc::SafeHeadResponse;
+use op_succinct_host_utils::fetcher::{OPSuccinctDataFetcher, RPCMode};
+
+/// Extract the Celestia height from batcher transaction based on the version byte.
+///
+/// Returns:
+/// - Some(height) if the transaction is a valid Celestia batcher transaction.
+/// - None if the transaction is an ETH DA transaction (EIP4844 transaction or non-EIP4844
+///   transaction with version byte 0x00).
+/// - Err if the version byte is invalid or the da layer byte is incorrect for non-EIP4844
+///   transactions.
+pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
+    // Skip calldata parsing for EIP4844 transactions since there is no calldata.
+    if tx.inner.is_eip4844() {
+        Ok(None)
+    } else {
+        let calldata = tx.input();
+        // Check version byte to determine if it is ETH DA or Alt DA.
+        // https://specs.optimism.io/protocol/derivation.html#batcher-transaction-format.
+        match calldata[0] {
+            0x00 => Ok(None), // ETH DA transaction.
+            0x01 => {
+                // Check that the DA layer byte prefix is correct.
+                // https://github.com/ethereum-optimism/specs/discussions/135.
+                if calldata[2] != 0x0c {
+                    return Err(anyhow!("Invalid prefix for Celestia batcher transaction"));
+                }
+
+                // The encoding of the commitment is the Celestia block height followed
+                // by the Celestia commitment.
+                let height_bytes = &calldata[3..11];
+                let celestia_height = u64::from_le_bytes(height_bytes.try_into().unwrap());
+
+                Ok(Some(celestia_height))
+            }
+            _ => Err(anyhow!("Invalid version byte for batcher transaction")),
+        }
+    }
+}
+
+/// Get the latest Celestia block height that has been committed to Ethereum via Blobstream.
+pub async fn get_latest_blobstream_celestia_block(fetcher: &OPSuccinctDataFetcher) -> Result<u64> {
+    let blobstream_contract = SP1Blobstream::new(
+        blostream_address(fetcher.rollup_config.as_ref().unwrap().l1_chain_id)
+            .expect("Failed to fetch blobstream contract address"),
+        fetcher.l1_provider.clone(),
+    );
+
+    let latest_celestia_block = blobstream_contract.latestBlock().call().await?;
+    Ok(latest_celestia_block)
+}
+
+/// Find the L1 block that posted a batch with Celestia height less than or equal to the given
+/// target height. This uses binary search to efficiently find the appropriate L1 block.
+pub async fn find_l1_block_for_celestia_height(
+    fetcher: &OPSuccinctDataFetcher,
+    target_celestia_height: u64,
+    search_start_l1_block: u64,
+    search_end_l1_block: u64,
+) -> Result<Option<u64>> {
+    let batch_inbox_address = fetcher.rollup_config.as_ref().unwrap().batch_inbox_address;
+
+    let mut low = search_start_l1_block;
+    let mut high = search_end_l1_block;
+    let mut result_l1_block = None;
+
+    while low <= high {
+        let mid = (high + low) / 2;
+        let l1_block_hex = format!("0x{mid:x}");
+
+        // Get the safe head for the chain at the midpoint. This will return the latest
+        // transaction with a batch.
+        let result: SafeHeadResponse = fetcher
+            .fetch_rpc_data_with_mode(
+                RPCMode::L2Node,
+                "optimism_safeHeadAtL1Block",
+                vec![l1_block_hex.into()],
+            )
+            .await?;
+        let safe_head_l1_block_number = result.l1_block.number;
+
+        let block = fetcher
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Number(safe_head_l1_block_number))
+            .full()
+            .await?
+            .unwrap();
+
+        let mut found_valid_batch = false;
+        for tx in block.transactions.txns() {
+            if let Some(to_addr) = tx.to() {
+                if to_addr == batch_inbox_address {
+                    match extract_celestia_height(tx)? {
+                        None => {
+                            // ETH DA transaction - always valid.
+                            found_valid_batch = true;
+                            result_l1_block = Some(mid);
+                        }
+                        Some(celestia_height) => {
+                            if celestia_height <= target_celestia_height {
+                                found_valid_batch = true;
+                                result_l1_block = Some(mid);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if found_valid_batch {
+            low = mid + 1; // Look for a more recent batch.
+        } else {
+            high = mid - 1; // The batch at this block is too new, look earlier.
+        }
+    }
+
+    Ok(result_l1_block)
+}
+
+/// Calculate a safe L1 head for Celestia DA by finding the L1 block where the last safe
+/// Celestia batch was posted, considering blobstream commitments.
+pub async fn calculate_celestia_safe_l1_head(
+    fetcher: &OPSuccinctDataFetcher,
+    l2_end_block: u64,
+) -> Result<B256> {
+    // Get the latest Celestia block committed via Blobstream.
+    let latest_committed_celestia_block = get_latest_blobstream_celestia_block(fetcher).await?;
+
+    // Get the L1 block range to search using the existing method from the fetcher.
+    let start_l1_block = fetcher.get_safe_l1_block_for_l2_block(l2_end_block).await?.1;
+
+    let finalized_l1_header = fetcher.get_l1_header(alloy_eips::BlockId::finalized()).await?;
+
+    // Find the L1 block that posted a batch with Celestia height <= latest committed height.
+    match find_l1_block_for_celestia_height(
+        fetcher,
+        latest_committed_celestia_block,
+        start_l1_block,
+        finalized_l1_header.number,
+    )
+    .await?
+    {
+        Some(safe_l1_block) => Ok(fetcher.get_l1_header(safe_l1_block.into()).await?.hash_slow()),
+        None => {
+            bail!("Failed to find a safe L1 block for the given L2 block.");
+        }
+    }
+}

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -14,8 +14,8 @@ use op_succinct_host_utils::fetcher::{OPSuccinctDataFetcher, RPCMode};
 /// - Some(height) if the transaction is a valid Celestia batcher transaction.
 /// - None if the transaction is an ETH DA transaction (EIP4844 transaction or non-EIP4844
 ///   transaction with version byte 0x00).
-/// - Err if the version byte is invalid or the da layer byte is incorrect for non-EIP4844
-///   transactions.
+/// - Err if the version byte is invalid, the commitment type is incorrect, or the da layer byte is
+///   incorrect for non-EIP4844 transactions.
 pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
     // Skip calldata parsing for EIP4844 transactions since there is no calldata.
     if tx.inner.is_eip4844() {
@@ -23,14 +23,37 @@ pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
     } else {
         let calldata = tx.input();
 
-        // TODO: add check for minimum calldata length. This prevents from panics in the case the
-        // calldata is too short.
+        // Check minimum calldata length for version byte
+        if calldata.is_empty() {
+            return Err(anyhow!("Calldata is empty, cannot extract version byte"));
+        }
 
         // Check version byte to determine if it is ETH DA or Alt DA.
         // https://specs.optimism.io/protocol/derivation.html#batcher-transaction-format.
         match calldata[0] {
             0x00 => Ok(None), // ETH DA transaction.
             0x01 => {
+                // Check minimum length for Celestia DA transaction:
+                // [0] = version byte (0x01)
+                // [1] = commitment type (0x01 for altda commitment)
+                // [2] = da layer byte (0x0c for Celestia)
+                // [3..11] = 8-byte Celestia height (little-endian)
+                // [11..] = commitment data
+                if calldata.len() < 11 {
+                    return Err(anyhow!(
+                        "Celestia batcher transaction too short: {} bytes, need at least 11",
+                        calldata.len()
+                    ));
+                }
+
+                // Check that the commitment type is altda (0x01)
+                if calldata[1] != 0x01 {
+                    return Err(anyhow!(
+                        "Invalid commitment type for Celestia batcher transaction: expected 0x01, got 0x{:02x}",
+                        calldata[1]
+                    ));
+                }
+
                 // Check that the DA layer byte prefix is correct.
                 // https://github.com/ethereum-optimism/specs/discussions/135.
                 if calldata[2] != 0x0c {
@@ -40,11 +63,17 @@ pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
                 // The encoding of the commitment is the Celestia block height followed
                 // by the Celestia commitment.
                 let height_bytes = &calldata[3..11];
-                let celestia_height = u64::from_le_bytes(height_bytes.try_into().unwrap());
+                let celestia_height = u64::from_le_bytes(
+                    height_bytes
+                        .try_into()
+                        .map_err(|_| anyhow!("Failed to convert height bytes to u64"))?,
+                );
 
                 Ok(Some(celestia_height))
             }
-            _ => Err(anyhow!("Invalid version byte for batcher transaction")),
+            _ => {
+                Err(anyhow!("Invalid version byte for batcher transaction: 0x{:02x}", calldata[0]))
+            }
         }
     }
 }

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use alloy_provider::Provider;
 use alloy_rpc_types::eth::Transaction as EthTransaction;
 use anyhow::{anyhow, bail, Result};
-use hana_blobstream::blobstream::{blostream_address, SP1Blobstream};
+use hana_blobstream::blobstream::{blobstream_address, SP1Blobstream};
 use kona_rpc::SafeHeadResponse;
 use op_succinct_host_utils::fetcher::{OPSuccinctDataFetcher, RPCMode};
 
@@ -48,7 +48,7 @@ pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
 /// Get the latest Celestia block height that has been committed to Ethereum via Blobstream.
 pub async fn get_latest_blobstream_celestia_block(fetcher: &OPSuccinctDataFetcher) -> Result<u64> {
     let blobstream_contract = SP1Blobstream::new(
-        blostream_address(fetcher.rollup_config.as_ref().unwrap().l1_chain_id)
+        blobstream_address(fetcher.rollup_config.as_ref().unwrap().l1_chain_id)
             .expect("Failed to fetch blobstream contract address"),
         fetcher.l1_provider.clone(),
     );

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -23,7 +23,7 @@ pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
     } else {
         let calldata = tx.input();
 
-        // Check minimum calldata length for version byte
+        // Check minimum calldata length for version byte.
         if calldata.is_empty() {
             return Err(anyhow!("Calldata is empty, cannot extract version byte"));
         }
@@ -46,7 +46,7 @@ pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
                     ));
                 }
 
-                // Check that the commitment type is altda (0x01)
+                // Check that the commitment type is altda (0x01).
                 if calldata[1] != 0x01 {
                     return Err(anyhow!(
                         "Invalid commitment type for Celestia batcher transaction: expected 0x01, got 0x{:02x}",
@@ -106,7 +106,7 @@ pub struct CelestiaL1SafeHead {
 }
 
 impl CelestiaL1SafeHead {
-    /// Get the L1 block hash for this safe head
+    /// Get the L1 block hash for this safe head.
     pub async fn get_l1_hash(&self, fetcher: &OPSuccinctDataFetcher) -> Result<B256> {
         Ok(fetcher.get_l1_header(self.l1_block_number.into()).await?.hash_slow())
     }
@@ -130,10 +130,10 @@ pub async fn get_celestia_safe_head_info(
         .ok_or_else(|| anyhow!("System config not found in genesis"))?
         .batcher_address;
 
-    // Get the latest Celestia block committed via Blobstream
+    // Get the latest Celestia block committed via Blobstream.
     let latest_committed_celestia_block = get_latest_blobstream_celestia_block(fetcher).await?;
 
-    // Get the L1 block range to search
+    // Get the L1 block range to search.
     let mut low = fetcher.get_safe_l1_block_for_l2_block(l2_reference_block).await?.1;
     let mut high = fetcher.get_l1_header(BlockId::finalized()).await?.number;
     let mut result = None;

--- a/utils/celestia/host/src/host.rs
+++ b/utils/celestia/host/src/host.rs
@@ -6,7 +6,7 @@ use alloy_primitives::B256;
 use alloy_provider::Provider;
 use anyhow::Result;
 use async_trait::async_trait;
-use hana_blobstream::blobstream::{blostream_address, SP1Blobstream};
+use hana_blobstream::blobstream::{blobstream_address, SP1Blobstream};
 use hana_host::celestia::{CelestiaCfg, CelestiaChainHost};
 use kona_rpc::SafeHeadResponse;
 use op_succinct_celestia_client_utils::executor::CelestiaDAWitnessExecutor;
@@ -83,7 +83,7 @@ impl OPSuccinctHost for CelestiaOPSuccinctHost {
         let batch_inbox_address = fetcher.rollup_config.as_ref().unwrap().batch_inbox_address;
 
         let blobstream_contract = SP1Blobstream::new(
-            blostream_address(fetcher.rollup_config.as_ref().unwrap().l1_chain_id)
+            blobstream_address(fetcher.rollup_config.as_ref().unwrap().l1_chain_id)
                 .expect("Failed to fetch blobstream contract address"),
             fetcher.l1_provider.clone(),
         );

--- a/utils/celestia/host/src/host.rs
+++ b/utils/celestia/host/src/host.rs
@@ -4,7 +4,7 @@ use alloy_consensus::Transaction;
 use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use alloy_provider::Provider;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use hana_blobstream::blobstream::{blostream_address, SP1Blobstream};
 use hana_host::celestia::{CelestiaCfg, CelestiaChainHost};
@@ -14,6 +14,8 @@ use op_succinct_host_utils::{
     fetcher::{OPSuccinctDataFetcher, RPCMode},
     host::OPSuccinctHost,
 };
+
+use crate::blobstream_utils::{calculate_celestia_safe_l1_head, extract_celestia_height};
 
 use crate::witness_generator::CelestiaDAWitnessGenerator;
 
@@ -37,19 +39,19 @@ impl OPSuccinctHost for CelestiaOPSuccinctHost {
         l2_start_block: u64,
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
-        safe_db_fallback: Option<bool>,
+        safe_db_fallback: bool,
     ) -> Result<CelestiaChainHost> {
-        let host = self
-            .fetcher
-            .get_host_args(
-                l2_start_block,
-                l2_end_block,
-                l1_head_hash,
-                safe_db_fallback.expect("`safe_db_fallback` must be set"),
-            )
-            .await?;
+        // Calculate L1 head hash using blobstream logic if not provided.
+        let l1_head_hash = match l1_head_hash {
+            Some(hash) => hash,
+            None => {
+                self.calculate_safe_l1_head(&self.fetcher, l2_end_block, safe_db_fallback).await?
+            }
+        };
 
-        // Create `CelestiaCfg` directly from environment variables
+        let host = self.fetcher.get_host_args(l2_start_block, l2_end_block, l1_head_hash).await?;
+
+        // Create `CelestiaCfg` directly from environment variables.
         let celestia_args = CelestiaCfg {
             celestia_connection: std::env::var("CELESTIA_CONNECTION").ok(),
             auth_token: std::env::var("AUTH_TOKEN").ok(),
@@ -161,6 +163,15 @@ impl OPSuccinctHost for CelestiaOPSuccinctHost {
 
         Ok(l2_block_number)
     }
+
+    async fn calculate_safe_l1_head(
+        &self,
+        fetcher: &OPSuccinctDataFetcher,
+        l2_end_block: u64,
+        _safe_db_fallback: bool,
+    ) -> Result<B256> {
+        calculate_celestia_safe_l1_head(fetcher, l2_end_block).await
+    }
 }
 
 impl CelestiaOPSuccinctHost {
@@ -170,43 +181,6 @@ impl CelestiaOPSuccinctHost {
             witness_generator: Arc::new(CelestiaDAWitnessGenerator {
                 executor: CelestiaDAWitnessExecutor::new(),
             }),
-        }
-    }
-}
-
-/// Extract the Celestia height from batcher transaction based on the version byte.
-///
-/// Returns:
-/// - Some(height) if the transaction is a valid Celestia batcher transaction.
-/// - None if the transaction is an ETH DA transaction (EIP4844 transaction or non-EIP4844
-///   transaction with version byte 0x00).
-/// - Err if the version byte is invalid or the da layer byte is incorrect for non-EIP4844
-///   transactions.
-fn extract_celestia_height(tx: &alloy_rpc_types::eth::Transaction) -> Result<Option<u64>> {
-    // Skip calldata parsing for EIP4844 transactions since there is no calldata.
-    if tx.inner.is_eip4844() {
-        Ok(None)
-    } else {
-        let calldata = tx.input();
-        // Check version byte to determine if it is ETH DA or Alt DA.
-        // https://specs.optimism.io/protocol/derivation.html#batcher-transaction-format.
-        match calldata[0] {
-            0x00 => Ok(None), // ETH DA transaction.
-            0x01 => {
-                // Check that the DA layer byte prefix is correct.
-                // https://github.com/ethereum-optimism/specs/discussions/135.
-                if calldata[2] != 0x0c {
-                    return Err(anyhow!("Invalid prefix for Celestia batcher transaction"));
-                }
-
-                // The encoding of the commitment is the Celestia block height followed
-                // by the Celestia commitment.
-                let height_bytes = &calldata[3..11];
-                let celestia_height = u64::from_le_bytes(height_bytes.try_into().unwrap());
-
-                Ok(Some(celestia_height))
-            }
-            _ => Err(anyhow!("Invalid version byte for batcher transaction")),
         }
     }
 }

--- a/utils/celestia/host/src/lib.rs
+++ b/utils/celestia/host/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod blobstream_utils;
 pub mod host;
 pub mod witness_generator;

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -682,7 +682,7 @@ impl OPSuccinctDataFetcher {
 
                 // FIXME: Investigate requirement for L1 head offset beyond batch posting block with
                 // safe head > L2 end block.
-                let l1_head_number = l1_head_number + 20;
+                let l1_head_number = l1_head_number + 300;
                 // The new L1 header requested should not be greater than the finalized L1 header
                 // minus 10 blocks.
                 let finalized_l1_header = self.get_l1_header(BlockId::finalized()).await?;

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -532,7 +532,11 @@ impl OPSuccinctDataFetcher {
     /// for the end L2 block was posted. If the safeDB is not activated:
     ///   - If `safe_db_fallback` is `true`, estimate the L1 head based on the L2 block timestamp.
     ///   - Else, return an error.
-    async fn get_l1_head(&self, l2_end_block: u64, safe_db_fallback: bool) -> Result<(B256, u64)> {
+    pub async fn get_l1_head(
+        &self,
+        l2_end_block: u64,
+        safe_db_fallback: bool,
+    ) -> Result<(B256, u64)> {
         if self.rollup_config.is_none() {
             return Err(anyhow::anyhow!("Rollup config not loaded."));
         }
@@ -618,8 +622,7 @@ impl OPSuccinctDataFetcher {
         &self,
         l2_start_block: u64,
         l2_end_block: u64,
-        l1_head_hash: Option<B256>,
-        safe_db_fallback: bool,
+        l1_head_hash: B256,
     ) -> Result<SingleChainHost> {
         // If the rollup config is not already loaded, fetch and save it.
         if self.rollup_config.is_none() {
@@ -674,27 +677,6 @@ impl OPSuccinctDataFetcher {
             l2_claim_hash: l2_claim_hash.0.into(),
         };
         let claimed_l2_output_root = keccak256(l2_claim_encoded.abi_encode());
-
-        let l1_head_hash = match l1_head_hash {
-            Some(l1_head_hash) => l1_head_hash,
-            None => {
-                let (_, l1_head_number) = self.get_l1_head(l2_end_block, safe_db_fallback).await?;
-
-                // FIXME: Investigate requirement for L1 head offset beyond batch posting block with
-                // safe head > L2 end block.
-                let l1_head_number = l1_head_number + 400;
-                // The new L1 header requested should not be greater than the finalized L1 header
-                // minus 10 blocks.
-                let finalized_l1_header = self.get_l1_header(BlockId::finalized()).await?;
-
-                match l1_head_number > finalized_l1_header.number {
-                    true => {
-                        self.get_l1_header(finalized_l1_header.number.into()).await?.hash_slow()
-                    }
-                    false => self.get_l1_header(l1_head_number.into()).await?.hash_slow(),
-                }
-            }
-        };
 
         Ok(SingleChainHost {
             l1_head: l1_head_hash,

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -682,7 +682,7 @@ impl OPSuccinctDataFetcher {
 
                 // FIXME: Investigate requirement for L1 head offset beyond batch posting block with
                 // safe head > L2 end block.
-                let l1_head_number = l1_head_number + 300;
+                let l1_head_number = l1_head_number + 400;
                 // The new L1 header requested should not be greater than the finalized L1 header
                 // minus 10 blocks.
                 let finalized_l1_header = self.get_l1_header(BlockId::finalized()).await?;

--- a/utils/host/src/host.rs
+++ b/utils/host/src/host.rs
@@ -57,18 +57,17 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
     /// Fetch the host arguments.
     ///
     /// Parameters:
-    /// - `l2_start_block`: The starting L2 block number
-    /// - `l2_end_block`: The ending L2 block number
+    /// - `l2_start_block`: The starting L2 block number.
+    /// - `l2_end_block`: The ending L2 block number.
     /// - `l1_head_hash`: Optionally supplied L1 head block hash used as the L1 origin.
-    /// - `safe_db_fallback`: Optionally supplied flag to indicate whether to fallback to
-    ///   timestamp-based L1 head estimation when SafeDB is not available. This is optional to
-    ///   support abstraction across different node implementations.
+    /// - `safe_db_fallback`: Flag to indicate whether to fallback to timestamp-based L1 head
+    ///   estimation when SafeDB is not available.
     async fn fetch(
         &self,
         l2_start_block: u64,
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
-        safe_db_fallback: Option<bool>,
+        safe_db_fallback: bool,
     ) -> Result<Self::Args>;
 
     /// Run the host and client program.
@@ -107,4 +106,22 @@ pub trait OPSuccinctHost: Send + Sync + 'static {
         fetcher: &OPSuccinctDataFetcher,
         latest_proposed_block_number: u64,
     ) -> Result<Option<u64>>;
+
+    /// Calculate a safe L1 head hash for the given L2 end block.
+    ///
+    /// This method is DA-specific:
+    /// - For ETH DA: Uses simple offset logic.
+    /// - For Celestia DA: Uses blobstream commitment logic to ensure data availability.
+    ///
+    /// Parameters:
+    /// - `fetcher`: The data fetcher for accessing blockchain data.
+    /// - `l2_end_block`: The ending L2 block number for the range.
+    /// - `safe_db_fallback`: Whether to fallback to timestamp-based estimation when SafeDB is
+    ///   unavailable.
+    async fn calculate_safe_l1_head(
+        &self,
+        fetcher: &OPSuccinctDataFetcher,
+        l2_end_block: u64,
+        safe_db_fallback: bool,
+    ) -> Result<B256>;
 }

--- a/validity/src/proof_requester.rs
+++ b/validity/src/proof_requester.rs
@@ -69,7 +69,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
                 request.start_block as u64,
                 request.end_block as u64,
                 None,
-                Some(self.safe_db_fallback),
+                self.safe_db_fallback,
             )
             .await?;
 


### PR DESCRIPTION
Bumps hana to latest tag.

Fixes below error
```
thread 'tokio-runtime-worker' panicked at /home/ubuntu/.cargo/git/checkouts/hana-68f924a88074081e/3f49cc6/crates/proofs/src/blobstream_inclusion.rs:171:10:
called `Result::unwrap()` on an `Err` value: "No matching event found for the given Celestia height"
```
by doing l1 head selection based on Blobstream commitments.

- [x] e2e testing