### PR TITLE
docs: clarify SP1 mock verifier auto-deployment behavior

### DIFF
--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -46,7 +46,9 @@ Create a `.env` file in the project root directory with the following variables:
 
 ### SP1 Verifier Configuration
 
-For testing, deploy a [Mock Verifier](../validity/quick-start.md#step-2-deploy-an-sp1mockverifier-for-verifying-mock-proofs). If you do this, make sure to set the `OP_SUCCINCT_MOCK` environment variable to `true`, and set the `VERIFIER_ADDRESS` to your newly deployed mock verifier.
+**For testing**: Set `OP_SUCCINCT_MOCK=true`. The deployment script will automatically deploy a new `SP1MockVerifier` contract — no need to set `VERIFIER_ADDRESS`.
+
+**For production**: Leave `OP_SUCCINCT_MOCK` unset (defaults to `false`) and optionally set `VERIFIER_ADDRESS` to a custom verifier. If `VERIFIER_ADDRESS` is not set, it defaults to Succinct's official Groth16 VerifierGateway.
 
 ## Deployment
 
@@ -68,8 +70,8 @@ The deployment script deploys the contracts with the following parameters:
 | `PERMISSIONLESS_MODE` | If set to true, anyone can propose or challenge games. Default: `false` | `true` or `false` |
 | `FALLBACK_TIMEOUT_FP_SECS` | Timeout in seconds after which permissionless proposing is allowed if no proposal has been made. | `1209600` (for 2 weeks) |
 | `STARTING_L2_BLOCK_NUMBER` | Starting L2 block number in decimal. Default: \<Latest L2 Finalized block\> - \<Number of blocks since the `DISPUTE_GAME_FINALITY_SECONDS`>  | `786000` |
-| `VERIFIER_ADDRESS` | Default: Succinct's official Groth16 VerifierGateway. Address of the `ISP1Verifier` contract used to verify proofs. For mock proofs, this is the address of the `SP1MockVerifier` contract. | `0x...` |
-| `OP_SUCCINCT_MOCK` | Default: `false`. If true, this verifies mock SP1 proofs instead of real proofs, in order for faster and cheaper testing. | `true` or `false` |
+| `VERIFIER_ADDRESS` | Default: Succinct's official Groth16 VerifierGateway. Address of the `ISP1Verifier` contract used to verify proofs. **Ignored when `OP_SUCCINCT_MOCK=true`**. | `0x...` |
+| `OP_SUCCINCT_MOCK` | Default: `false`. If `true`, the deployment script automatically deploys a new `SP1MockVerifier` for testing (faster and cheaper than real proofs). | `true` or `false` |
 
 Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 


### PR DESCRIPTION
Update fault proofs deployment documentation to clarify:
- OP_SUCCINCT_MOCK=true auto-deploys SP1MockVerifier (no manual setup)
- VERIFIER_ADDRESS is ignored when mock mode is enabled
- Production defaults to Succinct's Groth16 VerifierGateway