### PR TITLE
fix: retain canonical head when pruning resolved games

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -404,7 +404,17 @@ where
                         }
                     }
                     GameSyncAction::Remove(index) => {
-                        state.games.remove(&index);
+                        let is_canonical_head =
+                            state.canonical_head_index.map_or(false, |head| head == index);
+
+                        if is_canonical_head {
+                            tracing::debug!(
+                                game_index = %index,
+                                "Retaining canonical head game in cache despite zero credit"
+                            );
+                        } else {
+                            state.games.remove(&index);
+                        }
                     }
                     GameSyncAction::RemoveSubtree(index) => {
                         state.remove_subtree(index);


### PR DESCRIPTION
## Problem
The proposer prunes `DEFENDER_WINS` games once bond credit reaches zero. When the canonical head is pruned before any games are created, future descendants are orphaned.

The canonical head never advances, and the proposer keeps trying to create the already-existing game, hitting `GameAlreadyExists`.

## Solution
Keep the canonical-head game cached while it’s still the tip.

