### PR TITLE
fix: refactor fault-proof proposer to use task-based concurrency

### DIFF
--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -254,14 +254,9 @@ where
                 }
             }
 
-            match self.handle_game_resolution().await {
-                Ok(_) => {
-                    ChallengerGauge::GamesResolved.increment(1.0);
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to handle game resolution: {:?}", e);
-                    ChallengerGauge::GameResolutionError.increment(1.0);
-                }
+            if let Err(e) = self.handle_game_resolution().await {
+                tracing::warn!("Failed to handle game resolution: {:?}", e);
+                ChallengerGauge::GameResolutionError.increment(1.0);
             }
 
             match self.handle_bond_claiming().await {

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
     // Initialize the metrics gauges.
     ProposerGauge::init_all();
 
-    proposer.clone().run().await.expect("Runs in an infinite loop");
+    proposer.run().await.expect("Runs in an infinite loop");
 
     Ok(())
 }

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -51,10 +51,11 @@ async fn main() -> Result<()> {
 
     let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
     let host = initialize_host(Arc::new(fetcher.clone()));
-    let proposer =
+    let proposer = Arc::new(
         OPSuccinctProposer::new(prover_address, proposer_signer, factory, Arc::new(fetcher), host)
             .await
-            .unwrap();
+            .unwrap(),
+    );
 
     // Initialize proposer gauges.
     ProposerGauge::register_all();
@@ -65,7 +66,7 @@ async fn main() -> Result<()> {
     // Initialize the metrics gauges.
     ProposerGauge::init_all();
 
-    proposer.run().await.expect("Runs in an infinite loop");
+    proposer.clone().run().await.expect("Runs in an infinite loop");
 
     Ok(())
 }

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -21,7 +21,7 @@ use crate::{
         AnchorStateRegistry, DisputeGameFactory::DisputeGameFactoryInstance, GameStatus, L2Output,
         OPSuccinctFaultDisputeGame, ProposalStatus,
     },
-    prometheus::ProposerGauge,
+    prometheus::{ChallengerGauge, ProposerGauge},
 };
 use op_succinct_host_utils::metrics::MetricsGauge;
 
@@ -719,7 +719,11 @@ where
                     )
                     .await
                 {
-                    ProposerGauge::GamesResolved.increment(1.0);
+                    // Use mode-specific metrics to avoid cross-contamination
+                    match mode {
+                        Mode::Proposer => ProposerGauge::GamesResolved.increment(1.0),
+                        Mode::Challenger => ChallengerGauge::GamesResolved.increment(1.0),
+                    }
                 }
             }
         } else {

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -302,7 +302,7 @@ where
     ) -> Result<Option<(U256, U256)>> {
         // Get latest game index, return None if no games exist.
         let Some(mut game_index) = self.fetch_latest_game_index().await? else {
-            tracing::debug!("No games exist yet for finding latest valid proposal");
+            tracing::info!("No games exist yet for finding latest valid proposal");
             return Ok(None);
         };
 
@@ -352,7 +352,7 @@ where
             game_index -= U256::from(1);
         }
 
-        tracing::debug!(
+        tracing::info!(
             "Latest valid proposal at game index {:?} with l2 block number: {:?}",
             game_index,
             block_number
@@ -404,7 +404,7 @@ where
         // NOTE(fakedev9999): This is a redundant check with the is_game_finalized check below,
         // but is useful for better logging.
         if claim_data.status != ProposalStatus::Resolved {
-            tracing::debug!("Game {:?} is not resolved yet", game_address);
+            tracing::info!("Game {:?} is not resolved yet", game_address);
             return Ok(false);
         }
 
@@ -416,7 +416,7 @@ where
 
         // Claimant must have credit left to claim.
         if game.credit(claimant).call().await? == U256::ZERO {
-            tracing::debug!(
+            tracing::info!(
                 "Claimant {:?} has no credit to claim from game {:?}",
                 claimant,
                 game_address
@@ -452,7 +452,7 @@ where
             let claim_data = game.claimData().call().await?;
 
             if !status_check(claim_data.status) {
-                tracing::debug!(
+                tracing::info!(
                     "Game {:?} at index {:?} does not match status criteria, skipping",
                     game_address,
                     game_index
@@ -468,7 +468,7 @@ where
                 .timestamp;
             let deadline = U256::from(claim_data.deadline).to::<u64>();
             if deadline < current_timestamp {
-                tracing::debug!(
+                tracing::info!(
                     "Game {:?} at index {:?} deadline {:?} has passed, skipping",
                     game_address,
                     game_index,
@@ -548,7 +548,7 @@ where
         let latest_game_index = match self.fetch_latest_game_index().await? {
             Some(index) => index,
             None => {
-                tracing::debug!("No games exist yet for bond claiming");
+                tracing::info!("No games exist yet for bond claiming");
                 return Ok(None);
             }
         };
@@ -692,7 +692,7 @@ where
     ) -> Result<()> {
         // Find latest game index, return early if no games exist.
         let Some(latest_game_index) = self.fetch_latest_game_index().await? else {
-            tracing::debug!("No games exist, skipping resolution");
+            tracing::info!("No games exist, skipping resolution");
             return Ok(());
         };
 
@@ -723,7 +723,7 @@ where
                 }
             }
         } else {
-            tracing::debug!(
+            tracing::info!(
                 "Oldest game {:?} at index {:?} has unresolved parent, not attempting resolution",
                 game_address,
                 oldest_game_index

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -500,10 +500,6 @@ where
     }
 
     /// Get the oldest challengable game address.
-    #[tracing::instrument(
-        name = "[[Challenging]]",
-        skip(self, max_games_to_check_for_challenge, l2_provider)
-    )]
     async fn get_oldest_challengable_game_address(
         &self,
         max_games_to_check_for_challenge: u64,
@@ -673,7 +669,6 @@ where
     }
 
     /// Attempts to resolve games, up to `max_games_to_check_for_resolution`.
-    /// Skip all fields for logging.
     #[tracing::instrument(
         name = "[[Resolving]]",
         skip(

--- a/fault-proof/src/prometheus.rs
+++ b/fault-proof/src/prometheus.rs
@@ -43,10 +43,10 @@ pub enum ProposerGauge {
     )]
     GameCreationError,
     #[strum(
-        serialize = "op_succinct_fp_game_defense_error",
-        message = "Total number of game defense errors encountered by the proposer"
+        serialize = "op_succinct_fp_game_proving_error",
+        message = "Total number of game proving errors encountered by the proposer"
     )]
-    GameDefenseError,
+    GameProvingError,
     #[strum(
         serialize = "op_succinct_fp_game_resolution_error",
         message = "Total number of game resolution errors encountered by the proposer"

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -687,7 +687,7 @@ where
     }
 
     /// Spawn a game creation task if conditions are met
-    /// 
+    ///
     /// Returns:
     /// - Ok(true): Task was successfully spawned
     /// - Ok(false): No work needed (proposal interval not elapsed or no finalized blocks)
@@ -779,7 +779,7 @@ where
     }
 
     /// Spawn game defense tasks if needed
-    /// 
+    ///
     /// Returns:
     /// - Ok(true): Defense task was successfully spawned
     /// - Ok(false): No work needed (no defensible games or task already exists)
@@ -855,7 +855,7 @@ where
     }
 
     /// Spawn a game resolution task if needed
-    /// 
+    ///
     /// Returns:
     /// - Ok(true): Resolution task was successfully spawned
     /// - Ok(false): No work needed (no games to resolve)
@@ -885,7 +885,7 @@ where
     }
 
     /// Spawn a bond claim task if needed
-    /// 
+    ///
     /// Returns:
     /// - Ok(true): Bond claim task was successfully spawned
     /// - Ok(false): No work needed (no claimable bonds available)

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -489,7 +489,7 @@ where
                 )),
             }
         } else {
-            tracing::debug!("No new games to claim bonds from");
+            tracing::info!("No new games to claim bonds from");
 
             Ok(Action::Skipped)
         }
@@ -502,7 +502,7 @@ where
             match self.factory.get_latest_valid_proposal(self.l2_provider.clone()).await? {
                 Some((l2_block_number, _game_index)) => l2_block_number,
                 None => {
-                    tracing::debug!("No valid proposals found for metrics");
+                    tracing::info!("No valid proposals found for metrics");
                     self.factory.get_anchor_l2_block_number(self.config.game_type).await?
                 }
             };
@@ -585,7 +585,7 @@ where
             if let Some((handle, info)) = tasks.remove(&id) {
                 match handle.await_result().await {
                     Ok(Ok(())) => {
-                        tracing::debug!("Task {:?} completed successfully", info);
+                        tracing::info!("Task {:?} completed successfully", info);
                     }
                     Ok(Err(e)) => {
                         tracing::warn!("Task {:?} failed: {:?}", info, e);
@@ -627,43 +627,43 @@ where
         if !self.has_active_task_of_type(&TaskInfo::GameCreation { block_number: U256::ZERO }).await
         {
             match self.spawn_game_creation_task().await {
-                Ok(true) => tracing::debug!("Successfully spawned game creation task"),
+                Ok(true) => tracing::info!("Successfully spawned game creation task"),
                 Ok(false) => {
-                    tracing::trace!("No game creation needed - proposal interval not elapsed")
+                    tracing::debug!("No game creation needed - proposal interval not elapsed")
                 }
                 Err(e) => tracing::warn!("Failed to spawn game creation task: {:?}", e),
             }
         } else {
-            tracing::trace!("Game creation task already active");
+            tracing::info!("Game creation task already active");
         }
 
         // Check if we should defend games
         match self.spawn_game_defense_tasks().await {
-            Ok(true) => tracing::debug!("Successfully spawned game defense task"),
-            Ok(false) => tracing::trace!("No games need defense or task already active"),
+            Ok(true) => tracing::info!("Successfully spawned game defense task"),
+            Ok(false) => tracing::debug!("No games need defense or task already active"),
             Err(e) => tracing::warn!("Failed to spawn game defense tasks: {:?}", e),
         }
 
         // Check if we should resolve games
         if !self.has_active_task_of_type(&TaskInfo::GameResolution).await {
             match self.spawn_game_resolution_task().await {
-                Ok(true) => tracing::debug!("Successfully spawned game resolution task"),
-                Ok(false) => tracing::trace!("No games need resolution"),
+                Ok(true) => tracing::info!("Successfully spawned game resolution task"),
+                Ok(false) => tracing::debug!("No games need resolution"),
                 Err(e) => tracing::warn!("Failed to spawn game resolution task: {:?}", e),
             }
         } else {
-            tracing::trace!("Game resolution task already active");
+            tracing::info!("Game resolution task already active");
         }
 
         // Check if we should claim bonds
         if !self.has_active_task_of_type(&TaskInfo::BondClaim).await {
             match self.spawn_bond_claim_task().await {
-                Ok(true) => tracing::debug!("Successfully spawned bond claim task"),
-                Ok(false) => tracing::trace!("No bonds available to claim"),
+                Ok(true) => tracing::info!("Successfully spawned bond claim task"),
+                Ok(false) => tracing::debug!("No bonds available to claim"),
                 Err(e) => tracing::warn!("Failed to spawn bond claim task: {:?}", e),
             }
         } else {
-            tracing::trace!("Bond claim task already active");
+            tracing::info!("Bond claim task already active");
         }
 
         Ok(())
@@ -682,7 +682,7 @@ where
         let tasks = self.tasks.lock().await;
         let active_count = tasks.len();
         if active_count > 0 {
-            tracing::debug!("Active tasks: {}", active_count);
+            tracing::info!("Active tasks: {}", active_count);
         }
     }
 
@@ -719,7 +719,7 @@ where
         let task_info = TaskInfo::GameCreation { block_number: next_block };
 
         self.tasks.lock().await.insert(task_id, (handle, task_info));
-        tracing::debug!("Spawned game creation task {}", task_id);
+        tracing::info!("Spawned game creation task {}", task_id);
         Ok(true)
     }
 
@@ -850,7 +850,7 @@ where
 
         let task_info = TaskInfo::GameProving { game_address };
         self.tasks.lock().await.insert(task_id, (handle, task_info));
-        tracing::debug!("Spawned game proving task {} for game {:?}", task_id, game_address);
+        tracing::info!("Spawned game proving task {} for game {:?}", task_id, game_address);
         Ok(())
     }
 
@@ -880,7 +880,7 @@ where
 
         let task_info = TaskInfo::GameResolution;
         self.tasks.lock().await.insert(task_id, (handle, task_info));
-        tracing::debug!("Spawned game resolution task {}", task_id);
+        tracing::info!("Spawned game resolution task {}", task_id);
         Ok(true)
     }
 
@@ -922,7 +922,7 @@ where
 
         let task_info = TaskInfo::BondClaim;
         self.tasks.lock().await.insert(task_id, (handle, task_info));
-        tracing::debug!("Spawned bond claim task {}", task_id);
+        tracing::info!("Spawned bond claim task {}", task_id);
         Ok(true)
     }
 }

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -409,43 +409,6 @@ where
         }
     }
 
-    /// Handles the resolution of all eligible unchallenged games.
-    pub async fn handle_game_resolution(&self) -> Result<()> {
-        self.factory
-            .resolve_games(
-                Mode::Proposer,
-                self.config.max_games_to_check_for_resolution,
-                self.signer.clone(),
-                self.config.l1_rpc.clone(),
-                self.l1_provider.clone(),
-                self.l2_provider.clone(),
-            )
-            .await
-    }
-
-    /// Handles the defense of all eligible games by providing proofs.
-    pub async fn handle_game_defense(&self) -> Result<()> {
-        if let Some(game_address) = self
-            .factory
-            .get_oldest_defensible_game_address(
-                self.config.max_games_to_check_for_defense,
-                self.l2_provider.clone(),
-            )
-            .await?
-        {
-            tracing::info!("Attempting to defend game {:?}", game_address);
-
-            let tx_hash = self.prove_game(game_address).await?;
-            tracing::info!(
-                "\x1b[1mSuccessfully defended game {:?} with tx {:?}\x1b[0m",
-                game_address,
-                tx_hash
-            );
-        }
-
-        Ok(())
-    }
-
     /// Handles claiming bonds from resolved games.
     #[tracing::instrument(name = "[[Claiming Bonds]]", skip(self))]
     async fn handle_bond_claiming(&self) -> Result<Action> {

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -313,7 +313,7 @@ pub async fn get_highest_finalized_l2_block(
     }
 
     if let Some(highest_block) = result {
-        tracing::info!(
+        tracing::debug!(
             "Found highest provable L2 block: {} (out of range {}-{})",
             highest_block,
             latest_proposed_block_number,

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -51,7 +51,7 @@ fn verify_data_commitment_event(
     // Decode the DataCommitmentStored event
     let decoded_event = SP1Blobstream::DataCommitmentStored::decode_log(&primitive_log)?;
 
-    tracing::info!(
+    tracing::debug!(
         "Decoded DataCommitmentStored event: proof_nonce={}, start_block={}, end_block={}",
         decoded_event.proofNonce,
         decoded_event.startBlock,
@@ -63,7 +63,7 @@ fn verify_data_commitment_event(
         target_celestia_height <= decoded_event.endBlock;
 
     if is_within_range {
-        tracing::info!(
+        tracing::debug!(
             "Found matching DataCommitmentStored event covering Celestia height {} (range: {}-{})",
             target_celestia_height,
             decoded_event.startBlock,
@@ -99,7 +99,7 @@ async fn find_minimum_blobstream_block(
     let mut current_start = start_block;
     let latest_block = fetcher.l1_provider.get_block_number().await?;
 
-    tracing::info!(
+    tracing::debug!(
         "Scanning for Blobstream proof for Celestia height {} starting from L1 block {}",
         celestia_height,
         start_block
@@ -128,7 +128,7 @@ async fn find_minimum_blobstream_block(
                 // Decode and verify the event contains our target Celestia height
                 match verify_data_commitment_event(&log, celestia_height) {
                     Ok(true) => {
-                        tracing::info!(
+                        tracing::debug!(
                             "Found verified Blobstream event at L1 block {} containing Celestia height {}",
                             block_number,
                             celestia_height
@@ -136,7 +136,7 @@ async fn find_minimum_blobstream_block(
                         return Ok(block_number);
                     }
                     Ok(false) => {
-                        tracing::info!(
+                        tracing::debug!(
                             "DataCommitmentStored event at L1 block {} does not contain Celestia height {}, continuing search",
                             block_number,
                             celestia_height
@@ -144,7 +144,7 @@ async fn find_minimum_blobstream_block(
                         // Continue searching for the correct event
                     }
                     Err(e) => {
-                        tracing::warn!(
+                        tracing::debug!(
                             "Failed to decode DataCommitmentStored event at L1 block {}: {}, skipping",
                             block_number,
                             e
@@ -226,7 +226,7 @@ pub async fn get_celestia_safe_head_info(
     // Query the Celestia indexer for this L2 block's location.
     match query_celestia_indexer(l2_reference_block).await {
         Ok(Some(location)) => {
-            tracing::info!(
+            tracing::debug!(
                 "Celestia indexer returned location for L2 block {}: height {}, L1 block {}",
                 l2_reference_block,
                 location.height,
@@ -236,7 +236,7 @@ pub async fn get_celestia_safe_head_info(
             // Find the minimum L1 block that contains the Blobstream proof
             match find_minimum_blobstream_block(location.height, location.l1_block, fetcher).await {
                 Ok(safe_l1_block) => {
-                    tracing::info!(
+                    tracing::debug!(
                         "Using L1 block {} (Blobstream proof found) for L2 block {}",
                         safe_l1_block,
                         l2_reference_block
@@ -275,7 +275,7 @@ pub async fn get_highest_finalized_l2_block(
     let l2_finalized_header = fetcher.get_l2_header(BlockId::finalized()).await?;
     let l2_finalized_block = l2_finalized_header.number;
 
-    tracing::info!(
+    tracing::debug!(
         "Searching for highest provable L2 block between {} (latest proposed) and {} (finalized)",
         latest_proposed_block_number,
         l2_finalized_block,
@@ -306,7 +306,7 @@ pub async fn get_highest_finalized_l2_block(
             }
             Err(e) => {
                 // Error occurred (e.g., indexer error), treat as unavailable and search lower
-                tracing::warn!("Error checking L2 block {}: {}, treating as unavailable", mid, e);
+                tracing::debug!("Error checking L2 block {}: {}, treating as unavailable", mid, e);
                 high = mid - 1;
             }
         }


### PR DESCRIPTION
- Convert sequential operations to concurrent tasks using task tracking
- Fix dashboard showing 0 values during proof generation
- Implement task spawning for game creation, defense, resolution, and bond claiming
- Add centralized task management with completion handling
- Ensure metrics collection runs independently of other operations

This prevents long-running operations (like witness generation for proof generation) from blocking metrics updates and other proposer activities.