### PR TITLE
fix(fault-proof): sort defense candidates by deadline ascending

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -295,6 +295,25 @@ where
         state.games.get(&index).cloned()
     }
 
+    /// Spawns game defense tasks for testing. Returns true if any tasks were spawned.
+    #[cfg(feature = "integration")]
+    pub async fn spawn_defense_tasks_for_test(&self) -> Result<bool> {
+        self.spawn_game_defense_tasks().await
+    }
+
+    /// Returns the list of game addresses with active defense proving tasks (for testing).
+    #[cfg(feature = "integration")]
+    pub async fn get_active_defense_game_addresses(&self) -> Vec<Address> {
+        let tasks = self.tasks.lock().await;
+        tasks
+            .iter()
+            .filter_map(|(_, (_, info))| match info {
+                TaskInfo::GameProving { game_address, is_defense: true } => Some(*game_address),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Runs the proposer indefinitely.
     pub async fn run(self: Arc<Self>) -> Result<()> {
         tracing::info!("OP Succinct Proposer running...");

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -41,7 +41,7 @@ pub async fn init_proposer(
         proposal_interval_in_blocks: 10, // Much smaller interval for testing
         fetch_interval: 5,               // Check more frequently in tests
         game_type,
-        max_concurrent_defense_tasks: 0,
+        max_concurrent_defense_tasks: 1,
         safe_db_fallback: false,
         metrics_port: 9000,
         fast_finality_proving_limit: 0,


### PR DESCRIPTION
Adds deadline-based prioritization when defending challenged games, ensuring games closest to expiring are defended first.