### PR TITLE
feat: update to support celestia indexer changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,8 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.7.0"
-source = "git+https://github.com/eigerco/lumina?rev=4751731#4751731c50345f7e78841497714b1e278471a0e5"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a027c55dacaabcc6daddf23375c0d80a401880cd1e3a57c36982f66c540e51d4"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -2289,24 +2290,27 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.10.0"
-source = "git+https://github.com/eigerco/lumina?rev=4751731#4751731c50345f7e78841497714b1e278471a0e5"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43555437ffde5f46770dcfaa8499bbe2d46866b2c1ff50e7b5d4619c4a5f2e93"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "celestia-types",
  "http 1.3.1",
- "jsonrpsee 0.24.9",
+ "jsonrpsee",
  "prost 0.13.5",
  "serde",
+ "serde_repr",
  "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "celestia-types"
-version = "0.11.0"
-source = "git+https://github.com/eigerco/lumina?rev=4751731#4751731c50345f7e78841497714b1e278471a0e5"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6230f51ca735829affa9762f20acbb4e94a38b423d97c0bcacdd6b54ddfbbb78"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -4086,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "hana-blobstream"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc#ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc"
+source = "git+https://github.com/celestiaorg/hana?rev=3d4b9c1524dbba2f2817af3577b3fb7a1f006e81#3d4b9c1524dbba2f2817af3577b3fb7a1f006e81"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.9",
@@ -4104,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "hana-celestia"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc#ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc"
+source = "git+https://github.com/celestiaorg/hana?rev=3d4b9c1524dbba2f2817af3577b3fb7a1f006e81#3d4b9c1524dbba2f2817af3577b3fb7a1f006e81"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4117,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "hana-client"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc#ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc"
+source = "git+https://github.com/celestiaorg/hana?rev=3d4b9c1524dbba2f2817af3577b3fb7a1f006e81#3d4b9c1524dbba2f2817af3577b3fb7a1f006e81"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-evm",
@@ -4142,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "hana-host"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc#ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc"
+source = "git+https://github.com/celestiaorg/hana?rev=3d4b9c1524dbba2f2817af3577b3fb7a1f006e81#3d4b9c1524dbba2f2817af3577b3fb7a1f006e81"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4173,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "hana-oracle"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc#ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc"
+source = "git+https://github.com/celestiaorg/hana?rev=3d4b9c1524dbba2f2817af3577b3fb7a1f006e81#3d4b9c1524dbba2f2817af3577b3fb7a1f006e81"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4190,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "hana-proofs"
 version = "0.1.0"
-source = "git+https://github.com/celestiaorg/hana?rev=ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc#ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc"
+source = "git+https://github.com/celestiaorg/hana?rev=3d4b9c1524dbba2f2817af3577b3fb7a1f006e81#3d4b9c1524dbba2f2817af3577b3fb7a1f006e81"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4983,57 +4987,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
-dependencies = [
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-http-client 0.24.9",
- "jsonrpsee-proc-macros 0.24.9",
- "jsonrpsee-types 0.24.9",
- "jsonrpsee-ws-client 0.24.9",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fba77a59c4c644fd48732367624d1bcf6f409f9c9a286fbc71d2f1fc0b2ea16"
 dependencies = [
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-http-client 0.25.1",
- "jsonrpsee-proc-macros 0.25.1",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client 0.25.1",
+ "jsonrpsee-ws-client",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
-dependencies = [
- "base64 0.22.1",
- "futures-util",
- "http 1.3.1",
- "jsonrpsee-core 0.24.9",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -5047,7 +5014,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http 1.3.1",
- "jsonrpsee-core 0.25.1",
+ "jsonrpsee-core",
  "pin-project",
  "rustls",
  "rustls-pki-types",
@@ -5063,30 +5030,6 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-timer",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "jsonrpsee-types 0.24.9",
- "pin-project",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-core"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693c93cbb7db25f4108ed121304b671a36002c2db67dff2ee4391a688c738547"
@@ -5098,7 +5041,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-types",
  "parking_lot",
  "pin-project",
  "rand 0.9.1",
@@ -5115,31 +5058,6 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
@@ -5149,8 +5067,8 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustls",
  "rustls-platform-verifier",
  "serde",
@@ -5159,19 +5077,6 @@ dependencies = [
  "tokio",
  "tower 0.5.2",
  "url",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
-dependencies = [
- "heck 0.5.0",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -5199,8 +5104,8 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -5212,18 +5117,6 @@ dependencies = [
  "tokio-util",
  "tower 0.5.2",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
-dependencies = [
- "http 1.3.1",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5244,23 +5137,10 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67695cbcf4653f39f8f8738925547e0e23fd9fe315bccf951097b9f6a38781"
 dependencies = [
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "tower 0.5.2",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
-dependencies = [
- "http 1.3.1",
- "jsonrpsee-client-transport 0.24.9",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
- "url",
 ]
 
 [[package]]
@@ -5270,9 +5150,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
 dependencies = [
  "http 1.3.1",
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "tower 0.5.2",
  "url",
 ]
@@ -5813,7 +5693,7 @@ dependencies = [
  "async-trait",
  "derive_more 2.0.1",
  "getrandom 0.3.3",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-engine",
  "kona-genesis",
  "kona-interop",
@@ -5893,7 +5773,7 @@ source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.2#62a4ff9c0e6
 dependencies = [
  "alloy-eips 1.0.9",
  "alloy-primitives",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-interop",
  "kona-protocol",
  "kona-supervisor-types",
@@ -7304,7 +7184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cb0771602eb2b25e38817d64cd0f841ff07ef9df1e9ce96a53c1742776e874"
 dependencies = [
  "alloy-primitives",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,10 @@ kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.
 
 # hana
 # TODO(fakedev9999): Bump to 1.0.0 once the release is out.
-hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc" }
-hana-celestia = { git = "https://github.com/celestiaorg/hana", rev = "ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc" }
-hana-host = { git = "https://github.com/celestiaorg/hana", rev = "ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc" }
-hana-oracle = { git = "https://github.com/celestiaorg/hana", rev = "ebb7cf711c3f2eba951f3fb3211c1cb1f87475dc" }
+hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "3d4b9c1524dbba2f2817af3577b3fb7a1f006e81" }
+hana-celestia = { git = "https://github.com/celestiaorg/hana", rev = "3d4b9c1524dbba2f2817af3577b3fb7a1f006e81" }
+hana-host = { git = "https://github.com/celestiaorg/hana", rev = "3d4b9c1524dbba2f2817af3577b3fb7a1f006e81" }
+hana-oracle = { git = "https://github.com/celestiaorg/hana", rev = "3d4b9c1524dbba2f2817af3577b3fb7a1f006e81" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -26,10 +26,10 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    setup_logger();
-
     let args = Args::parse();
     dotenv::from_filename(args.env_file).ok();
+
+    setup_logger();
 
     let challenger_signer = Signer::from_env()?;
 

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -29,10 +29,10 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    setup_logger();
-
     let args = Args::parse();
     dotenv::from_filename(args.env_file).ok();
+
+    setup_logger();
 
     let proposer_signer = Signer::from_env()?;
 


### PR DESCRIPTION
There was an issue in the proposer for celestia da where batcher falls back to eth da for batch submission, the proposer cannot calculate safe l1 head for celestia. This was due to op-celestia indexer missing feature to handle eth da batches, only handling celestia da batches. Fix was made for op-celestia indexer in this [PR]( https://github.com/celestiaorg/optimism/pull/502), which introduces an API change.

This PR updates op-succinct's implementation according to the recent API change to calculate safe l1 head properly even the batcher posts batches to eth da on fallback.