### PR TITLE
chore: fix audit links

### DIFF
--- a/book/faq.md
+++ b/book/faq.md
@@ -2,7 +2,7 @@
 
 ## Has OP Succinct been audited?
 
-Cantina has audited both [OP Succinct](https://github.com/succinctlabs/op-succinct/blob/edward/docs/audits/OP%20Succinct%20Spearbit.pdf) and [OP Succinct Lite](https://github.com/succinctlabs/op-succinct/blob/edward/docs/audits/OP%20Succinct%20Lite%20Spearbit.pdf). 
+Cantina has audited both [OP Succinct](https://github.com/succinctlabs/op-succinct/blob/main/audits/OP%20Succinct%20Spearbit.pdf) and [OP Succinct Lite](https://github.com/succinctlabs/op-succinct/blob/main/audits/OP%20Succinct%20Lite%20Spearbit.pdf). 
 
 ## How is data availability proven?
 


### PR DESCRIPTION
I saw I can't access audit links at https://succinctlabs.github.io/op-succinct/faq.html so I thought I'd fix it