### PR TITLE
fix(fault-proof): improve network proof handling with retry logic

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -932,7 +932,6 @@ where
 
             Ok((proof, total_instruction_cycles, total_sp1_gas))
         } else {
-            // Step 1: Submit the proof request
             tracing::info!("Submitting range proof request to network");
             let proof_id = self
                 .prover
@@ -950,7 +949,6 @@ where
                 .request_async()
                 .await?;
 
-            // Step 2: Wait for proof completion and download
             let proof = self.wait_for_proof(proof_id, "range").await?;
 
             Ok((proof, 0, 0))
@@ -980,7 +978,6 @@ where
                 SP1_CIRCUIT_VERSION,
             )
         } else {
-            // Step 1: Submit the proof request (only once, no retry here)
             tracing::info!("Submitting aggregation proof request to network");
             let proof_id = self
                 .prover
@@ -997,7 +994,6 @@ where
                 .request_async()
                 .await?;
 
-            // Step 2: Wait for proof completion and download (with retry on network errors)
             self.wait_for_proof(proof_id, "aggregation").await?
         };
 


### PR DESCRIPTION
### Background
The current prove_game implementation uses blocking mode (run_async()) to submit proof requests to SP1 Network. This causes resource waste when network instability occurs:
- Poor error recovery: Any network error forces a complete restart of the proving process
- Resource waste: Transient network issues lead to redundant proof generation and wasted SP1 costs

### Solution
Enhances network proof request handling for SP1 Network with robust retry and error handling:

- Split proof generation into request + polling pattern (`request_async()` + `wait_for_proof()`)
- Add retry logic for transient query failures (up to 600 attempts / 10 min)
- Handle `Unfulfillable` status with immediate failure
- Improve logging for network proof submission and status tracking
- Apply to both range and aggregation proofs

Fixes potential issues where network proof requests would fail silently or timeout without proper error reporting.