### PR TITLE
chore: pin nightly rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = ["llvm-tools", "rustc-dev"]
+channel = "nightly-2025-08-02"
+components = ["llvm-tools", "rustc-dev", "rustfmt", "clippy"]

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -932,6 +932,7 @@ where
                 self.requester_config.op_succinct_config_name_hash,
                 completed_agg_proof.proof.as_ref().unwrap().clone().into(),
             ));
+            // dummy
 
             let transaction_request = self
                 .contract_config

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -932,7 +932,6 @@ where
                 self.requester_config.op_succinct_config_name_hash,
                 completed_agg_proof.proof.as_ref().unwrap().clone().into(),
             ));
-            // dummy
 
             let transaction_request = self
                 .contract_config


### PR DESCRIPTION
rust nightly v1.91 breaks kona.

cycle count ci fails for this reason, but the elfs aren't changing.