### PR TITLE
feat: improve fault proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7533,6 +7533,7 @@ dependencies = [
  "sp1-sdk",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.19",

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -101,7 +101,7 @@ PROPOSER_METRICS_PORT=9000               # The port to expose metrics on
 
 ## Running
 
-To run the proposer:
+To run the proposer, from the fault-proof directory:
    ```bash
    cargo run --bin proposer
    ```
@@ -130,6 +130,7 @@ The proposer will run indefinitely, creating new games and optionally resolving 
 - Supports mock mode for testing without using the Succinct Prover Network. (Set `MOCK_MODE=true` in `.env.proposer`)
 ### Game Resolution
 When enabled (`ENABLE_GAME_RESOLUTION=true`), the proposer:
+- **Fast Finality**: Immediately resolves proven games (UnchallengedAndValidProofProvided or ChallengedAndValidProofProvided)
 - Monitors unchallenged games
 - Resolves games after their challenge period expires
 - Respects parent-child game relationships in resolution

--- a/fault-proof/Cargo.toml
+++ b/fault-proof/Cargo.toml
@@ -62,6 +62,7 @@ tracing.workspace = true
 hex.workspace = true
 strum = { workspace = true, features = ["derive"] }
 strum_macros.workspace = true
+tikv-jemallocator = "0.6.0"
 
 [dev-dependencies]
 alloy-signer-local.workspace = true

--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -13,6 +13,10 @@ use op_succinct_host_utils::{
     setup_logger,
 };
 use op_succinct_signer_utils::Signer;
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static ALLOCATOR: Jemalloc = Jemalloc;
 
 #[derive(Parser)]
 struct Args {

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -16,6 +16,10 @@ use op_succinct_host_utils::{
 };
 use op_succinct_proof_utils::initialize_host;
 use op_succinct_signer_utils::Signer;
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static ALLOCATOR: Jemalloc = Jemalloc;
 
 #[derive(Parser)]
 struct Args {

--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -177,7 +177,7 @@ where
     }
 
     /// Handles claiming bonds from resolved games.
-    #[tracing::instrument(skip(self), level = "info", name = "[[Claiming Bonds]]")]
+    #[tracing::instrument(skip(self), level = "info", name = "[[Claiming Challenger Bonds]]")]
     pub async fn handle_bond_claiming(&self) -> Result<Action> {
         if let Some(game_address) = self
             .factory
@@ -185,10 +185,14 @@ where
                 self.config.game_type,
                 self.config.max_games_to_check_for_bond_claiming,
                 self.challenger_address,
+                Mode::Challenger,
             )
             .await?
         {
-            tracing::info!("Attempting to claim bond from game {:?}", game_address);
+            tracing::info!(
+                "Attempting to claim bond from game {:?} where challenger won",
+                game_address
+            );
 
             // Create a contract instance for the game
             let game = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
@@ -204,7 +208,7 @@ where
             {
                 Ok(receipt) => {
                     tracing::info!(
-                        "\x1b[1mSuccessfully claimed bond from game {:?} with tx {:?}\x1b[0m",
+                        "\x1b[1mSuccessfully claimed challenger bond from game {:?} with tx {:?}\x1b[0m",
                         game_address,
                         receipt.transaction_hash
                     );
@@ -212,13 +216,13 @@ where
                     Ok(Action::Performed)
                 }
                 Err(e) => Err(anyhow::anyhow!(
-                    "Failed to claim bond from game {:?}: {:?}",
+                    "Failed to claim challenger bond from game {:?}: {:?}",
                     game_address,
                     e
                 )),
             }
         } else {
-            tracing::info!("No new games to claim bonds from");
+            tracing::info!("No games found where challenger won to claim bonds from");
 
             Ok(Action::Skipped)
         }


### PR DESCRIPTION
1. Improve game resolution: refac + fix proposer to resolve proven games as well.

2. Separate bond claiming based on role for clearer metrics collection.
  - Update `is_claimable` to check game outcomes based on role
    - Proposer: only claims from DEFENDER_WINS games
    - Challenger: only claims from CHALLENGER_WINS games