### PR TITLE
fix: fix l1 head selection for celestia da

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -651,7 +651,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "tokio",
@@ -980,11 +980,11 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-transport",
  "http-body-util",
- "hyper",
- "hyper-tls",
+ "hyper 1.6.0",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.12.18",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1672,9 +1672,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1687,7 +1687,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -1705,12 +1705,12 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1763,6 +1763,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -3152,7 +3158,7 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.18",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -3931,6 +3937,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.9.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
@@ -4284,6 +4309,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -4301,7 +4337,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4319,6 +4355,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -4326,9 +4386,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
+ "h2 0.4.10",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4345,7 +4405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
  "http 1.3.1",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls",
@@ -4363,11 +4423,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4378,7 +4451,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4398,14 +4471,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -4577,7 +4650,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "windows 0.53.0",
 ]
@@ -4594,7 +4667,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rand 0.8.5",
@@ -4877,7 +4950,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types 0.24.9",
  "parking_lot",
@@ -4902,7 +4975,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types 0.25.1",
  "parking_lot",
@@ -4925,8 +4998,8 @@ checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core 0.24.9",
@@ -4976,9 +5049,9 @@ checksum = "d38b0bcf407ac68d241f90e2d46041e6a06988f97fe1721fb80b91c42584fae6"
 dependencies = [
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
@@ -5315,7 +5388,7 @@ dependencies = [
  "kona-std-fpvm",
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
- "reqwest",
+ "reqwest 0.12.18",
  "revm",
  "rocksdb",
  "serde",
@@ -5531,7 +5604,7 @@ dependencies = [
  "lru 0.14.0",
  "op-alloy-consensus",
  "op-alloy-network",
- "reqwest",
+ "reqwest 0.12.18",
  "serde",
  "thiserror 2.0.12",
  "tower 0.5.2",
@@ -6337,7 +6410,7 @@ checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
  "indexmap 2.9.0",
@@ -6358,7 +6431,7 @@ checksum = "df88858cd28baaaf2cfc894e37789ed4184be0e1351157aec7bf3c2266c793fd"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "indexmap 2.9.0",
  "ipnet",
@@ -7097,7 +7170,10 @@ dependencies = [
  "op-succinct-celestia-client-utils",
  "op-succinct-client-utils",
  "op-succinct-host-utils",
+ "reqwest 0.11.27",
  "rkyv",
+ "serde",
+ "serde_json",
  "sp1-sdk",
 ]
 
@@ -7241,7 +7317,7 @@ dependencies = [
  "op-alloy-network",
  "op-succinct-client-utils",
  "op-succinct-elfs",
- "reqwest",
+ "reqwest 0.12.18",
  "rkyv",
  "serde",
  "serde_cbor",
@@ -7280,7 +7356,7 @@ dependencies = [
  "op-succinct-host-utils",
  "op-succinct-proof-utils",
  "op-succinct-scripts",
- "reqwest",
+ "reqwest 0.12.18",
  "serde_json",
  "sp1-sdk",
  "tokio",
@@ -7367,7 +7443,7 @@ dependencies = [
  "op-succinct-host-utils",
  "op-succinct-proof-utils",
  "op-succinct-signer-utils",
- "reqwest",
+ "reqwest 0.12.18",
  "rustls",
  "serde",
  "serde_json",
@@ -8703,6 +8779,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
@@ -8712,13 +8828,13 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.10",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -8734,7 +8850,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -8759,7 +8875,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest",
+ "reqwest 0.12.18",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -9250,6 +9366,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.2.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -10312,7 +10437,7 @@ dependencies = [
  "p3-field",
  "p3-fri",
  "prost",
- "reqwest",
+ "reqwest 0.12.18",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -10799,6 +10924,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -10834,13 +10965,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -11222,18 +11374,18 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
+ "h2 0.4.10",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
  "tokio-rustls",
@@ -11273,7 +11425,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -11290,7 +11442,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.2",
@@ -11455,9 +11607,9 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "prost",
- "reqwest",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7159,6 +7159,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "hana-blobstream",
@@ -7175,6 +7176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-sdk",
+ "tracing",
 ]
 
 [[package]]

--- a/utils/celestia/host/Cargo.toml
+++ b/utils/celestia/host/Cargo.toml
@@ -34,3 +34,6 @@ alloy-rpc-types.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 rkyv.workspace = true
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/utils/celestia/host/Cargo.toml
+++ b/utils/celestia/host/Cargo.toml
@@ -29,6 +29,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-types.workspace = true
+alloy-sol-types.workspace = true
 
 # general
 anyhow.workspace = true
@@ -37,3 +38,4 @@ rkyv.workspace = true
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tracing.workspace = true

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -74,9 +74,8 @@ fn verify_data_commitment_event(
     Ok(is_within_range)
 }
 
-// Constants for block scanning configuration
+// Constant for block scanning configuration
 const DEFAULT_FILTER_BLOCK_RANGE: u64 = 5000;
-const MAX_SCAN_DISTANCE: u64 = 10000;
 
 /// Find the minimum L1 block that contains a Blobstream proof for the given Celestia height.
 /// Scans forward from the start block to find the first block with the proof.
@@ -154,16 +153,6 @@ async fn find_minimum_blobstream_block(
                     }
                 }
             }
-        }
-
-        // If we've scanned too far ahead without finding anything, error out
-        if current_start > start_block + MAX_SCAN_DISTANCE {
-            return Err(anyhow!(
-                "No Blobstream proof found for Celestia height {} within {} blocks of L1 block {}",
-                celestia_height,
-                MAX_SCAN_DISTANCE,
-                start_block
-            ));
         }
 
         // Move to next batch
@@ -287,20 +276,10 @@ pub async fn get_highest_finalized_l2_block(
     let l2_finalized_block = l2_finalized_header.number;
 
     tracing::info!(
-        "Searching for highest provable L2 block between {} (finalized) and {} (latest proposed)",
+        "Searching for highest provable L2 block between {} (latest proposed) and {} (finalized)",
+        latest_proposed_block_number,
         l2_finalized_block,
-        latest_proposed_block_number
     );
-
-    // If the range is invalid, return None
-    if l2_finalized_block > latest_proposed_block_number {
-        tracing::warn!(
-            "L2 finalized block {} is higher than latest proposed block {}",
-            l2_finalized_block,
-            latest_proposed_block_number
-        );
-        return Ok(None);
-    }
 
     // Binary search to find the highest L2 block with available Celestia data
     let mut low = l2_finalized_block;
@@ -337,14 +316,14 @@ pub async fn get_highest_finalized_l2_block(
         tracing::info!(
             "Found highest provable L2 block: {} (out of range {}-{})",
             highest_block,
-            l2_finalized_block,
-            latest_proposed_block_number
+            latest_proposed_block_number,
+            l2_finalized_block
         );
     } else {
         tracing::warn!(
             "No provable L2 blocks found in range {}-{}",
+            latest_proposed_block_number,
             l2_finalized_block,
-            latest_proposed_block_number
         );
     }
 

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -1,103 +1,10 @@
-use alloy_consensus::Transaction;
-use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{keccak256, B256};
 use alloy_provider::Provider;
-use alloy_rpc_types::eth::Transaction as EthTransaction;
+use alloy_rpc_types::Filter;
 use anyhow::{anyhow, Result};
-use hana_blobstream::blobstream::{blobstream_address, SP1Blobstream};
-use kona_rpc::SafeHeadResponse;
-use op_succinct_host_utils::fetcher::{OPSuccinctDataFetcher, RPCMode};
-
-/// Extract the Celestia height from batcher transaction based on the version byte.
-///
-/// Returns:
-/// - Some(height) if the transaction is a valid Celestia batcher transaction.
-/// - None if the transaction is an ETH DA transaction (EIP4844 transaction or non-EIP4844
-///   transaction with version byte 0x00).
-/// - Err if the version byte is invalid, the commitment type is incorrect, or the da layer byte is
-///   incorrect for non-EIP4844 transactions.
-pub fn extract_celestia_height(tx: &EthTransaction) -> Result<Option<u64>> {
-    // Skip calldata parsing for EIP4844 transactions since there is no calldata.
-    if tx.inner.is_eip4844() {
-        Ok(None)
-    } else {
-        let calldata = tx.input();
-
-        // Check minimum calldata length for version byte.
-        if calldata.is_empty() {
-            return Err(anyhow!("Calldata is empty, cannot extract version byte"));
-        }
-
-        // Check version byte to determine if it is ETH DA or Alt DA.
-        // https://specs.optimism.io/protocol/derivation.html#batcher-transaction-format.
-        match calldata[0] {
-            0x00 => Ok(None), // ETH DA transaction.
-            0x01 => {
-                // Check minimum length for Celestia DA transaction:
-                // [0] = version byte (0x01)
-                // [1] = commitment type (0x01 for altda commitment)
-                // [2] = da layer byte (0x0c for Celestia)
-                // [3..11] = 8-byte Celestia height (little-endian)
-                // [11..] = commitment data
-                if calldata.len() < 11 {
-                    return Err(anyhow!(
-                        "Celestia batcher transaction too short: {} bytes, need at least 11",
-                        calldata.len()
-                    ));
-                }
-
-                // Check that the commitment type is altda (0x01).
-                if calldata[1] != 0x01 {
-                    return Err(anyhow!(
-                        "Invalid commitment type for Celestia batcher transaction: expected 0x01, got 0x{:02x}",
-                        calldata[1]
-                    ));
-                }
-
-                // Check that the DA layer byte prefix is correct.
-                // https://github.com/ethereum-optimism/specs/discussions/135.
-                if calldata[2] != 0x0c {
-                    return Err(anyhow!("Invalid prefix for Celestia batcher transaction"));
-                }
-
-                // The encoding of the commitment is the Celestia block height followed
-                // by the Celestia commitment.
-                let height_bytes = &calldata[3..11];
-                let celestia_height = u64::from_le_bytes(
-                    height_bytes
-                        .try_into()
-                        .map_err(|_| anyhow!("Failed to convert height bytes to u64"))?,
-                );
-
-                Ok(Some(celestia_height))
-            }
-            _ => {
-                Err(anyhow!("Invalid version byte for batcher transaction: 0x{:02x}", calldata[0]))
-            }
-        }
-    }
-}
-
-/// Get the latest Celestia block height that has been committed to Ethereum via Blobstream.
-pub async fn get_latest_blobstream_celestia_block(fetcher: &OPSuccinctDataFetcher) -> Result<u64> {
-    let blobstream_contract = SP1Blobstream::new(
-        blobstream_address(fetcher.rollup_config.as_ref().unwrap().l1_chain_id)
-            .expect("Failed to fetch blobstream contract address"),
-        fetcher.l1_provider.clone(),
-    );
-
-    let latest_celestia_block = blobstream_contract.latestBlock().call().await?;
-    Ok(latest_celestia_block)
-}
-
-fn is_valid_batch_transaction(
-    tx: &EthTransaction,
-    batch_inbox_address: Address,
-    batcher_address: Address,
-) -> Result<bool> {
-    Ok(tx.to().is_some_and(|addr| addr == batch_inbox_address) &&
-        tx.inner.recover_signer().is_ok_and(|signer| signer == batcher_address))
-}
+use hana_blobstream::blobstream::blobstream_address;
+use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
 pub struct CelestiaL1SafeHead {
@@ -108,86 +15,225 @@ pub struct CelestiaL1SafeHead {
 impl CelestiaL1SafeHead {
     /// Get the L1 block hash for this safe head.
     pub async fn get_l1_hash(&self, fetcher: &OPSuccinctDataFetcher) -> Result<B256> {
+        println!("L1 HEAD NUMBER: {}", self.l1_block_number);
         Ok(fetcher.get_l1_header(self.l1_block_number.into()).await?.hash_slow())
     }
 }
 
-/// Find the latest safe L1 block with Celestia batches committed via Blobstream.
-/// Uses binary search to efficiently locate the highest L1 block containing batch transactions
-/// with Celestia heights that have been committed to Ethereum through Blobstream.
+/// Response structure from Celestia indexer RPC.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CelestiaLocationResponse {
+    pub height: u64,
+    pub commitment: String,
+    pub l2_range: L2Range,
+    pub l1_block: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct L2Range {
+    pub start: u64,
+    pub end: u64,
+}
+
+/// Find the minimum L1 block that contains a Blobstream proof for the given Celestia height.
+/// Scans forward from the start block to find the first block with the proof.
+async fn find_minimum_blobstream_block(
+    celestia_height: u64,
+    start_block: u64,
+    fetcher: &OPSuccinctDataFetcher,
+) -> Result<u64> {
+    const FILTER_BLOCK_RANGE: u64 = 5000;
+
+    // Get the Blobstream contract address for this chain
+    let chain_id = fetcher.rollup_config.as_ref().unwrap().l1_chain_id;
+    let blobstream_addr = blobstream_address(chain_id)
+        .ok_or_else(|| anyhow!("No Blobstream address found for chain ID {}", chain_id))?;
+
+    // Calculate event signature for DataCommitmentStored
+    let event_signature = "DataCommitmentStored(uint256,uint64,uint64,bytes32)";
+    let event_selector = keccak256(event_signature.as_bytes());
+
+    // Start scanning from the indexer-provided block
+    let mut current_start = start_block;
+    let latest_block = fetcher.l1_provider.get_block_number().await?;
+
+    println!(
+        "Scanning for Blobstream proof for Celestia height {} starting from L1 block {}",
+        celestia_height, start_block
+    );
+
+    loop {
+        let current_end = std::cmp::min(current_start + FILTER_BLOCK_RANGE - 1, latest_block);
+
+        // Create filter for DataCommitmentStored events
+        let filter = Filter::new()
+            .address(blobstream_addr)
+            .event_signature(event_selector)
+            .from_block(current_start)
+            .to_block(current_end);
+
+        // Get logs from L1 provider
+        let logs = fetcher.l1_provider.get_logs(&filter).await?;
+
+        // Check each log to find the one containing our Celestia height
+        for log in logs {
+            // For simplicity, we'll check if the log is from the Blobstream contract
+            // The actual decoding happens in the hana code later
+            if log.address() == blobstream_addr {
+                let block_number =
+                    log.block_number.ok_or_else(|| anyhow!("Log missing block number"))?;
+
+                // Since we're scanning forward and Blobstream posts sequentially,
+                // the first event we find after the indexer block should contain our height
+                println!(
+                    "Found potential Blobstream event at L1 block {} for Celestia height {}",
+                    block_number, celestia_height
+                );
+
+                // Return this block as the minimum safe block
+                return Ok(block_number);
+            }
+        }
+
+        // If we've scanned too far ahead without finding anything, error out
+        if current_start > start_block + 10000 {
+            return Err(anyhow!(
+                "No Blobstream proof found for Celestia height {} within 10000 blocks of L1 block {}",
+                celestia_height, start_block
+            ));
+        }
+
+        // Move to next batch
+        current_start = current_end + 1;
+        if current_start > latest_block {
+            return Err(anyhow!(
+                "Reached latest block {} without finding Blobstream proof for Celestia height {}",
+                latest_block,
+                celestia_height
+            ));
+        }
+    }
+}
+
+/// Query the Celestia indexer for the location of an L2 block.
+async fn query_celestia_indexer(l2_block: u64) -> Result<Option<CelestiaLocationResponse>> {
+    // Get the indexer RPC endpoint from environment variable.
+    let indexer_rpc = std::env::var("CELESTIA_INDEXER_RPC").unwrap_or_else(|_| {
+        // Default to localhost if not set.
+        "http://localhost:57220".to_string()
+    });
+
+    // Create the RPC request.
+    let client = reqwest::Client::new();
+    let request_body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "admin_getCelestiaLocation",
+        "params": [l2_block],
+        "id": 1
+    });
+
+    let response = client
+        .post(&indexer_rpc)
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| anyhow!("Failed to query Celestia indexer: {}", e))?;
+
+    let json_response: serde_json::Value =
+        response.json().await.map_err(|e| anyhow!("Failed to parse indexer response: {}", e))?;
+
+    // Check for errors in the RPC response.
+    if let Some(error) = json_response.get("error") {
+        // If the block is not found, return None instead of an error.
+        if error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .map_or(false, |msg| msg.contains("not found"))
+        {
+            return Ok(None);
+        }
+        return Err(anyhow!("Indexer RPC error: {:?}", error));
+    }
+
+    // Parse the result.
+    let result =
+        json_response.get("result").ok_or_else(|| anyhow!("No result in indexer response"))?;
+
+    serde_json::from_value(result.clone())
+        .map(Some)
+        .map_err(|e| anyhow!("Failed to parse Celestia location response: {}", e))
+}
+
+/// Find the earliest safe L1 block with Celestia batches committed via Blobstream.
+/// Uses the Celestia indexer to efficiently locate the L1 block where the L2 block's
+/// Celestia data has been committed to Ethereum through Blobstream.
 pub async fn get_celestia_safe_head_info(
     fetcher: &OPSuccinctDataFetcher,
     l2_reference_block: u64,
 ) -> Result<Option<CelestiaL1SafeHead>> {
-    let rollup_config =
-        fetcher.rollup_config.as_ref().ok_or_else(|| anyhow!("Rollup config not found"))?;
+    // Query the Celestia indexer for this L2 block's location.
+    match query_celestia_indexer(l2_reference_block).await {
+        Ok(Some(location)) => {
+            println!(
+                "Celestia indexer returned location for L2 block {}: height {}, L1 block {}",
+                l2_reference_block, location.height, location.l1_block
+            );
 
-    let batch_inbox_address = rollup_config.batch_inbox_address;
-    let batcher_address = rollup_config
-        .genesis
-        .system_config
-        .as_ref()
-        .ok_or_else(|| anyhow!("System config not found in genesis"))?
-        .batcher_address;
-
-    // Get the latest Celestia block committed via Blobstream.
-    let latest_committed_celestia_block = get_latest_blobstream_celestia_block(fetcher).await?;
-
-    // Get the L1 block range to search.
-    let mut low = fetcher.get_safe_l1_block_for_l2_block(l2_reference_block).await?.1;
-    let mut high = fetcher.get_l1_header(BlockId::finalized()).await?.number;
-    let mut result = None;
-
-    while low <= high {
-        let current_l1_block = low + (high - low) / 2;
-        let l1_block_hex = format!("0x{current_l1_block:x}");
-
-        let safe_head_response: SafeHeadResponse = fetcher
-            .fetch_rpc_data_with_mode(
-                RPCMode::L2Node,
-                "optimism_safeHeadAtL1Block",
-                vec![l1_block_hex.into()],
-            )
-            .await?;
-
-        let block = fetcher
-            .l1_provider
-            .get_block_by_number(BlockNumberOrTag::Number(safe_head_response.l1_block.number))
-            .full()
-            .await?
-            .ok_or_else(|| anyhow!("Block {} not found", safe_head_response.l1_block.number))?;
-
-        let mut found_valid_batch = false;
-        for tx in block.transactions.txns() {
-            if is_valid_batch_transaction(tx, batch_inbox_address, batcher_address)? {
-                match extract_celestia_height(tx)? {
-                    None => {
-                        // ETH DA transaction - always valid.
-                        found_valid_batch = true;
-                        result = Some(CelestiaL1SafeHead {
-                            l1_block_number: current_l1_block,
-                            l2_safe_head_number: safe_head_response.safe_head.number,
-                        });
-                        break;
-                    }
-                    Some(celestia_height) => {
-                        if celestia_height <= latest_committed_celestia_block {
-                            found_valid_batch = true;
-                            result = Some(CelestiaL1SafeHead {
-                                l1_block_number: current_l1_block,
-                                l2_safe_head_number: safe_head_response.safe_head.number,
-                            });
-                            break;
-                        }
-                    }
+            // Find the minimum L1 block that contains the Blobstream proof
+            match find_minimum_blobstream_block(location.height, location.l1_block, fetcher).await {
+                Ok(safe_l1_block) => {
+                    println!(
+                        "Using L1 block {} (Blobstream proof found) for L2 block {}",
+                        safe_l1_block, l2_reference_block
+                    );
+                    Ok(Some(CelestiaL1SafeHead {
+                        l1_block_number: safe_l1_block,
+                        l2_safe_head_number: l2_reference_block,
+                    }))
+                }
+                Err(e) => {
+                    // If we can't find a Blobstream proof, return an error
+                    Err(anyhow!(
+                        "Failed to find Blobstream proof for Celestia height {}: {}",
+                        location.height,
+                        e
+                    ))
                 }
             }
         }
+        Ok(None) => {
+            // Indexer doesn't have data for this block, return error
+            Err(anyhow!("Celestia indexer has no data for L2 block {}", l2_reference_block))
+        }
+        Err(e) => Err(anyhow!("Celestia indexer error: {}", e)),
+    }
+}
 
-        if found_valid_batch {
-            low = current_l1_block + 1;
-        } else {
-            high = current_l1_block - 1;
+/// Find the highest L2 block that can be safely proven given Celestia's Blobstream commitments.
+/// Searches backwards from the latest proposed block to find the highest block with committed data.
+pub async fn get_highest_finalized_l2_block(
+    _fetcher: &OPSuccinctDataFetcher,
+    latest_proposed_block: u64,
+) -> Result<Option<u64>> {
+    // Binary search to find the highest L2 block with Celestia data indexed.
+    let mut low = 0u64;
+    let mut high = latest_proposed_block;
+    let mut result = None;
+
+    while low <= high {
+        let mid = low + (high - low) / 2;
+
+        // Query the indexer for this L2 block's Celestia location.
+        match query_celestia_indexer(mid).await? {
+            Some(_location) => {
+                // This block has Celestia data indexed, try to find a higher one.
+                result = Some(mid);
+                low = mid + 1;
+            }
+            None => {
+                // No Celestia data for this block, search lower.
+                high = mid - 1;
+            }
         }
     }
 

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -282,8 +282,8 @@ pub async fn get_highest_finalized_l2_block(
     );
 
     // Binary search to find the highest L2 block with available Celestia data
-    let mut low = l2_finalized_block;
-    let mut high = latest_proposed_block_number;
+    let mut low = latest_proposed_block_number;
+    let mut high = l2_finalized_block;
     let mut result = None;
 
     while low <= high {

--- a/utils/celestia/host/src/host.rs
+++ b/utils/celestia/host/src/host.rs
@@ -8,7 +8,8 @@ use op_succinct_celestia_client_utils::executor::CelestiaDAWitnessExecutor;
 use op_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, host::OPSuccinctHost};
 
 use crate::{
-    blobstream_utils::get_celestia_safe_head_info, witness_generator::CelestiaDAWitnessGenerator,
+    blobstream_utils::{get_celestia_safe_head_info, get_highest_finalized_l2_block},
+    witness_generator::CelestiaDAWitnessGenerator,
 };
 
 #[derive(Clone)]
@@ -65,9 +66,7 @@ impl OPSuccinctHost for CelestiaOPSuccinctHost {
         fetcher: &OPSuccinctDataFetcher,
         latest_proposed_block_number: u64,
     ) -> Result<Option<u64>> {
-        Ok(get_celestia_safe_head_info(fetcher, latest_proposed_block_number)
-            .await?
-            .map(|safe_head| safe_head.l2_safe_head_number))
+        get_highest_finalized_l2_block(fetcher, latest_proposed_block_number).await
     }
 
     /// Calculate the safe L1 head hash for Celestia DA considering Blobstream commitments.


### PR DESCRIPTION
Fixes l1 head selection for celestia da via offchain indexer.

The offchain indexer:
- monitors L1 batch inbox transactions for Celestia references
- fetches the corresponding frame data from Celestia,
- parses frames to determine which L2 blocks they contain
- maintains an index mapping L2 block numbers to Celestia locations
- and provides an RPC API to query L2 block locations.

Using a dedicated off-chain indexer, we now,
1. Ask the Indexer: We query the indexer with the L2 block we care about.
2. Get Location: The indexer tells us the exact Celestia block height and the original L1 block where the L2 data was referenced.
3. Find Proof: We then scan forward from that L1 block to find the DataCommitmentStored event from the Blobstream contract, which is the on-chain proof that the data is available.

This change replaces a broad, inefficient on-chain search with a precise lookup, making it much faster to find the correct L1 head for Celestia DA.