### PR TITLE
chore: bump to v3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "aggregation"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-primitives 1.1.2",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-bindings"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy",
  "alloy-sol-types",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-build-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "cargo_metadata",
  "sp1-build",
@@ -8119,7 +8119,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-celestia-client-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8137,7 +8137,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-celestia-host-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-eips 1.0.9",
@@ -8166,7 +8166,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-client-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-eips 1.0.9",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-eigenda-host-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-eips 1.0.9",
  "alloy-primitives 1.1.2",
@@ -8244,11 +8244,11 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-elfs"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "op-succinct-ethereum-client-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-ethereum-host-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-eips 1.0.9",
  "alloy-primitives 1.1.2",
@@ -8283,7 +8283,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-fp"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-host-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-contract",
@@ -8382,7 +8382,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-proof-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "cfg-if",
  "op-succinct-celestia-host-utils",
@@ -8395,7 +8395,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-prove"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-primitives 1.1.2",
  "anyhow",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-range-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "kona-proof",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-scripts"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-eips 1.0.9",
  "alloy-primitives 1.1.2",
@@ -8460,7 +8460,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-signer-utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-eips 1.0.9",
@@ -8477,7 +8477,7 @@ dependencies = [
 
 [[package]]
 name = "op-succinct-validity"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "alloy-eips 1.0.9",
  "alloy-primitives 1.1.2",
@@ -9850,7 +9850,7 @@ dependencies = [
 
 [[package]]
 name = "range"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "kona-proof",
  "op-succinct-client-utils",
@@ -9863,7 +9863,7 @@ dependencies = [
 
 [[package]]
 name = "range-celestia"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "kona-proof",
  "op-succinct-celestia-client-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 authors = ["ratankaliani", "zachobront", "fakedev9999", "yuwen01"]
 homepage = "https://succinctlabs.github.io/op-succinct/"
 repository = "https://github.com/succinctlabs/op-succinct"
-version = "3.1.0"
+version = "3.2.0"
 
 [workspace.dependencies]
 # general


### PR DESCRIPTION
Bumps op-succinct to v3.2.0 for a new release.