### PR TITLE
refactor: clean up bin/config.rs

### DIFF
--- a/scripts/utils/bin/config.rs
+++ b/scripts/utils/bin/config.rs
@@ -1,39 +1,38 @@
 use alloy_primitives::B256;
-use anyhow::Result;
 use clap::Parser;
-use op_succinct_client_utils::{boot::hash_rollup_config, types::u32_to_u8};
+use op_succinct_client_utils::boot::hash_rollup_config;
 use op_succinct_elfs::AGGREGATION_ELF;
 use op_succinct_host_utils::fetcher::OPSuccinctDataFetcher;
 use op_succinct_proof_utils::get_range_elf_embedded;
-use op_succinct_scripts::ConfigArgs;
 use sp1_sdk::{utils, HashableKey, Prover, ProverClient};
+
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ConfigArgs {
+    /// The environment file to use.
+    #[arg(long)]
+    pub env_file: Option<PathBuf>,
+}
 
 // Get the verification keys for the ELFs and check them against the contract.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     let args = ConfigArgs::parse();
+    if let Some(path) = args.env_file {
+        dotenv::from_path(path)?;
+    }
+    utils::setup_logger();
 
     let prover = ProverClient::builder().cpu().build();
-
     let (_, range_vk) = prover.setup(get_range_elf_embedded());
-
-    // Get the 32 byte commitment to the vkey from vkey.vk.hash_u32()
-    let range_vk_hash = B256::from(u32_to_u8(range_vk.vk.hash_u32()));
-    println!("Range Verification Key Hash: {range_vk_hash}");
-
+    println!("Range Verification Key Hash: {}", B256::from(range_vk.hash_bytes()));
     let (_, agg_vk) = prover.setup(AGGREGATION_ELF);
     println!("Aggregation Verification Key Hash: {}", agg_vk.bytes32());
 
-    if let Some(env_file) = args.env_file {
-        dotenv::from_path(env_file).ok();
-
-        utils::setup_logger();
-
-        let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
-
-        let rollup_config = data_fetcher.rollup_config.as_ref().unwrap();
-        println!("Rollup Config Hash: 0x{:x}", hash_rollup_config(rollup_config));
-    }
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+    let rollup_config = data_fetcher.rollup_config.as_ref().unwrap();
+    println!("Rollup Config Hash: {}", hash_rollup_config(rollup_config));
 
     Ok(())
 }

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -35,10 +35,3 @@ pub struct HostExecutorArgs {
     #[clap(long)]
     pub safe_db_fallback: bool,
 }
-
-#[derive(Debug, Clone, Parser)]
-pub struct ConfigArgs {
-    /// The environment file to use.
-    #[arg(long)]
-    pub env_file: Option<PathBuf>,
-}


### PR DESCRIPTION
This PR cleans up `bin/config.rs`.

The main change is that it uses `range_vk.hash_bytes()` instead of `B256::from(u32_to_u8(range_vk.vk.hash_u32()));`. Note that this change is equivalent because the implementation of `.hash_bytes()` is:

```rust
pub trait HashableKey {
    /// Hash the key into a digest of bytes elements.
    fn hash_bytes(&self) -> [u8; DIGEST_SIZE * 4] {
        words_to_bytes_be(&self.hash_u32())
    }
    ...
}

// some other related codes

impl HashableKey for SP1VerifyingKey {
    fn hash_u32(&self) -> [u32; DIGEST_SIZE] {
        self.vk.hash_u32()
    }
    ...
}

pub fn words_to_bytes_be(words: &[u32; 8]) -> [u8; 32] {
    let mut bytes = [0u8; 32];
    for i in 0..8 {
        let word_bytes = words[i].to_be_bytes();
        bytes[i * 4..(i + 1) * 4].copy_from_slice(&word_bytes);
    }
    bytes
}
```

Example output:

```
Range Verification Key Hash: 0x3ff25eee3666121a2d276f231daca85041d0ac866e3d5fda3214f7d4041a4570
Aggregation Verification Key Hash: 0x007eaf0b5bc3bb33c21517a421a1244b634af16f3c26d5e637c0c9ac374ea9c2
Rollup Config Hash: 0xf5906156280da1d07f84b1073ffd27b78d4b2031840604a28ee807d1d9389f9e
```