### PR TITLE
chore: unify binary name for celestia docker image

### DIFF
--- a/validity/Dockerfile.celestia
+++ b/validity/Dockerfile.celestia
@@ -26,7 +26,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/build/target \
     cargo build --bin validity --release --features celestia && \
-    cp target/release/validity /build/celestia-validity-proposer
+    cp target/release/validity /build/validity-proposer
 
 # Final stage
 FROM rust:1.85-slim
@@ -50,10 +50,10 @@ RUN curl -L https://sp1.succinct.xyz | bash && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only the built binaries from builder
-COPY --from=builder /build/celestia-validity-proposer /usr/local/bin/celestia-validity-proposer
+COPY --from=builder /build/validity-proposer /usr/local/bin/validity-proposer
 
 # Set jemalloc flags to aggressively release memory to avoid memory fragmentation.
 ENV JEMALLOC_SYS_WITH_MALLOC_CONF="background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,abort_conf:true"
 
 # Run the server from its permanent location
-CMD ["/usr/local/bin/celestia-validity-proposer"]
+CMD ["/usr/local/bin/validity-proposer"]


### PR DESCRIPTION
Align the Celestia Docker image binary name with the standard validity proposer to ensure consistent deployment across all variants. This reduces complexity of infra code switching between op-succinct and op-succinct-celestia images.

Docker image tag already differentiates the celestia variant, so having different binary name seems to just increase complexity.