### PR TITLE
feat: branch on challenger won chains

### DIFF
--- a/fault-proof/tests/e2e.rs
+++ b/fault-proof/tests/e2e.rs
@@ -261,3 +261,184 @@ async fn test_honest_challenger_native() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_proposer_branch_creation_after_challenger_wins() -> Result<()> {
+    TestEnvironment::init_logging();
+    info!("=== Test: Proposer Branch Creation After Challenger Wins ===");
+
+    const NUM_INVALID_GAMES: usize = 2;
+    const NUM_VALID_GAMES_AFTER: usize = 2;
+
+    // Setup common test environment
+    let env = TestEnvironment::setup().await?;
+    let mut l2_block_number = env.anvil.starting_l2_block_number;
+
+    // Create a signer for creating games
+    let wallet = PrivateKeySigner::from_str(PROPOSER_PRIVATE_KEY)?;
+    let provider_with_signer = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(wallet))
+        .connect_http(env.anvil.endpoint.parse::<Url>()?);
+
+    let factory = DisputeGameFactory::new(env.deployed.factory, provider_with_signer.clone());
+    let init_bond = factory.initBonds(TEST_GAME_TYPE).call().await?;
+
+    // === PHASE 1: Create Valid Base Games ===
+    info!("=== Phase 1: Create Valid Base Games ===");
+    
+    // Start proposer to create some valid games first
+    let proposer_handle = start_proposer(
+        &env.rpc_config,
+        PROPOSER_PRIVATE_KEY,
+        &env.deployed.factory,
+        TEST_GAME_TYPE,
+    )
+    .await?;
+    info!("✓ Proposer service started");
+
+    // Wait for proposer to create 2 valid games
+    let tracked_games =
+        wait_and_track_games(&factory, TEST_GAME_TYPE, 2, Duration::from_secs(60)).await?;
+
+    info!("✓ Proposer created {} valid base games:", tracked_games.len());
+    for (i, game) in tracked_games.iter().enumerate() {
+        info!("  Game {}: {} at L2 block {}", i + 1, game.address, game.l2_block_number);
+    }
+
+    // Stop proposer temporarily
+    proposer_handle.abort();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    info!("✓ Stopped proposer temporarily");
+
+    // === PHASE 2: Create Invalid Games on Top ===
+    info!("=== Phase 2: Create Invalid Games on Top ===");
+    
+    let mut invalid_games = Vec::new();
+    let mut rng = rand::rng();
+    let last_game_index = factory.gameCount().call().await? - U256::from(1);
+
+    for i in 0..NUM_INVALID_GAMES {
+        l2_block_number += 10;
+        // Create game with random invalid output root
+        let mut invalid_root_bytes = [0u8; 32];
+        rng.fill(&mut invalid_root_bytes);
+        let invalid_root = FixedBytes::<32>::from(invalid_root_bytes);
+
+        // Chain these games - first one references the last valid game, subsequent ones reference previous invalid game
+        let parent_index = if i == 0 {
+            last_game_index.to::<u32>()
+        } else {
+            (last_game_index + U256::from(i)).to::<u32>()
+        };
+        
+        let extra_data = (U256::from(l2_block_number), parent_index).abi_encode_packed();
+
+        let tx = factory
+            .create(TEST_GAME_TYPE, invalid_root, extra_data.into())
+            .value(init_bond)
+            .send()
+            .await?;
+
+        let _receipt = tx.get_receipt().await?;
+        let new_game_count = factory.gameCount().call().await?;
+        let game_index = new_game_count - U256::from(1);
+        let game_info = factory.gameAtIndex(game_index).call().await?;
+        let game_address = game_info.proxy_;
+
+        invalid_games.push(game_address);
+    }
+
+    info!("✓ Created {} invalid games chained on top:", invalid_games.len());
+    for (i, game) in invalid_games.iter().enumerate() {
+        info!("  Invalid Game {}: {}", i + 1, game);
+    }
+
+    // === PHASE 3: Challenge and Resolve Invalid Games ===
+    info!("=== Phase 3: Challenge and Resolve Invalid Games ===");
+    
+    // Start challenger service
+    let challenger_handle = start_challenger(
+        &env.rpc_config,
+        CHALLENGER_PRIVATE_KEY,
+        &env.deployed.factory,
+        TEST_GAME_TYPE,
+        None,
+    )
+    .await?;
+    info!("✓ Challenger service started");
+
+    // Wait for challenges
+    wait_for_challenges(&env.anvil.provider, &invalid_games, Duration::from_secs(60)).await?;
+    info!("✓ All invalid games challenged successfully");
+
+    // Warp time to resolve in challenger's favor
+    warp_time(
+        &env.anvil.provider,
+        Duration::from_secs(MAX_CHALLENGE_DURATION + MAX_PROVE_DURATION),
+    )
+    .await?;
+    info!("✓ Warped time to trigger challenger wins");
+
+    // Wait for and verify challenger wins
+    wait_and_verify_game_resolutions(
+        &env.anvil.provider,
+        &invalid_games,
+        GameStatus::CHALLENGER_WINS,
+        "ChallengerWins",
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    // Stop challenger
+    challenger_handle.abort();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    info!("✓ Challenger stopped after resolving invalid games");
+
+    // === PHASE 4: Restart Proposer - Should Create New Branch ===
+    info!("=== Phase 4: Restart Proposer - Should Create New Branch ===");
+    
+    let games_before_restart = factory.gameCount().call().await?;
+    info!("Games count before proposer restart: {}", games_before_restart);
+
+    // Start proposer again - it should detect challenger-won games and create a new branch
+    let proposer_handle_2 = start_proposer(
+        &env.rpc_config,
+        PROPOSER_PRIVATE_KEY,
+        &env.deployed.factory,
+        TEST_GAME_TYPE,
+    )
+    .await?;
+    info!("✓ Proposer service restarted");
+
+    // Wait for proposer to create new games (should branch from safe point)
+    let new_tracked_games = wait_and_track_games(
+        &factory, 
+        TEST_GAME_TYPE, 
+        games_before_restart.to::<usize>() + NUM_VALID_GAMES_AFTER, 
+        Duration::from_secs(90)
+    ).await?;
+
+    let newly_created_games: Vec<_> = new_tracked_games
+        .into_iter()
+        .skip(games_before_restart.to::<usize>())
+        .collect();
+
+    info!("✓ Proposer created {} new games after challenger wins:", newly_created_games.len());
+    for (i, game) in newly_created_games.iter().enumerate() {
+        info!("  New Game {}: {} at L2 block {}", i + 1, game.address, game.l2_block_number);
+    }
+
+    // Verify the new games are valid by checking they don't get challenged
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    info!("✓ New games remained unchallengeable for 10 seconds - likely valid");
+
+    // Stop proposer
+    proposer_handle_2.abort();
+    info!("✓ Proposer stopped gracefully");
+
+    info!("=== Branch Creation Test Complete ===");
+    info!("✓ Proposer successfully created new branch after challenger won invalid games");
+    info!("✓ This validates the fix prevents building on challenger-won chains");
+
+    Ok(())
+}


### PR DESCRIPTION
This PR implements logic to prevent proposers from building on challenger-won chains and enables them to create new branches from safe points when blocked.

Before: Proposer would continue building on the most recent game, even if it or its ancestors were resolved as `CHALLENGER_WINS`

After:
  1. Proposer checks if latest game was resolved as `CHALLENGER_WINS` → skip it
  2. Proposer checks if any ancestors of a valid game were resolved as `CHALLENGER_WINS` → skip the entire chain
  3. Proposer finds safe branch point from most recent `DEFENDER_WINS` game with no challenger-won ancestors
  4. Proposer creates new branch from safe point, avoiding invalidated chains