### PR TITLE
test(fault-proof): add more targeted integrations tests

### DIFF
--- a/fault-proof/tests/common/env.rs
+++ b/fault-proof/tests/common/env.rs
@@ -355,7 +355,7 @@ impl TestEnvironment {
     }
 
     pub async fn resolve_game(&self, address: Address) -> Result<TransactionReceipt> {
-        let game = self.fault_dispute_game_with_role(address, Role::Proposer).await?;
+        let game = self.fault_dispute_game(address).await?;
         let receipt =
             game.resolve().send().await?.with_required_confirmations(1).get_receipt().await?;
         Ok(receipt)

--- a/fault-proof/tests/e2e.rs
+++ b/fault-proof/tests/e2e.rs
@@ -453,9 +453,7 @@ mod e2e {
                 let new_game_info = factory.gameAtIndex(new_game_index).call().await?;
 
                 // Check that the new game doesn't build on the invalid chain
-                let new_game = env
-                    .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                    .await?;
+                let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
 
                 let claim_data = new_game.claimData().call().await?;
 
@@ -522,9 +520,7 @@ mod e2e {
         info!("=== Phase 2: Creating Child Game with Valid Parent ===");
 
         // Double-check parent game status right before creating child
-        let parent_game = env
-            .fault_dispute_game_with_role(parent_game_address, common::env::Role::Proposer)
-            .await?;
+        let parent_game = env.fault_dispute_game(parent_game_address).await?;
 
         let parent_status = parent_game.status().call().await?;
         info!("Parent game status right before child creation: {:?}", parent_status);
@@ -623,9 +619,7 @@ mod e2e {
                 let new_game_info = factory.gameAtIndex(new_game_index).call().await?;
 
                 // Check that the new game doesn't build on the challenged parent chain
-                let new_game = env
-                    .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                    .await?;
+                let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
                 let claim_data = new_game.claimData().call().await?;
 
                 // The new game should be a new anchor game (parentIndex = u32::MAX)
@@ -754,9 +748,7 @@ mod e2e {
             if current_count > b1_index + U256::from(1) {
                 let new_game_index = current_count - U256::from(1);
                 let new_game_info = factory.gameAtIndex(new_game_index).call().await?;
-                let new_game = env
-                    .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                    .await?;
+                let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
                 let claim_data = new_game.claimData().call().await?;
 
                 assert_eq!(
@@ -883,9 +875,7 @@ mod e2e {
         while i < current_game_count {
             // Verify the new game is built on the last valid game at index 1
             let new_game_info = factory.gameAtIndex(i).call().await?;
-            let new_game = env
-                .fault_dispute_game_with_role(new_game_info.proxy_, common::env::Role::Proposer)
-                .await?;
+            let new_game = env.fault_dispute_game(new_game_info.proxy_).await?;
             let claim_data = new_game.claimData().call().await?;
             if claim_data.parentIndex == EXPECTED_PARENT_INDEX {
                 found = true;


### PR DESCRIPTION
## Changes
- Add test_anchor_with_zero_credit_sibling_and_in_progress_branch to cover eviction of a zero-credit sibling while retaining the anchor and selecting an in-progress branch as canonical head.
- Add test_anchor_with_challenger_pruning_and_zero_credit_eviction to cover combined CHALLENGER_WINS pruning, zero-credit eviction, and anchor retention in a single sync pass.
-  Add test_in_progress_proposal_status_multi_branch to cover divergent proposal statuses on sibling branches (Challenged vs UnchallengedAndValidProofProvided) in a single sync and ensure should_attempt_to_resolve flags and canonical head selection stay correct.
- Add test_three_sibling_states_eviction_and_pruning to cover three root siblings (zero-credit DEFENDER_WINS, CHALLENGER_WINS, zero-credit anchor) and verify, in one sync, that challenger wins branches are pruned, non-anchor zero-credit games are evicted, and a finalized zero-credit anchor is retained/canonical.