### PR TITLE
perf(utils/celestia): get minimal safe head

### DIFF
--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -150,9 +150,10 @@ pub async fn get_minimal_celestia_safe_head_info(
             )
             .await?;
 
-        // Check if this L1 block contains enough L2 data
+        // Check if this L1 block contains enough L2 data.
         if safe_head_response.safe_head.number >= l2_reference_block {
-            // This L1 block contains sufficient data. Now verify all Celestia heights are committed.
+            // This L1 block contains sufficient data. Now verify all Celestia heights are
+            // committed.
             let block = fetcher
                 .l1_provider
                 .get_block_by_number(BlockNumberOrTag::Number(safe_head_response.l1_block.number))
@@ -173,18 +174,18 @@ pub async fn get_minimal_celestia_safe_head_info(
             }
 
             if all_celestia_committed {
-                // Found a valid L1 block, try to find an earlier one
+                // Found a valid L1 block, try to find an earlier one.
                 result = Some(CelestiaL1SafeHead {
                     l1_block_number: current_l1_block,
                     l2_safe_head_number: safe_head_response.safe_head.number,
                 });
                 high = current_l1_block - 1;
             } else {
-                // Celestia data not committed, need a later block
+                // Celestia data not committed, need a later block.
                 low = current_l1_block + 1;
             }
         } else {
-            // L2 safe head is too low, need a later L1 block
+            // L2 safe head is too low, need a later L1 block.
             low = current_l1_block + 1;
         }
     }

--- a/utils/celestia/host/src/host.rs
+++ b/utils/celestia/host/src/host.rs
@@ -8,7 +8,8 @@ use op_succinct_celestia_client_utils::executor::CelestiaDAWitnessExecutor;
 use op_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, host::OPSuccinctHost};
 
 use crate::{
-    blobstream_utils::get_celestia_safe_head_info, witness_generator::CelestiaDAWitnessGenerator,
+    blobstream_utils::{get_celestia_safe_head_info, get_minimal_celestia_safe_head_info},
+    witness_generator::CelestiaDAWitnessGenerator,
 };
 
 #[derive(Clone)]
@@ -71,14 +72,14 @@ impl OPSuccinctHost for CelestiaOPSuccinctHost {
     }
 
     /// Calculate the safe L1 head hash for Celestia DA considering Blobstream commitments.
-    /// Finds the latest L1 block containing batches with Celestia data committed via Blobstream.
+    /// Finds the minimal L1 block containing all necessary data for the L2 block range.
     async fn calculate_safe_l1_head(
         &self,
         fetcher: &OPSuccinctDataFetcher,
         l2_end_block: u64,
         _safe_db_fallback: bool,
     ) -> Result<B256> {
-        match get_celestia_safe_head_info(fetcher, l2_end_block).await? {
+        match get_minimal_celestia_safe_head_info(fetcher, l2_end_block).await? {
             Some(safe_head) => safe_head.get_l1_hash(fetcher).await,
             None => bail!("Failed to find a safe L1 block for the given L2 block."),
         }

--- a/utils/celestia/host/src/host.rs
+++ b/utils/celestia/host/src/host.rs
@@ -85,7 +85,7 @@ impl OPSuccinctHost for CelestiaOPSuccinctHost {
 
         // Add a buffer for Celestia DA (larger than Ethereum DA due to Blobstream commitment
         // delay).
-        let l1_head_number = l1_head_number + 400;
+        let l1_head_number = l1_head_number + 500;
 
         // Ensure we don't exceed the finalized L1 header.
         let finalized_l1_header = fetcher.get_l1_header(BlockId::finalized()).await?;


### PR DESCRIPTION
Chooses the minimal L1 head that has the celestia block height that contains the relevant data for proving a range of L2 blocks.