### PR TITLE
fix: disable span list in logger JSON output

### DIFF
--- a/utils/host/src/logger.rs
+++ b/utils/host/src/logger.rs
@@ -71,7 +71,12 @@ pub fn setup_logger() {
                     // Initialize with JSON formatting
                     Some(Box::new(
                         tracing_subscriber::fmt::layer()
-                            .event_format(tracing_subscriber::fmt::format().json())
+                            .event_format(
+                                tracing_subscriber::fmt::format()
+                                    .json()
+                                    .with_span_list(false)
+                                    .with_current_span(false)
+                            )
                             .with_filter(build_env_filter()),
                     ))
                 }


### PR DESCRIPTION
This pull request makes a targeted improvement to the logger configuration in `utils/host/src/logger.rs`. The change disables the inclusion of span lists and the current span in the JSON-formatted log output, fixing the issues detected when enabling JSON logging, example:

```
{"timestamp":"2025-12-10T14:09:57.132320Z","level":"WARN","fields":{"message":"No range proof requests inserted into the database."},"target":"op_succinct_validity::proposer","span":{"field_error":"EOF while parsing a value at line 1 column 0","name":"proposer.add_new_ranges"},"spans":[{"field_error":"EOF while parsing a value at line 1 column 0","name":"proposer.run"},{"field_error":"EOF while parsing a value at line 1 column 0","name":"proposer.add_new_ranges"}]}
```

- Logging configuration update:
  * Modified the logger setup to use JSON formatting without including span lists or the current span in the output. (`utils/host/src/logger.rs`)