### PR TITLE
feat: add sp1Verifier() getter to OPSuccinctFaultDisputeGame

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -641,6 +641,11 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
         disputeGameFactory_ = DISPUTE_GAME_FACTORY;
     }
 
+    /// @notice Returns the SP1 verifier contract.
+    function sp1Verifier() external view returns (ISP1Verifier verifier_) {
+        verifier_ = SP1_VERIFIER;
+    }
+
     /// @notice Returns the rollup config hash.
     function rollupConfigHash() external view returns (bytes32 rollupConfigHash_) {
         rollupConfigHash_ = ROLLUP_CONFIG_HASH;


### PR DESCRIPTION
Adds public getter for the `SP1_VERIFIER` immutable variable to maintain consistency with other immutable getters and improve transparency.

This allows:
- Users/contracts to verify which SP1 verifier is being used
- Off-chain tools to validate proof verification configurations
- Easier debugging and deployment validation

Follows the existing pattern of exposing all immutable constructor parameters (disputeGameFactory, rollupConfigHash, aggregationVkey, etc.).