### PR TITLE
fix: update L2OutputOracle.sol link to archived version

### DIFF
--- a/book/contracts/modifications.md
+++ b/book/contracts/modifications.md
@@ -1,6 +1,6 @@
 # Modifications to Original `L2OutputOracle`
 
-The original `L2OutputOracle` contract can be found [here](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/L2OutputOracle.sol).
+The original `L2OutputOracle` contract can be found [here](https://github.com/ethereum-optimism/optimism/blob/9300db95bbd721e1700211a3e795b22c8290d780/packages/contracts-bedrock/src/L1/L2OutputOracle.sol).
 
 The changes introduced in the `OPSuccinctL2OutputOracle` contract are:
 


### PR DESCRIPTION
The original link to L2OutputOracle.sol was broken because the contract was removed from the Optimism repository. 
Replaced it with a link to the last archived version of the contract for historical reference.