### PR TITLE
fix: bump hokulea version and fix only ethda problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "canoe-bindings"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-sol-types",
 ]
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "canoe-provider"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-sol-types",
@@ -2612,13 +2612,12 @@ dependencies = [
  "canoe-bindings",
  "eigenda-cert",
  "serde",
- "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "canoe-sp1-cc-host"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-rpc-types 0.14.0",
@@ -3769,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "eigenda-cert"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-rlp",
@@ -4932,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-evm 0.10.0",
@@ -4951,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-evm 0.10.0",
  "cfg-if",
@@ -4969,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "hokulea-compute-proof"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "num",
@@ -4980,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "hokulea-eigenda"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "async-trait",
@@ -4996,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "hokulea-host-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "anyhow",
@@ -5023,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "hokulea-proof"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-sol-types",
@@ -5049,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "hokulea-witgen"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-consensus 1.0.9",
  "alloy-primitives 1.1.2",
@@ -5069,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "hokulea-zkvm-verification"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35bc996dafa49f9cb6892d722dfbfa33abf#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "hokulea-proof",
  "kona-preimage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v1.0.1" }
 hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v1.0.1" }
 
 # hokulea
+# TODO(fakedev9999): Bump to 1.0.0 once the release is out.
 hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
 hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
 hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,13 +102,12 @@ hana-host = { git = "https://github.com/celestiaorg/hana", tag = "v1.0.1" }
 hana-oracle = { git = "https://github.com/celestiaorg/hana", tag = "v1.0.1" }
 
 # hokulea
-# TODO(fakedev9999): Bump to 1.0.0 once the release is out.
-hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748" }
-hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748" }
-hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748" }
-hokulea-witgen = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748" }
-hokulea-zkvm-verification = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748" }
-canoe-sp1-cc-host = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748" }
+hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
+hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
+hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
+hokulea-witgen = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
+hokulea-zkvm-verification = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
+canoe-sp1-cc-host = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35bc996dafa49f9cb6892d722dfbfa33abf" }
 
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }

--- a/programs/range/eigenda/src/main.rs
+++ b/programs/range/eigenda/src/main.rs
@@ -32,11 +32,12 @@ fn main() {
             &witness_data.eigenda_data.clone().expect("eigenda witness data is not present"),
         )
         .expect("cannot deserialize eigenda witness");
-        let preloaded_blob_provider =
+        let preloaded_preimage_provider =
             eigenda_witness_to_preloaded_provider(oracle, CanoeSp1CCVerifier {}, eigenda_witness)
                 .await
                 .expect("Failed to get preloaded blob provider");
 
-        run_range_program(EigenDAWitnessExecutor::new(preloaded_blob_provider), witness_data).await;
+        run_range_program(EigenDAWitnessExecutor::new(preloaded_preimage_provider), witness_data)
+            .await;
     });
 }

--- a/utils/eigenda/client/src/executor.rs
+++ b/utils/eigenda/client/src/executor.rs
@@ -60,8 +60,9 @@ where
     ) -> Result<OraclePipeline<Self::O, Self::L1, Self::L2, Self::DA>> {
         let ethereum_data_source =
             EthereumDataSource::new_from_parts(l1_provider.clone(), beacon, &rollup_config);
-        let eigenda_blob_source = EigenDAPreimageSource::new(self.eigenda_blob_provider.clone());
-        let da_provider = EigenDADataSource::new(ethereum_data_source, eigenda_blob_source);
+        let eigenda_preimage_source =
+            EigenDAPreimageSource::new(self.eigenda_blob_provider.clone());
+        let da_provider = EigenDADataSource::new(ethereum_data_source, eigenda_preimage_source);
 
         Ok(OraclePipeline::new(
             rollup_config,

--- a/utils/eigenda/client/src/executor.rs
+++ b/utils/eigenda/client/src/executor.rs
@@ -21,7 +21,7 @@ where
     B: BlobProvider + Send + Sync + Debug + Clone,
     E: EigenDAPreimageProvider + Send + Sync + Debug + Clone,
 {
-    eigenda_blob_provider: E,
+    eigenda_preimage_provider: E,
     _marker: std::marker::PhantomData<(O, B)>,
 }
 
@@ -31,8 +31,8 @@ where
     B: BlobProvider + Send + Sync + Debug + Clone,
     E: EigenDAPreimageProvider + Send + Sync + Debug + Clone,
 {
-    pub fn new(eigenda_blob_provider: E) -> Self {
-        Self { eigenda_blob_provider, _marker: std::marker::PhantomData }
+    pub fn new(eigenda_preimage_provider: E) -> Self {
+        Self { eigenda_preimage_provider, _marker: std::marker::PhantomData }
     }
 }
 
@@ -61,7 +61,7 @@ where
         let ethereum_data_source =
             EthereumDataSource::new_from_parts(l1_provider.clone(), beacon, &rollup_config);
         let eigenda_preimage_source =
-            EigenDAPreimageSource::new(self.eigenda_blob_provider.clone());
+            EigenDAPreimageSource::new(self.eigenda_preimage_provider.clone());
         let da_provider = EigenDADataSource::new(ethereum_data_source, eigenda_preimage_source);
 
         Ok(OraclePipeline::new(

--- a/utils/eigenda/host/src/witness_generator.rs
+++ b/utils/eigenda/host/src/witness_generator.rs
@@ -48,13 +48,13 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
 
         // If eigenda blob witness data is present, write the canoe proof to stdin
         if let Some(eigenda_data) = &witness.eigenda_data {
-            let mut eigenda_blob_witness_data: EigenDAWitness =
-                serde_cbor::from_slice(eigenda_data).map_err(|e| {
+            let mut eigenda_witness: EigenDAWitness = serde_cbor::from_slice(eigenda_data)
+                .map_err(|e| {
                     anyhow::anyhow!("Failed to deserialize EigenDA blob witness data: {}", e)
                 })?;
 
             // Take the canoe proof bytes from the witness data
-            if let Some(proof_bytes) = eigenda_blob_witness_data.canoe_proof_bytes.take() {
+            if let Some(proof_bytes) = eigenda_witness.canoe_proof_bytes.take() {
                 // Get the canoe SP1 CC client ELF and setup verification key
                 // The ELF is included in the canoe-sp1-cc-host crate
                 const CANOE_ELF: &[u8] = canoe_sp1_cc_host::ELF;
@@ -67,10 +67,9 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
                 stdin.write_proof(reduced_proof, canoe_vk.vk.clone());
 
                 // Re-serialize the witness data without the proof
-                witness.eigenda_data =
-                    Some(serde_cbor::to_vec(&eigenda_blob_witness_data).map_err(|e| {
-                        anyhow::anyhow!("Failed to serialize sanitized EigenDA data: {}", e)
-                    })?);
+                witness.eigenda_data = Some(serde_cbor::to_vec(&eigenda_witness).map_err(|e| {
+                    anyhow::anyhow!("Failed to serialize sanitized EigenDA data: {}", e)
+                })?);
             }
         }
 
@@ -102,12 +101,12 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
         let beacon = OnlineBlobStore { provider: blob_provider.clone(), store: blob_data.clone() };
 
         // Create EigenDA blob provider that collects witness data
-        let eigenda_blob_provider = OracleEigenDAPreimageProvider::new(oracle.clone());
-        let eigenda_blobs_witness = Arc::new(Mutex::new(EigenDAWitness::default()));
+        let eigenda_preimage_provider = OracleEigenDAPreimageProvider::new(oracle.clone());
+        let eigenda_witness = Arc::new(Mutex::new(EigenDAWitness::default()));
 
         let eigenda_blob_and_witness_provider = OracleEigenDAWitnessProvider {
-            provider: eigenda_blob_provider,
-            witness: eigenda_blobs_witness.clone(),
+            provider: eigenda_preimage_provider,
+            witness: eigenda_witness.clone(),
         };
 
         let executor = EigenDAWitnessExecutor::new(eigenda_blob_and_witness_provider);
@@ -132,18 +131,7 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
         }
 
         // Extract the EigenDA witness data
-        let mut eigenda_witness_data = std::mem::take(&mut *eigenda_blobs_witness.lock().unwrap());
-
-        // If there are no EigenDA DA certs collected for this range, skip Canoe proof generation.
-        if eigenda_witness_data.validities.is_empty() {
-            let witness = EigenDAWitnessData {
-                preimage_store: preimage_witness_store.lock().unwrap().clone(),
-                blob_data: blob_data.lock().unwrap().clone(),
-                eigenda_data: None,
-            };
-
-            return Ok(witness);
-        }
+        let mut eigenda_witness_data = std::mem::take(&mut *eigenda_witness.lock().unwrap());
 
         // Generate canoe proofs using the reduced proof provider for proof aggregation
         use canoe_sp1_cc_host::CanoeSp1CCReducedProofProvider;
@@ -162,10 +150,12 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
         )
         .await?;
 
-        // Store the canoe proof in the witness data
-        let canoe_proof_bytes =
-            serde_cbor::to_vec(&canoe_proofs).expect("Failed to serialize canoe proof");
-        eigenda_witness_data.canoe_proof_bytes = Some(canoe_proof_bytes);
+        if let Some(proof) = canoe_proofs {
+            // Store the canoe proof in the witness data
+            let canoe_proof_bytes =
+                serde_cbor::to_vec(&proof).expect("Failed to serialize canoe proof");
+            eigenda_witness_data.canoe_proof_bytes = Some(canoe_proof_bytes);
+        }
 
         let eigenda_witness_bytes = serde_cbor::to_vec(&eigenda_witness_data)
             .expect("Failed to serialize EigenDA witness data");


### PR DESCRIPTION
This PR does three things

1. it bumps the hokulea version, and incorporate the rename PR https://github.com/Layr-Labs/hokulea/pull/160
2. it resolves the issue when there is only EthDA in the derivation pipeline. 
  - Previously the `EigenDAWitnessData::eigenda_data` is assigned to None, and the system would aborts at the client side expecting one. 
  - Now, `EigenDAWitnessData::eigenda_data` is always assigned to something, and sometimes it can be an empty struct
3. it incorporates the new hokulea change, where `hokulea_witgen::from_boot_info_to_canoe_proof` now returns an option, and when the returned value is None, it indicates there is no canoe proof to be expected.

See https://github.com/Layr-Labs/hokulea/pull/166.