### PR TITLE
fix: add calldata in Update contract.rs

### DIFF
--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -27,7 +27,7 @@ sol! {
         function gameAtIndex(uint256 _index) external view returns (GameType gameType, Timestamp timestamp, IDisputeGame proxy);
 
         /// @notice Creates a new DisputeGame proxy contract.
-        function create(GameType gameType, Claim rootClaim, bytes extraData) external;
+        function create(GameType gameType, Claim rootClaim, bytes calldata extraData) external;
     }
 
     #[allow(missing_docs)]


### PR DESCRIPTION
Description:
This change adds the calldata data location to the bytes extraData parameter in the create function of the DisputeGameFactory contract. Without explicitly specifying calldata or memory, the Solidity compiler will refuse to compile any external function signature that includes a dynamic type.

Why This Is Required:
Solidity requires every dynamic-type parameter in an external function (such as bytes, string, arrays, or structs) to explicitly specify a data location (memory or calldata). Omitting this causes a compilation error: TypeError: Data location must be "memory" or "calldata" for parameter in external function, but none was given.

Result:
Adding calldata ensures the contract compiles successfully.