### PR TITLE
feat: add --slow for deploy to testnet or mainnet

### DIFF
--- a/justfile
+++ b/justfile
@@ -115,6 +115,7 @@ deploy-fdg-contracts env_file=".env" *features='':
     echo "Running deployment script..."
     forge script script/fp/DeployOPSuccinctFDG.s.sol \
         --broadcast \
+        --slow \
         --rpc-url "$RPC_URL_TO_USE" \
         --private-key "$PRIVATE_KEY" \
         $VERIFY


### PR DESCRIPTION
add `--slow` when call forge script, it can await run failed in mainnet/testnet:

```
Sensitive values saved to: /home/fy/projects/op-succinct/contracts/cache/DeployOPSuccinctFDG.s.sol/11155111/run-latest.json

Error: Failed to send transaction

Context:
- server returned an error response: error code -32000: future transaction tries to replace pending
```