### PR TITLE
fix(validity): add DISTINCT to fetch_completed_ranges query

### DIFF
--- a/validity/src/db/client.rs
+++ b/validity/src/db/client.rs
@@ -424,7 +424,7 @@ impl DriverDBClient {
         l2_chain_id: i64,
     ) -> Result<Vec<(i64, i64)>, Error> {
         let blocks = sqlx::query!(
-            "SELECT start_block, end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC",
+            "SELECT DISTINCT start_block, end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC",
             &commitment.range_vkey_commitment[..],
             &commitment.rollup_config_hash[..],
             RequestStatus::Complete as i16,


### PR DESCRIPTION
## Summary

Adds `DISTINCT` to the `fetch_completed_ranges` SQL query to prevent duplicate completed range entries from breaking the contiguous block calculation.

## Problem

When duplicate completed range proof entries exist in the database for the same `(start_block, end_block)` range, the `get_highest_proven_contiguous_block()` function incorrectly detects a "gap" and stops advancing.

### Root Cause

The query in `fetch_completed_ranges()` (`client.rs:427`) returns ALL matching rows without deduplication:

```sql
SELECT start_block, end_block FROM requests WHERE ...
```

When duplicates exist, after sorting by `start_block`, the result looks like:
```
[(17549420, 17550020), (17549420, 17550020), (17550020, 17550620), ...]
```

The `get_highest_proven_contiguous_block()` algorithm then:
1. Sets `current_end = 17550020` (first range's end)
2. Checks next entry: `proof.0 = 17549420 != current_end = 17550020`
3. **Breaks immediately**, thinking there's a gap

### Real-World Example (Katana Mainnet)

We observed this on production where:
- `highest_contiguous_proven_block` was stuck at **17,550,020**
- New proofs were being generated for blocks **17,576,720 - 17,579,420** (~27K blocks ahead)
- The metric wasn't advancing despite proofs completing

Database showed duplicate completed entries:
```
start_block   end_block    status
17549420      17550020     4 (Complete)
17549420      17550020     4 (Complete)  <- DUPLICATE
17550020      17550620     4 (Complete)
17550020      17550620     4 (Complete)  <- DUPLICATE
...
```

Gap analysis confirmed the issue:
```sql
SELECT end_block, LEAD(start_block) OVER (ORDER BY start_block) - end_block as gap
FROM requests WHERE status = 4 ...

end_block   gap
17550020    -600  <- Negative gap indicates duplicate/out-of-order
17550020    -600
```

## Solution

Add `DISTINCT` to the query:
```sql
SELECT DISTINCT start_block, end_block FROM requests WHERE ...
```

This ensures each unique `(start_block, end_block)` pair appears only once, allowing the contiguous chain calculation to work correctly.

## Test Plan

- [x] Verify the fix on a database with duplicate completed entries
- [x] Confirm `highest_contiguous_proven_block` advances correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)