### PR TITLE
test: add fault game coverage

### DIFF
--- a/contracts/test/fp/AccessManager.t.sol
+++ b/contracts/test/fp/AccessManager.t.sol
@@ -94,6 +94,7 @@ contract AccessManagerTest is Test {
         vm.prank(owner);
         accessManager.setProposer(address(0), true);
 
+        assertTrue(accessManager.isProposalPermissionlessMode());
         assertTrue(accessManager.isAllowedProposer(proposer1));
         assertTrue(accessManager.isAllowedProposer(randomUser));
         assertTrue(accessManager.isAllowedProposer(address(0x9999)));


### PR DESCRIPTION
Added small bit of Foundry test coverage to `OPSuccinctFaultDisputeGame` and `AccessManager` contracts