### PR TITLE
fix: reduce RPC concurrency to prevent rate limit errors

### DIFF
--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -199,7 +199,7 @@ impl OPSuccinctDataFetcher {
                     total_tx_fees,
                 })
             })
-            .buffered(100)
+            .buffered(10)
             .collect::<Vec<Result<BlockInfo>>>()
             .await;
 


### PR DESCRIPTION
Reduces RPC concurrency to prevent rate limit errors in validity proposer.

op-succinct proposer was making up to 2,000 concurrent RPC calls when creating range proof requests, causing HTTP 429 rate limit errors from l2 nodes. With 1800-block ranges, this resulted in 36,000 total RPC calls for 10 range requests in a burst.

Reduced concurrency of block data fetching from 100 to 10 concurrent blocks

This limits peak concurrent RPC calls to 100 instead of 2,000, preventing rate limit errors while maintaining reasonable performance and stability of the proposer.