### PR TITLE
test: fix e2e test

### DIFF
--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -199,7 +199,7 @@ where
 
             // Create a transaction to claim credit
             let transaction_request =
-                game.claimCredit(self.challenger_address).into_transaction_request();
+                game.claimCredit(self.challenger_address).gas(200_000).into_transaction_request();
 
             match self
                 .signer

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -449,7 +449,7 @@ where
 
             // Create a transaction to claim credit
             let transaction_request =
-                game.claimCredit(self.prover_address).into_transaction_request();
+                game.claimCredit(self.prover_address).gas(200_000).into_transaction_request();
 
             // Sign and send the transaction
             match self

--- a/fault-proof/tests/e2e.rs
+++ b/fault-proof/tests/e2e.rs
@@ -104,7 +104,7 @@ async fn test_honest_proposer_native() -> Result<()> {
         &env.anvil.provider,
         &tracked_games,
         PROPOSER_ADDRESS,
-        Duration::from_secs(30),
+        Duration::from_secs(60),
     )
     .await?;
 


### PR DESCRIPTION
Gas estimation for claimCredit txs in e2e tests started to fail recently. Fixes by explicitly setting gas limit to 200k. Empirically, claimCredit tx used gas around 130k~160k.

Some example claimCredit tx [here](https://sepolia.etherscan.io/tx/0xfcb19c20e0e356a73283395d36b2b9b944ff14b5d3dc2f47e2808e75b61d0a88).