### PR TITLE
chore(ci): update mdBook GitHub Action to v2

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: peaceiris/actions-mdbook@v1
+      - uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: 'latest'
       - name: Install plugins


### PR DESCRIPTION
 Updated `peaceiris/actions-mdbook` from `v1` to `v2` for compatibility with the latest action version.
  This ensures better maintenance and compatibility with recent GitHub Actions features.

  Action reference: https://github.com/peaceiris/actions-mdbook