### PR TITLE
Upgrade actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/sqlx-check.yml
+++ b/.github/workflows/sqlx-check.yml
@@ -15,7 +15,7 @@ jobs:
     name: Verify SQLx queries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Updated actions/checkout@v3 to actions/checkout@v4

https://github.com/actions/checkout/releases/tag/v4.2.2


This is the only file in the repository that was still using the old version (v3). Updating it ensures consistency and up-to-date security across all workflows.