### PR TITLE
test(fault-proof): add test_challenger_wins_cascade_removal

### DIFF
--- a/fault-proof/tests/common/env.rs
+++ b/fault-proof/tests/common/env.rs
@@ -315,6 +315,14 @@ impl TestEnvironment {
         Ok(portal)
     }
 
+    /// Create a fault dispute game instance as the proposer by default
+    pub async fn fault_dispute_game(
+        &self,
+        game_address: Address,
+    ) -> Result<OPSuccinctFaultDisputeGameInstance<impl alloy_provider::Provider + Clone>> {
+        self.fault_dispute_game_with_role(game_address, Role::Proposer).await
+    }
+
     /// Create a fault dispute game instance with a provider for the specified role
     pub async fn fault_dispute_game_with_role(
         &self,
@@ -347,7 +355,7 @@ impl TestEnvironment {
     }
 
     pub async fn resolve_game(&self, address: Address) -> Result<TransactionReceipt> {
-        let game = self.fault_dispute_game_with_role(address, Role::Proposer).await?;
+        let game = self.fault_dispute_game(address).await?;
         let receipt =
             game.resolve().send().await?.with_required_confirmations(1).get_receipt().await?;
         Ok(receipt)
@@ -358,7 +366,7 @@ impl TestEnvironment {
         game_address: Address,
         recipient: Address,
     ) -> Result<TransactionReceipt> {
-        let game = self.fault_dispute_game_with_role(game_address, Role::Proposer).await?;
+        let game = self.fault_dispute_game(game_address).await?;
         let receipt = game
             .claimCredit(recipient)
             .send()

--- a/fault-proof/tests/e2e.rs
+++ b/fault-proof/tests/e2e.rs
@@ -453,9 +453,7 @@ mod e2e {
                 let new_game_info = factory.gameAtIndex(new_game_index).call().await?;
 
                 // Check that the new game doesn't build on the invalid chain
-                let new_game = env
-                    .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                    .await?;
+                let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
 
                 let claim_data = new_game.claimData().call().await?;
 
@@ -522,9 +520,7 @@ mod e2e {
         info!("=== Phase 2: Creating Child Game with Valid Parent ===");
 
         // Double-check parent game status right before creating child
-        let parent_game = env
-            .fault_dispute_game_with_role(parent_game_address, common::env::Role::Proposer)
-            .await?;
+        let parent_game = env.fault_dispute_game(parent_game_address).await?;
 
         let parent_status = parent_game.status().call().await?;
         info!("Parent game status right before child creation: {:?}", parent_status);
@@ -623,9 +619,7 @@ mod e2e {
                 let new_game_info = factory.gameAtIndex(new_game_index).call().await?;
 
                 // Check that the new game doesn't build on the challenged parent chain
-                let new_game = env
-                    .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                    .await?;
+                let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
                 let claim_data = new_game.claimData().call().await?;
 
                 // The new game should be a new anchor game (parentIndex = u32::MAX)
@@ -754,9 +748,7 @@ mod e2e {
             if current_count > b1_index + U256::from(1) {
                 let new_game_index = current_count - U256::from(1);
                 let new_game_info = factory.gameAtIndex(new_game_index).call().await?;
-                let new_game = env
-                    .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                    .await?;
+                let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
                 let claim_data = new_game.claimData().call().await?;
 
                 assert_eq!(
@@ -883,9 +875,7 @@ mod e2e {
         while i < current_game_count {
             // Verify the new game is built on the last valid game at index 1
             let new_game_info = factory.gameAtIndex(i).call().await?;
-            let new_game = env
-                .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                .await?;
+            let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
             let claim_data = new_game.claimData().call().await?;
             if claim_data.parentIndex == EXPECTED_PARENT_INDEX {
                 found = true;


### PR DESCRIPTION
Adds integrations test that tests `CHALLENGER_WINS` cascade removal at various tree positions.