### PR TITLE
feat: add env-configurable proof fulfillment strategies

### DIFF
--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -55,6 +55,8 @@ Either `PRIVATE_KEY` or both `SIGNER_URL` and `SIGNER_ADDRESS` must be set for t
 |----------|-------------|---------------|
 | `MOCK_MODE` | Whether to use mock mode | `false` |
 | `FAST_FINALITY_MODE` | Whether to use fast finality mode | `false` |
+| `RANGE_PROOF_STRATEGY` | Proof fulfillment strategy for range proofs. Set to `hosted` to use the hosted proof strategy. | `reserved` |
+| `AGG_PROOF_STRATEGY` | Proof fulfillment strategy for aggregation proofs. Set to `hosted` to use the hosted proof strategy. | `reserved` |
 | `PROPOSAL_INTERVAL_IN_BLOCKS` | Number of L2 blocks between proposals | `1800` |
 | `FETCH_INTERVAL` | Polling interval in seconds | `30` |
 | `ENABLE_GAME_RESOLUTION` | Whether to enable automatic game resolution | `true` |
@@ -86,6 +88,8 @@ SIGNER_ADDRESS=          # Address of the account managed by the web3 signer
 # Optional Configuration
 MOCK_MODE=false                          # Whether to use mock mode
 FAST_FINALITY_MODE=false                 # Whether to use fast finality mode
+RANGE_PROOF_STRATEGY=reserved            # Set to hosted to use hosted proof strategy
+AGG_PROOF_STRATEGY=reserved              # Set to hosted to use hosted proof strategy
 PROPOSAL_INTERVAL_IN_BLOCKS=1800         # Number of L2 blocks between proposals
 FETCH_INTERVAL=30                        # Polling interval in seconds
 ENABLE_GAME_RESOLUTION=false             # Whether to enable automatic game resolution

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -4,6 +4,7 @@ use alloy_primitives::Address;
 use alloy_transport_http::reqwest::Url;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use sp1_sdk::network::FulfillmentStrategy;
 
 #[derive(Debug, Clone)]
 pub struct ProposerConfig {
@@ -21,6 +22,12 @@ pub struct ProposerConfig {
 
     /// Whether to use fast finality mode.
     pub fast_finality_mode: bool,
+
+    /// Proof fulfillment strategy for range proofs.
+    pub range_proof_strategy: FulfillmentStrategy,
+
+    /// Proof fulfillment strategy for aggregation proofs.
+    pub agg_proof_strategy: FulfillmentStrategy,
 
     /// The interval in blocks between proposing new games.
     pub proposal_interval_in_blocks: u64,
@@ -76,6 +83,22 @@ impl ProposerConfig {
             fast_finality_mode: env::var("FAST_FINALITY_MODE")
                 .unwrap_or("false".to_string())
                 .parse()?,
+            range_proof_strategy: if env::var("RANGE_PROOF_STRATEGY")
+                .unwrap_or("reserved".to_string())
+                .eq_ignore_ascii_case("hosted")
+            {
+                FulfillmentStrategy::Hosted
+            } else {
+                FulfillmentStrategy::Reserved
+            },
+            agg_proof_strategy: if env::var("AGG_PROOF_STRATEGY")
+                .unwrap_or("reserved".to_string())
+                .eq_ignore_ascii_case("hosted")
+            {
+                FulfillmentStrategy::Hosted
+            } else {
+                FulfillmentStrategy::Reserved
+            },
             proposal_interval_in_blocks: env::var("PROPOSAL_INTERVAL_IN_BLOCKS")
                 .unwrap_or("1800".to_string())
                 .parse()?,

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -20,8 +20,8 @@ use op_succinct_host_utils::{
 use op_succinct_proof_utils::get_range_elf_embedded;
 use op_succinct_signer_utils::Signer;
 use sp1_sdk::{
-    network::FulfillmentStrategy, NetworkProver, Prover, ProverClient, SP1ProofMode,
-    SP1ProofWithPublicValues, SP1ProvingKey, SP1VerifyingKey, SP1_CIRCUIT_VERSION,
+    NetworkProver, Prover, ProverClient, SP1ProofMode, SP1ProofWithPublicValues, SP1ProvingKey,
+    SP1VerifyingKey, SP1_CIRCUIT_VERSION,
 };
 use tokio::{sync::Mutex, time};
 
@@ -218,7 +218,7 @@ where
                 .network_prover
                 .prove(&self.prover.range_pk, &sp1_stdin)
                 .compressed()
-                .strategy(FulfillmentStrategy::Hosted)
+                .strategy(self.config.range_proof_strategy.clone())
                 .skip_simulation(true)
                 .cycle_limit(1_000_000_000_000)
                 .gas_limit(1_000_000_000_000)
@@ -282,6 +282,7 @@ where
                 .network_prover
                 .prove(&self.prover.agg_pk, &sp1_stdin)
                 .groth16()
+                .strategy(self.config.agg_proof_strategy.clone())
                 .timeout(Duration::from_secs(4 * 60 * 60))
                 .run_async()
                 .await?

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -218,7 +218,7 @@ where
                 .network_prover
                 .prove(&self.prover.range_pk, &sp1_stdin)
                 .compressed()
-                .strategy(self.config.range_proof_strategy.clone())
+                .strategy(self.config.range_proof_strategy)
                 .skip_simulation(true)
                 .cycle_limit(1_000_000_000_000)
                 .gas_limit(1_000_000_000_000)
@@ -282,7 +282,7 @@ where
                 .network_prover
                 .prove(&self.prover.agg_pk, &sp1_stdin)
                 .groth16()
-                .strategy(self.config.agg_proof_strategy.clone())
+                .strategy(self.config.agg_proof_strategy)
                 .timeout(Duration::from_secs(4 * 60 * 60))
                 .run_async()
                 .await?

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -31,6 +31,8 @@ pub async fn start_proposer(
         factory_address: *factory_address,
         mock_mode: true,
         fast_finality_mode: false,
+        range_proof_strategy: FulfillmentStrategy::Hosted,
+        agg_proof_strategy: FulfillmentStrategy::Hosted,
         proposal_interval_in_blocks: 10, // Much smaller interval for testing
         fetch_interval: 2,               // Check more frequently in tests
         game_type,

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -11,6 +11,7 @@ use fault_proof::{
 use op_succinct_host_utils::fetcher::{OPSuccinctDataFetcher, RPCConfig};
 use op_succinct_proof_utils::initialize_host;
 use op_succinct_signer_utils::Signer;
+use sp1_sdk::network::FulfillmentStrategy;
 use tracing::Instrument;
 
 /// Start a proposer, and return a handle to the proposer task.


### PR DESCRIPTION
Adding `RANGE_PROOF_STRATEGY` and `AGG_PROOF_STRATEGY` to fault-proof proposer so that proof fulfillment strategies are configurable. No longer defaults to `FulfillmentStrategy::Hosted`.