### PR TITLE
test: add fault game coverage

### DIFF
--- a/contracts/test/fp/AccessManager.t.sol
+++ b/contracts/test/fp/AccessManager.t.sol
@@ -108,6 +108,7 @@ contract AccessManagerTest is Test {
         vm.prank(owner);
         accessManager.setProposer(address(0), true);
 
+        assertTrue(accessManager.isProposalPermissionlessMode());
         assertTrue(accessManager.isAllowedProposer(proposer1));
         assertTrue(accessManager.isAllowedProposer(randomUser));
         assertTrue(accessManager.isAllowedProposer(address(0x9999)));


### PR DESCRIPTION
## Summary

Cherry-pick of #562 by @TiesD.

- Adds test coverage for `OPSuccinctFaultDisputeGame` getters: `createdAt()`, `extraData()`, `parentIndex()`, `anchorStateRegistry()`, `accessManager()`, `wasRespectedGameTypeWhenCreated()`, `credit()`, and `gameOver()`
- Adds test coverage for `AccessManager.isProposalPermissionlessMode()`
- Fixes comment accuracy (1 hour → 2 weeks timeout)

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)