### PR TITLE
feat: load .env from the specified path before falling back to root

### DIFF
--- a/scripts/utils/bin/fetch_fault_dispute_game_config.rs
+++ b/scripts/utils/bin/fetch_fault_dispute_game_config.rs
@@ -214,7 +214,10 @@ async fn main() -> Result<()> {
     if let Some(root) = find_project_root() {
         dotenv::from_path(root.join(args.env_file)).ok();
     } else {
-        eprintln!("Warning: Could not find project root. {} file not loaded.", args.env_file);
+        // Try to load the env file in case it's present
+        if dotenv::from_path(args.env_file.clone()).is_err() {
+            eprintln!("Warning: Could not find project root. {} file not loaded.", args.env_file);
+        }
     }
 
     update_fdg_config().await?;

--- a/scripts/utils/bin/fetch_l2oo_config.rs
+++ b/scripts/utils/bin/fetch_l2oo_config.rs
@@ -152,13 +152,13 @@ struct Args {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Load the env file in case it's present
-    if !dotenv::from_path(args.env_file.clone()).is_ok() {
-        // This fetches the .env file from the project root. If the command is invoked in the contracts/
-        // directory, the .env file in the root of the repo is used.
-        if let Some(root) = find_project_root() {
-            dotenv::from_path(root.join(args.env_file)).ok();
-        } else {
+    // This fetches the .env file from the project root. If the command is invoked in the contracts/
+    // directory, the .env file in the root of the repo is used.
+    if let Some(root) = find_project_root() {
+        dotenv::from_path(root.join(args.env_file)).ok();
+    } else {
+        // Try to load the env file in case it's present
+        if dotenv::from_path(args.env_file.clone()).is_err() {
             eprintln!("Warning: Could not find project root. {} file not loaded.", args.env_file);
         }
     }


### PR DESCRIPTION
## Description

This is a follow-up on my last [PR](https://github.com/succinctlabs/op-succinct/pull/652), it will try to load the env file from the specified path or fallback to search in the root project.

This also allows the fetch-l2oo-config to work standalone.

> [!note]
> This change is backwards compatible