### PR TITLE
feat: add save artifacts flag for multi script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8399,6 +8399,7 @@ version = "3.1.0"
 dependencies = [
  "alloy-primitives 1.1.2",
  "anyhow",
+ "bincode",
  "cargo_metadata",
  "clap",
  "csv",

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -44,6 +44,7 @@
 - [Advanced](./advanced/intro.md)
   - [Cost Estimator](./advanced/cost-estimator.md)
   - [Reproduce Binaries](./advanced/verify-binaries.md)
+  - [Run Multi-Block Execution](./advanced/run-multi.md)
   - [Node Setup](./advanced/node-setup.md)
   - [Kurtosis](./advanced/kurtosis.md)
   - [FAQ](./faq.md)

--- a/book/advanced/run-multi.md
+++ b/book/advanced/run-multi.md
@@ -1,0 +1,51 @@
+# Run `run-multi`
+
+The `run-multi` helper executes the OP Succinct range program for a span of L2 blocks and can
+optionally generate artifacts for later reuse.
+
+## Prerequisites
+
+- Populate a `.env` file at the repository root with the RPC endpoints required by the host:
+
+  ```env
+  L1_RPC=<YOUR_L1_RPC_ENDPOINT>
+  L1_BEACON_RPC=<YOUR_L1_BEACON_RPC_ENDPOINT>
+  L2_RPC=<YOUR_L2_RPC_ENDPOINT>
+  L2_NODE_RPC=<YOUR_L2_NODE_RPC_ENDPOINT>
+  ```
+
+
+- Install [`just`](https://github.com/casey/just).
+
+## Command
+
+```bash
+just run-multi <start-block> <end-block> \
+  use-cache=true \
+  prove=false \
+  save-artifacts=true
+```
+
+- `start-block` / `end-block` define the inclusive range executed by the host.
+- `use-cache=true` reuses cached witness data when available (set to `false` to recompute).
+- `prove=true` produces a compressed proof saved to
+  `data/<l2-chain-id>/proofs/<start>-<end>.bin`.
+- `save-artifacts=true` stores the embedded program and serialized stdin at
+  `data/<l2-chain-id>/binaries/<start>-<end>_{program,stdin}.bin`. Set to `false` to skip writing
+  these files when you only need execution stats. The `data/` directory is gitignored, so saved artifacts will not appear in `git diff` output.
+
+## Choose a Block Range
+
+Use the latest finalized L2 block as an upper bound and ensure the range size fits within your
+proving capacity. You can query the finalized block with Foundry's `cast` CLI:
+
+```bash
+cast block finalized --json --rpc-url "$L2_RPC" | jq '.number'
+```
+
+You can use the value as the `end-block`. Set `start-block` to an earlier finalized block so that `end-block - start-block` matches the number of blocks you want to execute.
+
+``` admonish info
+The `data/` directory is gitignored, so saved artifacts and proofs will not appear in `git diff`
+output. Copy files elsewhere if you need to share them.
+```

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ default:
   @just --list
 
 # Runs the op-succinct program for a single block.
-run-single l2_block_num use-cache="false" prove="false":
+run-single l2_block_num use-cache="false" prove="false" save-artifacts="false":
   #!/usr/bin/env bash
   CACHE_FLAG=""
   if [ "{{use-cache}}" = "true" ]; then
@@ -12,10 +12,14 @@ run-single l2_block_num use-cache="false" prove="false":
   if [ "{{prove}}" = "true" ]; then
     PROVE_FLAG="--prove"
   fi
-  cargo run --bin single --release -- --l2-block {{l2_block_num}} $CACHE_FLAG $PROVE_FLAG
+  SAVE_ARTIFACTS_FLAG=""
+  if [ "{{save-artifacts}}" = "true" ]; then
+    SAVE_ARTIFACTS_FLAG="--save-artifacts"
+  fi
+  RUST_LOG=info cargo run --bin single --release -- --l2-block {{l2_block_num}} $CACHE_FLAG $PROVE_FLAG $SAVE_ARTIFACTS_FLAG
 
 # Runs the op-succinct program for multiple blocks.
-run-multi start end use-cache="false" prove="false":
+run-multi start end use-cache="false" prove="false" save-artifacts="false":
   #!/usr/bin/env bash
   CACHE_FLAG=""
   if [ "{{use-cache}}" = "true" ]; then
@@ -26,7 +30,12 @@ run-multi start end use-cache="false" prove="false":
     PROVE_FLAG="--prove"
   fi
 
-  cargo run --bin multi --release -- --start {{start}} --end {{end}} $CACHE_FLAG $PROVE_FLAG
+  SAVE_ARTIFACTS_FLAG=""
+  if [ "{{save-artifacts}}" = "true" ]; then
+    SAVE_ARTIFACTS_FLAG="--save-artifacts"
+  fi
+
+  RUST_LOG=info cargo run --bin multi --release -- --start {{start}} --end {{end}} $CACHE_FLAG $PROVE_FLAG $SAVE_ARTIFACTS_FLAG
 
 # Runs the cost estimator for a given block range.
 # If no range is provided, runs for the last 5 finalized blocks.

--- a/scripts/prove/Cargo.toml
+++ b/scripts/prove/Cargo.toml
@@ -25,6 +25,7 @@ anyhow.workspace = true
 dotenv.workspace = true
 csv.workspace = true
 tracing.workspace = true
+bincode.workspace = true
 
 # local
 op-succinct-host-utils.workspace = true

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -30,6 +30,9 @@ pub struct HostExecutorArgs {
     /// Whether to generate proofs.
     #[arg(long)]
     pub prove: bool,
+    /// Whether to save the program and stdin artifacts locally.
+    #[arg(long)]
+    pub save_artifacts: bool,
     /// Whether to fallback to timestamp-based L1 head estimation even though SafeDB is not
     /// activated for op-node.
     #[clap(long)]


### PR DESCRIPTION
Adds `--save-artifacts` flag for multi script so that the program and stdin artifacts can be saved locally.