### PR TITLE
feat: spawn defense tasks concurrently

### DIFF
--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -60,6 +60,7 @@ Either `PRIVATE_KEY` or both `SIGNER_URL` and `SIGNER_ADDRESS` must be set for t
 | `ENABLE_GAME_RESOLUTION` | Whether to enable automatic game resolution | `true` |
 | `MAX_GAMES_TO_CHECK_FOR_RESOLUTION` | Maximum number of games to check for resolution | `100` |
 | `MAX_GAMES_TO_CHECK_FOR_DEFENSE` | Maximum number of recent games to check for defense | `100` |
+| `MAX_CONCURRENT_DEFENSE_TASKS` | Maximum number of concurrently running defense tasks | `8` |
 | `MAX_GAMES_TO_CHECK_FOR_BOND_CLAIMING` | Maximum number of games to check for bond claiming | `100` |
 | `L1_BEACON_RPC` | L1 Beacon RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |
 | `L2_NODE_RPC` | L2 Node RPC endpoint URL | (Only used if `FAST_FINALITY_MODE` is `true`) |

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -39,6 +39,9 @@ pub struct ProposerConfig {
     /// The number of games to check for defense.
     pub max_games_to_check_for_defense: u64,
 
+    /// The max number of defense tasks to run concurrently.
+    pub max_concurrent_defense_tasks: u64,
+
     /// Whether to enable game resolution.
     /// When game resolution is not enabled, the proposer will only propose new games.
     pub enable_game_resolution: bool,
@@ -80,6 +83,9 @@ impl ProposerConfig {
             game_type: env::var("GAME_TYPE").expect("GAME_TYPE not set").parse()?,
             max_games_to_check_for_defense: env::var("MAX_GAMES_TO_CHECK_FOR_DEFENSE")
                 .unwrap_or("100".to_string())
+                .parse()?,
+            max_concurrent_defense_tasks: env::var("MAX_CONCURRENT_DEFENSE_TASKS")
+                .unwrap_or("8".to_string())
                 .parse()?,
             enable_game_resolution: env::var("ENABLE_GAME_RESOLUTION")
                 .unwrap_or("true".to_string())

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -844,16 +844,16 @@ where
             )
             .await?;
 
-        let mut tasks_spanned = false;
+        let mut tasks_spawned = false;
         for game_address in game_addresses {
             // Check if we already have a proving task for this game
             if !self.has_active_proving_for_game(game_address).await {
                 self.spawn_game_proving_task(game_address).await?;
-                tasks_spanned = true;
+                tasks_spawned = true;
             }
         }
 
-        Ok(tasks_spanned)
+        Ok(tasks_spawned)
     }
 
     /// Check if there's an active proving task for a specific game

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -35,6 +35,7 @@ pub async fn start_proposer(
         fetch_interval: 2,               // Check more frequently in tests
         game_type,
         max_games_to_check_for_defense: 100,
+        max_concurrent_defense_tasks: 8,
         enable_game_resolution: true,
         max_games_to_check_for_resolution: 100,
         max_games_to_check_for_bond_claiming: 100,


### PR DESCRIPTION
Get all defensible game addresses and spawn a task for all of them, instead of doing it for the oldest only.