### PR TITLE
ci: Run e2e tests when dependencies change

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - 'Cargo.toml'
       - 'fault-proof/**'
       - 'bindings/**'
       - '.github/workflows/e2e-tests.yml'
@@ -12,6 +13,7 @@ on:
     branches:
       - main
     paths:
+      - 'Cargo.toml'
       - 'fault-proof/**'
       - 'bindings/**'
       - '.github/workflows/e2e-tests.yml'


### PR DESCRIPTION
Almost all the dependencies in fault-proof and bindings reference
workspace for their versions, so if the workspace versions change
the e2e tests should be run.