### PR TITLE
feat: enhance logging configuration and add logger test example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11392,6 +11392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11411,12 +11421,14 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ bincode = "1.3.3"
 base64 = "0.22.1"
 tower-http = { version = "0.5.2", features = ["limit"] }
 tracing = { version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.18", features = ["fmt", "json"] }
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.2"
 metrics-process = "2.4.0"

--- a/validity/Cargo.toml
+++ b/validity/Cargo.toml
@@ -11,6 +11,10 @@ homepage.workspace = true
 name = "validity"
 path = "bin/validity.rs"
 
+[[example]]
+name = "logger_test"
+path = "examples/logger_test.rs"
+
 [dependencies]
 
 # workspace

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -6,7 +6,7 @@ use op_succinct_host_utils::{
 };
 use op_succinct_proof_utils::initialize_host;
 use op_succinct_validity::{
-    read_proposer_env, setup_proposer_logger, DriverDBClient, Proposer, RequesterConfig,
+    read_proposer_env, setup_logger_with_format, DriverDBClient, Proposer, RequesterConfig,
     ValidityGauge,
 };
 use std::sync::Arc;
@@ -37,12 +37,13 @@ async fn main() -> Result<()> {
 
     dotenv::from_filename(args.env_file).ok();
 
-    setup_proposer_logger();
+    // Read the environment variables first to get the log format
+    let env_config = read_proposer_env()?;
+
+    // Setup logger with the configured format
+    setup_logger_with_format(&env_config.log_format);
 
     let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
-
-    // Read the environment variables.
-    let env_config = read_proposer_env()?;
 
     let db_client = Arc::new(DriverDBClient::new(&env_config.db_url).await?);
     let proposer_config = RequesterConfig {

--- a/validity/examples/logger_test.rs
+++ b/validity/examples/logger_test.rs
@@ -1,0 +1,47 @@
+/// Simple test program to verify LOG_FORMAT configuration works
+use op_succinct_validity::setup_logger_with_format;
+use std::env;
+use tracing::{info, warn, error};
+
+fn main() {
+    // Read LOG_FORMAT from environment variable, default to "pretty"
+    let log_format = env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
+    
+    println!("Testing LOG_FORMAT configuration...");
+    println!("LOG_FORMAT environment variable: {}", log_format);
+    
+    // Initialize logger with the format from environment
+    println!("\n=== Initializing logger with format: '{}' ===", log_format);
+    setup_logger_with_format(&log_format);
+    
+    // Test different log levels
+    info!("This is an info message");
+    warn!("This is a warning message");
+    error!("This is an error message");
+    
+    // Test structured logging
+    info!(
+        user_id = 12345,
+        action = "login",
+        ip_address = "192.168.1.1",
+        "User login event"
+    );
+    
+    warn!(
+        error_code = "E001",
+        retry_count = 3,
+        "Retrying failed operation"
+    );
+    
+    error!(
+        exception = "NullPointerException",
+        stack_trace = "at main.rs:42",
+        "Critical error occurred"
+    );
+    
+    println!("\nLogger test completed. Log output above shows format: '{}'", log_format);
+    println!("\nTo test different formats:");
+    println!("  LOG_FORMAT=pretty cargo run --example logger_test");
+    println!("  LOG_FORMAT=json cargo run --example logger_test");
+    println!("  LOG_FORMAT=invalid cargo run --example logger_test  # should default to pretty");
+}

--- a/validity/examples/logger_test.rs
+++ b/validity/examples/logger_test.rs
@@ -1,44 +1,35 @@
 /// Simple test program to verify LOG_FORMAT configuration works
 use op_succinct_validity::setup_logger_with_format;
 use std::env;
-use tracing::{info, warn, error};
+use tracing::{error, info, warn};
 
 fn main() {
     // Read LOG_FORMAT from environment variable, default to "pretty"
     let log_format = env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
-    
+
     println!("Testing LOG_FORMAT configuration...");
     println!("LOG_FORMAT environment variable: {}", log_format);
-    
+
     // Initialize logger with the format from environment
     println!("\n=== Initializing logger with format: '{}' ===", log_format);
     setup_logger_with_format(&log_format);
-    
+
     // Test different log levels
     info!("This is an info message");
     warn!("This is a warning message");
     error!("This is an error message");
-    
+
     // Test structured logging
-    info!(
-        user_id = 12345,
-        action = "login",
-        ip_address = "192.168.1.1",
-        "User login event"
-    );
-    
-    warn!(
-        error_code = "E001",
-        retry_count = 3,
-        "Retrying failed operation"
-    );
-    
+    info!(user_id = 12345, action = "login", ip_address = "192.168.1.1", "User login event");
+
+    warn!(error_code = "E001", retry_count = 3, "Retrying failed operation");
+
     error!(
         exception = "NullPointerException",
         stack_trace = "at main.rs:42",
         "Critical error occurred"
     );
-    
+
     println!("\nLogger test completed. Log output above shows format: '{}'", log_format);
     println!("\nTo test different formats:");
     println!("  LOG_FORMAT=pretty cargo run --example logger_test");

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -25,6 +25,7 @@ pub struct EnvironmentConfig {
     pub submission_interval: u64,
     pub mock: bool,
     pub safe_db_fallback: bool,
+    pub log_format: String,
 }
 
 /// Helper function to get environment variables with a default value and parse them.
@@ -106,6 +107,7 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         mock: get_env_var("OP_SUCCINCT_MOCK", Some(false))?,
         loop_interval,
         safe_db_fallback: get_env_var("SAFE_DB_FALLBACK", Some(false))?,
+        log_format: env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string()),
     };
 
     Ok(config)

--- a/validity/src/logger.rs
+++ b/validity/src/logger.rs
@@ -27,10 +27,7 @@ pub fn setup_logger_with_format(format: &str) {
     match format.to_lowercase().as_str() {
         "json" => {
             // Initialize with JSON formatting
-            tracing_subscriber::fmt()
-                .with_env_filter(env_filter)
-                .json()
-                .init();
+            tracing_subscriber::fmt().with_env_filter(env_filter).json().init();
         }
         "pretty" | _ => {
             // Default to pretty formatting with ANSI colors

--- a/validity/src/logger.rs
+++ b/validity/src/logger.rs
@@ -1,37 +1,52 @@
 /// Set up the logger for the proposer.
 pub fn setup_proposer_logger() {
-    // Set up logging using the provided format
-    let format = tracing_subscriber::fmt::format()
-        .with_level(true)
-        .with_target(false)
-        .with_thread_ids(false)
-        .with_thread_names(false)
-        .with_file(false)
-        .with_line_number(false)
-        .with_ansi(true);
+    setup_logger_with_format("pretty");
+}
 
+/// Set up the logger with a specific format.
+pub fn setup_logger_with_format(format: &str) {
     // Turn off all logging from kona and SP1.
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive(tracing::Level::INFO.into())
-                .add_directive("single_hint_handler=error".parse().unwrap())
-                .add_directive("execute=error".parse().unwrap())
-                .add_directive("sp1_prover=error".parse().unwrap())
-                .add_directive("boot_loader=error".parse().unwrap())
-                .add_directive("client_executor=error".parse().unwrap())
-                .add_directive("client=error".parse().unwrap())
-                .add_directive("channel_assembler=error".parse().unwrap())
-                .add_directive("attributes_queue=error".parse().unwrap())
-                .add_directive("batch_validator=error".parse().unwrap())
-                .add_directive("batch_queue=error".parse().unwrap())
-                .add_directive("client_derivation_driver=error".parse().unwrap())
-                .add_directive("block_builder=error".parse().unwrap())
-                .add_directive("host_server=error".parse().unwrap())
-                .add_directive("kona_protocol=error".parse().unwrap())
-                .add_directive("sp1_core_executor=off".parse().unwrap())
-                .add_directive("sp1_core_machine=error".parse().unwrap()),
-        )
-        .event_format(format)
-        .init();
+    let env_filter = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive("single_hint_handler=error".parse().unwrap())
+        .add_directive("execute=error".parse().unwrap())
+        .add_directive("sp1_prover=error".parse().unwrap())
+        .add_directive("boot_loader=error".parse().unwrap())
+        .add_directive("client_executor=error".parse().unwrap())
+        .add_directive("client=error".parse().unwrap())
+        .add_directive("channel_assembler=error".parse().unwrap())
+        .add_directive("attributes_queue=error".parse().unwrap())
+        .add_directive("batch_validator=error".parse().unwrap())
+        .add_directive("batch_queue=error".parse().unwrap())
+        .add_directive("client_derivation_driver=error".parse().unwrap())
+        .add_directive("block_builder=error".parse().unwrap())
+        .add_directive("host_server=error".parse().unwrap())
+        .add_directive("kona_protocol=error".parse().unwrap())
+        .add_directive("sp1_core_executor=off".parse().unwrap())
+        .add_directive("sp1_core_machine=error".parse().unwrap());
+
+    match format.to_lowercase().as_str() {
+        "json" => {
+            // Initialize with JSON formatting
+            tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .json()
+                .init();
+        }
+        "pretty" | _ => {
+            // Default to pretty formatting with ANSI colors
+            let pretty_format = tracing_subscriber::fmt::format()
+                .with_level(true)
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_thread_names(false)
+                .with_file(false)
+                .with_line_number(false)
+                .with_ansi(true);
+
+            tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .event_format(pretty_format)
+                .init();
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new feature to support configurable logging formats, adds an example program for testing the logging setup, and updates related dependencies and environment configurations. The changes primarily focus on enabling JSON and "pretty" log formats, improving flexibility for structured logging.

### Logging Enhancements:
* [`validity/src/logger.rs`](diffhunk://#diff-c62ac19a3ff8100cd19e8597614684d54675e7aec4416ae092dbe6a932f36a35L3-R9): Refactored logging setup to support configurable formats ("json" and "pretty") using the `setup_logger_with_format` function. Updated the `setup_proposer_logger` function to default to "pretty" format. [[1]](diffhunk://#diff-c62ac19a3ff8100cd19e8597614684d54675e7aec4416ae092dbe6a932f36a35L3-R9) [[2]](diffhunk://#diff-c62ac19a3ff8100cd19e8597614684d54675e7aec4416ae092dbe6a932f36a35L33-R52)

### Example Program:
* [`validity/examples/logger_test.rs`](diffhunk://#diff-e6d071880efa94e74a8efd4697de53d042025308a2acea0de040297b80b1d3e9R1-R47): Added a new example program to test the logging configuration with different formats, including structured logging and various log levels.

### Environment Configuration Updates:
* [`validity/src/env.rs`](diffhunk://#diff-9457bce61520b88fd84d0a3acbf405daf9044c14b276512d42a3088572d150e2R28): Added a `log_format` field to the `EnvironmentConfig` struct and updated the `read_proposer_env` function to read the `LOG_FORMAT` environment variable with a default value of "pretty." [[1]](diffhunk://#diff-9457bce61520b88fd84d0a3acbf405daf9044c14b276512d42a3088572d150e2R28) [[2]](diffhunk://#diff-9457bce61520b88fd84d0a3acbf405daf9044c14b276512d42a3088572d150e2R110)

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L55-R55): Updated the `tracing-subscriber` dependency to include the "json" feature, enabling support for JSON log formatting.

### Workspace Example Addition:
* [`validity/Cargo.toml`](diffhunk://#diff-979b9c56dbd827a0fc02ab1ed114349b7f075926be333fa67eb58ea4168aedabR14-R17): Added a new example entry for the `logger_test` program to the workspace configuration.