### PR TITLE
fix: use end exclusive range

### DIFF
--- a/scripts/utils/bin/fetch_fault_dispute_game_config.rs
+++ b/scripts/utils/bin/fetch_fault_dispute_game_config.rs
@@ -128,11 +128,7 @@ async fn update_fdg_config() -> Result<()> {
 
     // Get starting block number - use `latest finalized - dispute game finality delay` if not set.
     let starting_l2_block_number = match env::var("STARTING_L2_BLOCK_NUMBER") {
-        Ok(n) => {
-            let block_num = n.parse().unwrap();
-
-            block_num
-        }
+        Ok(n) => n.parse().unwrap(),
         Err(_) => {
             // Use finalized block minus the finality delay as a starting point
             let finalized_l2_header = data_fetcher.get_l2_header(BlockId::finalized()).await?;

--- a/scripts/utils/bin/fetch_fault_dispute_game_config.rs
+++ b/scripts/utils/bin/fetch_fault_dispute_game_config.rs
@@ -1,16 +1,18 @@
-use alloy_eips::BlockId;
+use std::{env, sync::Arc};
+
 use anyhow::Result;
 use fault_proof::config::FaultDisputeGameConfig;
 use op_succinct_host_utils::{
     fetcher::{OPSuccinctDataFetcher, RPCMode},
+    host::OPSuccinctHost,
     OP_SUCCINCT_FAULT_DISPUTE_GAME_CONFIG_PATH,
 };
+use op_succinct_proof_utils::initialize_host;
 use op_succinct_scripts::config_common::{
     find_project_root, get_shared_config_data, parse_addresses, write_config_file,
     TWO_WEEKS_IN_SECONDS,
 };
 use serde_json::Value;
-use std::env;
 
 /// Updates and generates the fault dispute game configuration file.
 ///
@@ -70,6 +72,7 @@ use std::env;
 /// needed for the Solidity deployment scripts.
 async fn update_fdg_config() -> Result<()> {
     let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+    let host = initialize_host(Arc::new(data_fetcher.clone()));
     let shared_config = get_shared_config_data().await?;
 
     // Game configuration.
@@ -126,8 +129,13 @@ async fn update_fdg_config() -> Result<()> {
     let starting_l2_block_number = match env::var("STARTING_L2_BLOCK_NUMBER") {
         Ok(n) => n.parse().unwrap(),
         Err(_) => {
-            let latest_finalized_header =
-                data_fetcher.get_l2_header(BlockId::finalized()).await.unwrap();
+            let finalized_l2_block_number = host
+                .get_finalized_l2_block_number(
+                    &data_fetcher,
+                    0, // latest_proposed_block_number
+                )
+                .await?
+                .unwrap();
 
             let block_time = &data_fetcher
                 .rollup_config
@@ -137,7 +145,7 @@ async fn update_fdg_config() -> Result<()> {
 
             let num_blocks_to_subtract = dispute_game_finality_delay_seconds / block_time;
 
-            latest_finalized_header.number.saturating_sub(num_blocks_to_subtract)
+            finalized_l2_block_number.saturating_sub(num_blocks_to_subtract)
         }
     };
 

--- a/scripts/utils/bin/fetch_l2oo_config.rs
+++ b/scripts/utils/bin/fetch_l2oo_config.rs
@@ -2,14 +2,16 @@ use alloy_eips::BlockId;
 use anyhow::Result;
 use op_succinct_host_utils::{
     fetcher::{OPSuccinctDataFetcher, RPCMode},
+    host::OPSuccinctHost,
     OP_SUCCINCT_L2_OUTPUT_ORACLE_CONFIG_PATH,
 };
+use op_succinct_proof_utils::initialize_host;
 use op_succinct_scripts::config_common::{
     find_project_root, get_address, get_shared_config_data, write_config_file, TWO_WEEKS_IN_SECONDS,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::env;
+use std::{env, sync::Arc};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,6 +51,7 @@ struct L2OOConfig {
 /// - owner: Set to the address associated with the private key.
 async fn update_l2oo_config() -> Result<()> {
     let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+    let host = initialize_host(Arc::new(data_fetcher.clone()));
     let shared_config = get_shared_config_data().await?;
 
     let rollup_config = data_fetcher.rollup_config.as_ref().unwrap();
@@ -80,7 +83,23 @@ async fn update_l2oo_config() -> Result<()> {
     // Get starting block number - use latest finalized if not set.
     let starting_block_number = match env::var("STARTING_BLOCK_NUMBER") {
         Ok(n) => n.parse().unwrap(),
-        Err(_) => data_fetcher.get_l2_header(BlockId::finalized()).await.unwrap().number,
+        Err(_) => {
+            // Use finalized block minus the finalization period as a starting point
+            let finalized_l2_header = data_fetcher.get_l2_header(BlockId::finalized()).await?;
+            let finalized_l2_block = finalized_l2_header.number;
+
+            let num_blocks_for_finality = finalization_period / l2_block_time;
+            let search_start = finalized_l2_block.saturating_sub(num_blocks_for_finality);
+
+            // Now search for the highest finalized block with available data
+            let finalized_l2_block_number =
+                match host.get_finalized_l2_block_number(&data_fetcher, search_start).await? {
+                    Some(block_num) => block_num,
+                    None => search_start,
+                };
+
+            finalized_l2_block_number.saturating_sub(num_blocks_for_finality)
+        }
     };
 
     let starting_block_number_hex = format!("0x{starting_block_number:x}");

--- a/utils/celestia/host/src/blobstream_utils.rs
+++ b/utils/celestia/host/src/blobstream_utils.rs
@@ -76,11 +76,11 @@ fn verify_data_commitment_event(
 
     // Check if the target Celestia height is within the range of this event
     let is_within_range = target_celestia_height >= decoded_event.startBlock &&
-        target_celestia_height <= decoded_event.endBlock;
+        target_celestia_height < decoded_event.endBlock;
 
     if is_within_range {
         tracing::info!(
-            "Found matching DataCommitmentStored event covering Celestia height {} (range: {}-{})",
+            "Found matching DataCommitmentStored event covering Celestia height {} (range: [{}, {}))",
             target_celestia_height,
             decoded_event.startBlock,
             decoded_event.endBlock


### PR DESCRIPTION
Fixes to treat Blobstream endBlock as exclusive in commitment check.

Blobstream DataCommitmentStored ranges are [start, end), but the original code treated `endBlock` as inclusive.
When target_celestia_height == endBlock, we incorrectly matched the *previous* commitment and returned its L1 block,
potentially causing witness generation to later fail with "No matching event found for the given Celestia height" error.

Changed the upper-bound check to `< endBlock` and update logs to print the range as `[start, end)` for clarity.

This should fix to select the correct (later) commitment and L1 head when height hits a boundary.