### PR TITLE
feat: implement malicious challenge

### DIFF
--- a/book/fault_proofs/challenger.md
+++ b/book/fault_proofs/challenger.md
@@ -87,7 +87,7 @@ The challenger will run indefinitely, monitoring for invalid games and challengi
 
 ## Testing Defense Mechanisms
 
-The challenger supports **malicious challenging** of valid games for testing purposes. This feature enables testing of proposer defense mechanisms without needing a separate binary.
+The challenger supports **malicious challenging** of valid games for defense mechanisms testing purposes.
 
 ### Configuration
 
@@ -112,7 +112,7 @@ MALICIOUS_CHALLENGE_PERCENTAGE=25.5
 When malicious challenging is enabled:
 
 1. **Priority 1**: Challenge invalid games (honest challenger behavior)
-2. **Priority 2**: Challenge valid games at the configured percentage (testing behavior)
+2. **Priority 2**: Challenge valid games at the configured percentage (defense mechanisms testing behavior)
 
 The challenger will always prioritize challenging invalid games first, then optionally challenge valid games based on the configured percentage.
 
@@ -120,13 +120,7 @@ The challenger will always prioritize challenging invalid games first, then opti
 
 The challenger provides clear logging to distinguish between challenge types:
 - `[CHALLENGE]` - Honest challenges of invalid games
-- `[MALICIOUS CHALLENGE]` - Testing challenges of valid games
-
-### Safety
-
-- **Production Safe**: Defaults to 0.0% (disabled)
-- **Backward Compatible**: No breaking changes to existing configurations
-- **Clear Warnings**: Startup logs clearly indicate when malicious challenging is enabled
+- `[MALICIOUS CHALLENGE]` - Testing defense mechanisms of challenged valid games
 
 ## Features
 

--- a/book/fault_proofs/challenger.md
+++ b/book/fault_proofs/challenger.md
@@ -54,6 +54,7 @@ Either `PRIVATE_KEY` or both `SIGNER_URL` and `SIGNER_ADDRESS` must be set for t
 | `MAX_GAMES_TO_CHECK_FOR_RESOLUTION` | Maximum number of games to check for resolution | `100` |
 | `MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING` | Maximum number of games to check for bond claiming | `100` |
 | `CHALLENGER_METRICS_PORT` | The port to expose metrics on. Update prometheus.yml to use this port, if using docker compose. | `9001` |
+| `MALICIOUS_CHALLENGE_PERCENTAGE` | Percentage (0.0-100.0) of valid games to challenge for testing defense mechanisms | `0.0` |
 
 ```env
 # Required Configuration
@@ -70,6 +71,9 @@ MAX_GAMES_TO_CHECK_FOR_CHALLENGE=100  # Maximum number of games to scan for chal
 MAX_GAMES_TO_CHECK_FOR_RESOLUTION=100 # Maximum number of games to check for resolution
 MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING=100 # Maximum number of games to check for bond claiming
 CHALLENGER_METRICS_PORT=9001          # The port to expose metrics on
+
+# Testing Configuration (Optional)
+MALICIOUS_CHALLENGE_PERCENTAGE=0.0    # Percentage of valid games to challenge for testing (0.0 = disabled)
 ```
 
 ## Running
@@ -80,6 +84,49 @@ cargo run --bin challenger
 ```
 
 The challenger will run indefinitely, monitoring for invalid games and challenging them as needed.
+
+## Testing Defense Mechanisms
+
+The challenger supports **malicious challenging** of valid games for testing purposes. This feature enables testing of proposer defense mechanisms without needing a separate binary.
+
+### Configuration
+
+Set `MALICIOUS_CHALLENGE_PERCENTAGE` to enable malicious challenging:
+
+```bash
+# Production mode (default) - only challenge invalid games
+MALICIOUS_CHALLENGE_PERCENTAGE=0.0
+
+# Testing mode - challenge all valid games
+MALICIOUS_CHALLENGE_PERCENTAGE=100.0
+
+# Fine-grained testing - challenge 0.1% of valid games
+MALICIOUS_CHALLENGE_PERCENTAGE=0.1
+
+# Mixed testing - challenge 25.5% of valid games
+MALICIOUS_CHALLENGE_PERCENTAGE=25.5
+```
+
+### Behavior
+
+When malicious challenging is enabled:
+
+1. **Priority 1**: Challenge invalid games (honest challenger behavior)
+2. **Priority 2**: Challenge valid games at the configured percentage (testing behavior)
+
+The challenger will always prioritize challenging invalid games first, then optionally challenge valid games based on the configured percentage.
+
+### Logging
+
+The challenger provides clear logging to distinguish between challenge types:
+- `[CHALLENGE]` - Honest challenges of invalid games
+- `[MALICIOUS CHALLENGE]` - Testing challenges of valid games
+
+### Safety
+
+- **Production Safe**: Defaults to 0.0% (disabled)
+- **Backward Compatible**: No breaking changes to existing configurations
+- **Clear Warnings**: Startup logs clearly indicate when malicious challenging is enabled
 
 ## Features
 

--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -127,12 +127,12 @@ where
         }
 
         // Maliciously challenge valid games (if configured for testing defense mechanisms)
-        if self.config.malicious_challenge_percentage > 0 {
+        if self.config.malicious_challenge_percentage > 0.0 {
             if let Some(game_address) = self.get_oldest_valid_game_for_malicious_challenge().await?
             {
                 let mut rng = rand::rng();
                 let should_challenge =
-                    rng.random_range(1..=100) <= self.config.malicious_challenge_percentage;
+                    rng.random_range(0.0..100.0) <= self.config.malicious_challenge_percentage;
 
                 if should_challenge {
                     tracing::warn!(
@@ -224,7 +224,7 @@ where
     /// resolve.
     async fn run(&mut self) -> Result<()> {
         tracing::info!("OP Succinct Challenger running...");
-        if self.config.malicious_challenge_percentage > 0 {
+        if self.config.malicious_challenge_percentage > 0.0 {
             tracing::warn!(
                 "\x1b[33mMalicious challenging enabled: {}% of valid games will be challenged for testing\x1b[0m",
                 self.config.malicious_challenge_percentage

--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -17,6 +17,7 @@ use fault_proof::{
 };
 use op_succinct_host_utils::metrics::{init_metrics, MetricsGauge};
 use op_succinct_signer_utils::Signer;
+use rand::Rng;
 use tokio::time;
 
 #[derive(Parser)]
@@ -84,10 +85,31 @@ where
         Ok(())
     }
 
+    /// Gets the oldest valid game address for malicious challenging (for defense mechanisms
+    /// testing purposes). This finds games with correct output roots that can be challenged to
+    /// test defense mechanisms.
+    async fn get_oldest_valid_game_for_malicious_challenge(&self) -> Result<Option<Address>> {
+        use fault_proof::contract::ProposalStatus;
+
+        self.factory
+            .get_oldest_game_address(
+                self.config.max_games_to_check_for_challenge,
+                self.l2_provider.clone(),
+                |status| status == ProposalStatus::Unchallenged,
+                |output_root, game_claim| output_root == game_claim, /* Valid games (opposite of
+                                                                      * honest challenger) */
+                "Oldest valid game for malicious challenge",
+            )
+            .await
+    }
+
     /// Handles challenging of invalid games by scanning recent games for potential challenges.
+    /// Also supports malicious challenging of valid games for testing defense mechanisms when
+    /// configured.
     async fn handle_game_challenging(&self) -> Result<Action> {
         let _span = tracing::info_span!("[[Challenging]]").entered();
 
+        // Challenge invalid games (honest challenger behavior)
         if let Some(game_address) = self
             .factory
             .get_oldest_challengable_game_address(
@@ -96,12 +118,41 @@ where
             )
             .await?
         {
-            tracing::info!("Attempting to challenge game {:?}", game_address);
+            tracing::info!(
+                "\x1b[32m[CHALLENGE]\x1b[0m Attempting to challenge invalid game {:?}",
+                game_address
+            );
             self.challenge_game(game_address).await?;
-            Ok(Action::Performed)
-        } else {
-            Ok(Action::Skipped)
+            return Ok(Action::Performed);
         }
+
+        // Maliciously challenge valid games (if configured for testing defense mechanisms)
+        if self.config.malicious_challenge_percentage > 0 {
+            if let Some(game_address) = self.get_oldest_valid_game_for_malicious_challenge().await?
+            {
+                let mut rng = rand::rng();
+                let should_challenge =
+                    rng.random_range(1..=100) <= self.config.malicious_challenge_percentage;
+
+                if should_challenge {
+                    tracing::warn!(
+                        "\x1b[31m[MALICIOUS CHALLENGE]\x1b[0m Attempting to challenge valid game {:?} for testing ({}% chance)",
+                        game_address,
+                        self.config.malicious_challenge_percentage
+                    );
+                    self.challenge_game(game_address).await?;
+                    return Ok(Action::Performed);
+                } else {
+                    tracing::debug!(
+                        "Found valid game {:?} but skipping malicious challenge ({}% chance)",
+                        game_address,
+                        self.config.malicious_challenge_percentage
+                    );
+                }
+            }
+        }
+
+        Ok(Action::Skipped)
     }
 
     /// Handles resolution of challenged games that are ready to be resolved.
@@ -173,6 +224,14 @@ where
     /// resolve.
     async fn run(&mut self) -> Result<()> {
         tracing::info!("OP Succinct Challenger running...");
+        if self.config.malicious_challenge_percentage > 0 {
+            tracing::warn!(
+                "\x1b[33mMalicious challenging enabled: {}% of valid games will be challenged for testing\x1b[0m",
+                self.config.malicious_challenge_percentage
+            );
+        } else {
+            tracing::info!("Honest challenger mode (malicious challenging disabled)");
+        }
         let mut interval = time::interval(Duration::from_secs(self.config.fetch_interval));
 
         // Each loop, check the oldest challengeable game and challenge it if it exists.

--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -128,6 +128,7 @@ where
 
         // Maliciously challenge valid games (if configured for testing defense mechanisms)
         if self.config.malicious_challenge_percentage > 0.0 {
+            tracing::debug!("Checking for valid games to challenge maliciously...");
             if let Some(game_address) = self.get_oldest_valid_game_for_malicious_challenge().await?
             {
                 let mut rng = rand::rng();
@@ -149,6 +150,8 @@ where
                         self.config.malicious_challenge_percentage
                     );
                 }
+            } else {
+                tracing::debug!("No valid games found for malicious challenging");
             }
         }
 

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -126,6 +126,11 @@ pub struct ChallengerConfig {
 
     /// The metrics port.
     pub metrics_port: u16,
+
+    /// Percentage (0-100) of valid games to challenge maliciously for testing.
+    /// Set to 0 (default) for production use (honest challenging only).
+    /// Set to >0 for testing defense mechanisms.
+    pub malicious_challenge_percentage: u8,
 }
 
 impl ChallengerConfig {
@@ -150,6 +155,9 @@ impl ChallengerConfig {
                 .parse()?,
             metrics_port: env::var("CHALLENGER_METRICS_PORT")
                 .unwrap_or("9001".to_string())
+                .parse()?,
+            malicious_challenge_percentage: env::var("MALICIOUS_CHALLENGE_PERCENTAGE")
+                .unwrap_or("0".to_string())
                 .parse()?,
         })
     }

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -127,10 +127,10 @@ pub struct ChallengerConfig {
     /// The metrics port.
     pub metrics_port: u16,
 
-    /// Percentage (0-100) of valid games to challenge maliciously for testing.
-    /// Set to 0 (default) for production use (honest challenging only).
-    /// Set to >0 for testing defense mechanisms.
-    pub malicious_challenge_percentage: u8,
+    /// Percentage (0.0-100.0) of valid games to challenge maliciously for testing.
+    /// Set to 0.0 (default) for production use (honest challenging only).
+    /// Set to >0.0 for testing defense mechanisms.
+    pub malicious_challenge_percentage: f64,
 }
 
 impl ChallengerConfig {
@@ -157,7 +157,7 @@ impl ChallengerConfig {
                 .unwrap_or("9001".to_string())
                 .parse()?,
             malicious_challenge_percentage: env::var("MALICIOUS_CHALLENGE_PERCENTAGE")
-                .unwrap_or("0".to_string())
+                .unwrap_or("0.0".to_string())
                 .parse()?,
         })
     }


### PR DESCRIPTION
# Summary
Enhances the existing challenger binary to support malicious challenging of valid games for testing defense mechanisms. 

# Changes
  - Added MALICIOUS_CHALLENGE_PERCENTAGE config option (0-100, default: 0)
  - Enhanced challenger logic with two-priority system:
    a. Challenge invalid games (honest behavior)
    b. Challenge valid games at configured percentage (testing purposes)
  - Added clear logging to distinguish honest vs malicious challenges
  - .env.challenger.example