### PR TITLE
docs: add RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,10 +45,10 @@ just build-elfs
 ### 3. Create Version Bump PR
 
 ```bash
-git checkout -b chore/bump-vX.Y.Z
+git checkout -b release/vX.Y.Z
 git add Cargo.toml Cargo.lock elf/
 git commit -m "chore: bump to vX.Y.Z"
-git push origin chore/bump-vX.Y.Z
+git push origin release/vX.Y.Z
 ```
 
 Merge the PR after review.

--- a/justfile
+++ b/justfile
@@ -385,10 +385,10 @@ vkeys:
     echo "## Verification Key Hashes"
     echo ""
     echo "| Program | Verification Key Hash |"
-    echo "|--------|-------------|"
+    echo "|--------|------------------------|"
     echo "| Ethereum DA Range Verification Key | **$ETH_RANGE** |"
     echo "| Celestia DA Range Verification Key | **$CEL_RANGE** |"
-    echo "| Eigen DA Range Verification Key | **$EIGEN_RANGE** |"
+    echo "| EigenDA Range Verification Key | **$EIGEN_RANGE** |"
     echo "| Aggregation Verification Key | **$AGG_KEY** |"
 
 # Build all ELF files.


### PR DESCRIPTION
Adds RELEASE.md documenting the release process including versioning scheme, pre-release checklist, and step-by-step instructions for cutting releases.

Also adds a just vkeys recipe that generates verification key hashes for all DA variants (Ethereum, Celestia, EigenDA) in a markdown table format, ready to copy into GitHub release notes for better quality of life.