### PR TITLE
refac: cursor+deadline scan with gameType filter

### DIFF
--- a/book/fault_proofs/challenger.md
+++ b/book/fault_proofs/challenger.md
@@ -50,7 +50,6 @@ Either `PRIVATE_KEY` or both `SIGNER_URL` and `SIGNER_ADDRESS` must be set for t
 |----------|-------------|---------------|
 | `FETCH_INTERVAL` | Polling interval in seconds | `30` |
 | `ENABLE_GAME_RESOLUTION` | Whether to enable automatic game resolution | `true` |
-| `MAX_GAMES_TO_CHECK_FOR_CHALLENGE` | Maximum number of games to scan for challenges | `100` |
 | `MAX_GAMES_TO_CHECK_FOR_RESOLUTION` | Maximum number of games to check for resolution | `100` |
 | `MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING` | Maximum number of games to check for bond claiming | `100` |
 | `CHALLENGER_METRICS_PORT` | The port to expose metrics on. Update prometheus.yml to use this port, if using docker compose. | `9001` |
@@ -67,7 +66,6 @@ PRIVATE_KEY=             # Private key for transaction signing
 # Optional Configuration
 FETCH_INTERVAL=30                     # Polling interval in seconds
 ENABLE_GAME_RESOLUTION=true           # Whether to enable automatic game resolution
-MAX_GAMES_TO_CHECK_FOR_CHALLENGE=100  # Maximum number of games to scan for challenges
 MAX_GAMES_TO_CHECK_FOR_RESOLUTION=100 # Maximum number of games to check for resolution
 MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING=100 # Maximum number of games to check for bond claiming
 CHALLENGER_METRICS_PORT=9001          # The port to expose metrics on
@@ -127,8 +125,8 @@ The challenger provides clear logging to distinguish between challenge types:
 ### Game Monitoring
 - Continuously scans for invalid games
 - Checks game validity against L2 state
-- Prioritizes oldest challengeable games
-- Maintains efficient scanning through configurable limits
+- Filters to the configured OP Succinct game type
+- Uses a cursor + deadline-based cutoff to avoid rescanning
 
 ### Game Challenging
 - Challenges invalid games with counter-proofs

--- a/book/fault_proofs/docker.md
+++ b/book/fault_proofs/docker.md
@@ -52,7 +52,6 @@ PRIVATE_KEY=             # Private key for transaction signing
 
 # Optional Configuration
 FETCH_INTERVAL=30        # Polling interval in seconds
-MAX_GAMES_TO_CHECK_FOR_CHALLENGE=100  # Maximum number of games to check for challenges
 ENABLE_GAME_RESOLUTION=true           # Whether to enable automatic game resolution
 MAX_GAMES_TO_CHECK_FOR_RESOLUTION=100 # Maximum number of games to check for resolution
 ```

--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use anyhow::Result;
@@ -8,9 +9,11 @@ use tokio::time;
 
 use crate::{
     config::ChallengerConfig,
-    contract::{DisputeGameFactory::DisputeGameFactoryInstance, OPSuccinctFaultDisputeGame},
+    contract::{
+        DisputeGameFactory::DisputeGameFactoryInstance, OPSuccinctFaultDisputeGame, ProposalStatus,
+    },
     prometheus::ChallengerGauge,
-    Action, FactoryTrait, L1Provider, L2Provider, Mode,
+    Action, FactoryTrait, L1Provider, L2Provider, L2ProviderTrait, Mode,
 };
 use op_succinct_host_utils::metrics::MetricsGauge;
 use op_succinct_signer_utils::Signer;
@@ -26,6 +29,8 @@ where
     l2_provider: L2Provider,
     factory: DisputeGameFactoryInstance<P>,
     challenger_bond: U256,
+    // In-memory scan cursor: last latest index we scanned up to.
+    scan_cursor: Option<U256>,
 }
 
 impl<P> OPSuccinctChallenger<P>
@@ -63,6 +68,7 @@ where
             l2_provider: ProviderBuilder::default().connect_http(l2_rpc),
             factory,
             challenger_bond,
+            scan_cursor: None,
         })
     }
 
@@ -84,78 +90,219 @@ where
             receipt.transaction_hash
         );
 
+        // Increment metrics on successful challenge
+        ChallengerGauge::GamesChallenged.increment(1.0);
+
         Ok(())
     }
 
-    /// Gets the oldest valid game address for malicious challenging (for defense mechanisms
-    /// testing purposes). This finds games with correct output roots that can be challenged to
-    /// test defense mechanisms.
-    async fn get_oldest_valid_game_for_malicious_challenge(&self) -> Result<Option<Address>> {
-        use crate::contract::ProposalStatus;
+    /// Get the current L1 timestamp (latest block).
+    async fn l1_now(&self) -> Result<u64> {
+        let now = self
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .unwrap()
+            .header
+            .timestamp;
+        Ok(now)
+    }
 
-        self.factory
-            .get_oldest_game_address(
-                self.config.max_games_to_check_for_challenge,
-                self.l1_provider.clone(),
-                self.l2_provider.clone(),
-                |status| status == ProposalStatus::Unchallenged,
-                |output_root, game_claim| output_root == game_claim, /* Valid games (opposite of
-                                                                      * honest challenger) */
-                "Oldest valid game for malicious challenge",
-            )
-            .await
+    /// Scan newly appended games and challenge invalid ones.
+    ///
+    /// - Filters to OP Succinct game type.
+    /// - Considers only in-progress and unexpired (deadline > now) unchallenged games.
+    /// - Computes local output root and challenges on mismatch.
+    async fn scan_and_challenge(&mut self) -> Result<Action> {
+        // Fetch latest index and current L1 time.
+        let Some(latest_index) = self.factory.fetch_latest_game_index().await? else {
+            tracing::debug!("No games exist yet, skipping challenging");
+            return Ok(Action::Skipped);
+        };
+        let now = self.l1_now().await?;
+
+        ChallengerGauge::LatestIndex.set(latest_index.to::<u64>() as f64);
+
+        // Determine lower bound for scanning on initial run by finding the first OP Succinct
+        // fault dispute game whose deadline has passed and is still in progress (not resolved).
+        let mut boundary_index: Option<U256> = None;
+        if self.scan_cursor.is_none() {
+            let mut i = latest_index;
+            loop {
+                let game = self.factory.gameAtIndex(i).call().await?;
+                if game.gameType == self.config.game_type {
+                    let game_addr = game.proxy;
+                    let game = OPSuccinctFaultDisputeGame::new(game_addr, self.l1_provider.clone());
+                    let claim = game.claimData().call().await?;
+                    let deadline = U256::from(claim.deadline).to::<u64>();
+                    if claim.status != ProposalStatus::Resolved && deadline < now {
+                        boundary_index = Some(i);
+                        break;
+                    }
+                }
+                if i == U256::ZERO {
+                    break;
+                }
+                i -= U256::from(1);
+            }
+        }
+
+        // Define scan range lower bound (exclusive). None => scan all the way to index 0.
+        let lower_exclusive_opt = match (self.scan_cursor, boundary_index) {
+            (Some(c), _) => Some(c),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+
+        let mut performed = false;
+        let mut oldest_scanned: Option<U256> = None;
+
+        let mut i = latest_index;
+        loop {
+            if let Some(lower_exclusive) = lower_exclusive_opt {
+                if i <= lower_exclusive {
+                    break;
+                }
+            }
+            let game = self.factory.gameAtIndex(i).call().await?;
+            // Filter only OP Succinct fault dispute games
+            if game.gameType != self.config.game_type {
+                if i == U256::ZERO {
+                    break;
+                }
+                i -= U256::from(1);
+                continue;
+            }
+
+            let game_addr = game.proxy;
+            let game = OPSuccinctFaultDisputeGame::new(game_addr, self.l1_provider.clone());
+            let claim = game.claimData().call().await?;
+
+            // Only consider in-progress unchallenged games
+            if claim.status != ProposalStatus::Unchallenged {
+                tracing::debug!(
+                    game_index = %i,
+                    status = ?claim.status,
+                    "Skipping game since not in-progress unchallenged"
+                );
+                if i == U256::ZERO {
+                    break;
+                }
+                i -= U256::from(1);
+                continue;
+            }
+
+            // Skip expired challenges
+            let deadline = U256::from(claim.deadline).to::<u64>();
+            if deadline <= now {
+                tracing::debug!(
+                    game_index = %i,
+                    deadline = %claim.deadline,
+                    now = %now,
+                    "Skipping game due to expired challenge window"
+                );
+                if i == U256::ZERO {
+                    break;
+                }
+                i -= U256::from(1);
+                continue;
+            }
+
+            // Compute expected output root and compare
+            let l2_block_number = game.l2BlockNumber().call().await?;
+            let expected = self.l2_provider.compute_output_root_at_block(l2_block_number).await?;
+            let proposed = game.rootClaim().call().await?;
+
+            oldest_scanned = Some(i);
+
+            if expected != proposed {
+                tracing::info!(
+                    "\x1b[32m[CHALLENGE]\x1b[0m Attempting to challenge invalid game {:?} at index {}",
+                    game_addr,
+                    i
+                );
+                self.challenge_game(game_addr).await?;
+                performed = true;
+            } else {
+                tracing::debug!(
+                    game_index = %i,
+                    l2_block = %l2_block_number,
+                    "Valid game detected (no challenge)"
+                );
+            }
+
+            if i == U256::ZERO {
+                break;
+            }
+            i -= U256::from(1);
+        }
+
+        // Update cursor to the latest index scanned up to.
+        self.scan_cursor = Some(latest_index);
+        ChallengerGauge::CursorIndex.set(latest_index.to::<u64>() as f64);
+        if let Some(oldest) = oldest_scanned {
+            ChallengerGauge::OldestIndexScanned.set(oldest.to::<u64>() as f64);
+        }
+
+        Ok(if performed { Action::Performed } else { Action::Skipped })
     }
 
     /// Handles challenging of invalid games by scanning recent games for potential challenges.
     /// Also supports malicious challenging of valid games for testing defense mechanisms when
     /// configured.
     #[tracing::instrument(skip(self), level = "info", name = "[[Challenging]]")]
-    async fn handle_game_challenging(&self) -> Result<Action> {
+    async fn handle_game_challenging(&mut self) -> Result<Action> {
         // Challenge invalid games (honest challenger behavior)
-        if let Some(game_address) = self
-            .factory
-            .get_oldest_challengable_game_address(
-                self.config.max_games_to_check_for_challenge,
-                self.l1_provider.clone(),
-                self.l2_provider.clone(),
-            )
-            .await?
-        {
-            tracing::info!(
-                "\x1b[32m[CHALLENGE]\x1b[0m Attempting to challenge invalid game {:?}",
-                game_address
-            );
-            self.challenge_game(game_address).await?;
-            return Ok(Action::Performed);
+        let action = self.scan_and_challenge().await?;
+        if matches!(action, Action::Performed) {
+            return Ok(action);
         }
 
         // Maliciously challenge valid games (if configured for testing defense mechanisms)
         if self.config.malicious_challenge_percentage > 0.0 {
-            tracing::debug!("Checking for valid games to challenge maliciously...");
-            if let Some(game_address) = self.get_oldest_valid_game_for_malicious_challenge().await?
-            {
-                let mut rng = StdRng::from_os_rng();
-                let should_challenge: f64 = rng.random_range(0.0..100.0);
-                let should_challenge =
-                    should_challenge <= self.config.malicious_challenge_percentage;
-
-                if should_challenge {
-                    tracing::warn!(
-                        "\x1b[31m[MALICIOUS CHALLENGE]\x1b[0m Attempting to challenge valid game {:?} for testing ({}% chance)",
-                        game_address,
-                        self.config.malicious_challenge_percentage
-                    );
-                    self.challenge_game(game_address).await?;
-                    return Ok(Action::Performed);
-                } else {
-                    tracing::debug!(
-                        "Found valid game {:?} but skipping malicious challenge ({}% chance)",
-                        game_address,
-                        self.config.malicious_challenge_percentage
-                    );
+            if let Some(index) = self.scan_cursor {
+                tracing::debug!("Checking scan_cursor index for malicious challenge...");
+                let game = self.factory.gameAtIndex(index).call().await?;
+                if game.gameType == self.config.game_type {
+                    let now = self.l1_now().await?;
+                    let game_addr = game.proxy;
+                    let game = OPSuccinctFaultDisputeGame::new(game_addr, self.l1_provider.clone());
+                    let claim = game.claimData().call().await?;
+                    if claim.status == ProposalStatus::Unchallenged {
+                        let deadline = U256::from(claim.deadline).to::<u64>();
+                        if deadline > now {
+                            let l2_block_number = game.l2BlockNumber().call().await?;
+                            let expected = self
+                                .l2_provider
+                                .compute_output_root_at_block(l2_block_number)
+                                .await?;
+                            let proposed = game.rootClaim().call().await?;
+                            if expected == proposed {
+                                let mut rng = StdRng::from_os_rng();
+                                let should_challenge: f64 = rng.random_range(0.0..100.0);
+                                if should_challenge
+                                    <= self.config.malicious_challenge_percentage
+                                {
+                                    tracing::warn!(
+                                        "\x1b[31m[MALICIOUS CHALLENGE]\x1b[0m Attempting to challenge valid game {:?} for testing ({}% chance)",
+                                        game_addr,
+                                        self.config.malicious_challenge_percentage
+                                    );
+                                    self.challenge_game(game_addr).await?;
+                                    return Ok(Action::Performed);
+                                } else {
+                                    tracing::debug!(
+                                        "Cursor game {:?} valid but skipping malicious challenge ({}% chance)",
+                                        game_addr,
+                                        self.config.malicious_challenge_percentage
+                                    );
+                                }
+                            }
+                        }
+                    }
                 }
             } else {
-                tracing::debug!("No valid games found for malicious challenging");
+                tracing::debug!("Skipping malicious challenge: scan_cursor not initialized yet");
             }
         }
 
@@ -212,6 +359,7 @@ where
                         game_address,
                         receipt.transaction_hash
                     );
+                    ChallengerGauge::GamesBondsClaimed.increment(1.0);
 
                     Ok(Action::Performed)
                 }
@@ -249,9 +397,7 @@ where
             interval.tick().await;
 
             match self.handle_game_challenging().await {
-                Ok(Action::Performed) => {
-                    ChallengerGauge::GamesChallenged.increment(1.0);
-                }
+                Ok(Action::Performed) => {}
                 Ok(Action::Skipped) => {}
                 Err(e) => {
                     tracing::warn!("Failed to handle game challenging: {:?}", e);
@@ -265,9 +411,7 @@ where
             }
 
             match self.handle_bond_claiming().await {
-                Ok(Action::Performed) => {
-                    ChallengerGauge::GamesBondsClaimed.increment(1.0);
-                }
+                Ok(Action::Performed) => {}
                 Ok(Action::Skipped) => {}
                 Err(e) => {
                     tracing::warn!("Failed to handle bond claiming: {:?}", e);

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -115,11 +115,6 @@ pub struct ChallengerConfig {
     /// The game type to challenge.
     pub game_type: u32,
 
-    /// The number of games to check for challenges.
-    /// The challenger will check for challenges up to `max_games_to_check_for_challenge` games
-    /// behind the latest game.
-    pub max_games_to_check_for_challenge: u64,
-
     /// Whether to enable game resolution.
     /// When game resolution is not enabled, the challenger will only challenge games.
     pub enable_game_resolution: bool,
@@ -149,9 +144,6 @@ impl ChallengerConfig {
             factory_address: env::var("FACTORY_ADDRESS")?.parse().expect("FACTORY_ADDRESS not set"),
             game_type: env::var("GAME_TYPE").expect("GAME_TYPE not set").parse()?,
             fetch_interval: env::var("FETCH_INTERVAL").unwrap_or("30".to_string()).parse()?,
-            max_games_to_check_for_challenge: env::var("MAX_GAMES_TO_CHECK_FOR_CHALLENGE")
-                .unwrap_or("100".to_string())
-                .parse()?,
             enable_game_resolution: env::var("ENABLE_GAME_RESOLUTION")
                 .unwrap_or("true".to_string())
                 .parse()?,

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -179,16 +179,7 @@ where
         S: Fn(ProposalStatus) -> bool + Send + Sync,
         O: Fn(B256, B256) -> bool + Send + Sync;
 
-    /// Get the oldest challengable game address.
-    ///
-    /// This function checks a window of recent games, starting from.
-    /// (latest_game_index - max_games_to_check_for_challenge) up to latest_game_index.
-    async fn get_oldest_challengable_game_address(
-        &self,
-        max_games_to_check_for_challenge: u64,
-        l1_provider: L1Provider,
-        l2_provider: L2Provider,
-    ) -> Result<Option<Address>>;
+    // Note: Challenging scan now handled by the challenger using a cursor-based approach.
 
     /// Get the oldest defensible game address.
     ///
@@ -524,24 +515,6 @@ where
         }
 
         Ok(None)
-    }
-
-    /// Get the oldest challengable game address.
-    async fn get_oldest_challengable_game_address(
-        &self,
-        max_games_to_check_for_challenge: u64,
-        l1_provider: L1Provider,
-        l2_provider: L2Provider,
-    ) -> Result<Option<Address>> {
-        self.get_oldest_game_address(
-            max_games_to_check_for_challenge,
-            l1_provider,
-            l2_provider,
-            |status| status == ProposalStatus::Unchallenged,
-            |output_root, game_claim| output_root != game_claim,
-            "Oldest challengable game",
-        )
-        .await
     }
 
     /// Get the oldest defensible game address.

--- a/fault-proof/src/prometheus.rs
+++ b/fault-proof/src/prometheus.rs
@@ -110,6 +110,21 @@ pub enum ChallengerGauge {
         message = "Total number of games that bonds were claimed by the challenger"
     )]
     GamesBondsClaimed,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_cursor_index",
+        message = "Challenger scan cursor index"
+    )]
+    CursorIndex,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_latest_index",
+        message = "Latest game index observed by challenger"
+    )]
+    LatestIndex,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_oldest_index_scanned",
+        message = "Oldest game index scanned in last tick"
+    )]
+    OldestIndexScanned,
     // Error metrics
     #[strum(
         serialize = "op_succinct_fp_challenger_game_challenging_error",

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -86,7 +86,6 @@ pub async fn start_challenger(
         factory_address: *factory_address,
         fetch_interval: 2, // Check more frequently in tests
         game_type,
-        max_games_to_check_for_challenge: 10, // Check more games
         enable_game_resolution: true,
         max_games_to_check_for_resolution: 100,
         max_games_to_check_for_bond_claiming: 100,


### PR DESCRIPTION
Improves challenger by doing cursor+deadline scan with gameType filter instead of having a `MAX_GAMES_TO_CHECK_FOR_CHALLENGE` scan window.

Removes MAX_GAMES_TO_CHECK_FOR_CHALLENGE.
Simplifies malicious challenge.