### PR TITLE
fix(ci): prevent duplicate misspell check run in GitHub UI

### DIFF
--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -27,7 +27,8 @@ jobs:
         id: check_for_typos
         uses: reviewdog/action-misspell@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
           path: "./book"
           locale: "US"
           exclude: |


### PR DESCRIPTION
## Summary
- Fix duplicate/misassociated `misspell` check run appearing under wrong workflows in GitHub UI
- Switch reviewdog reporter from `github-pr-check` to `github-pr-review`

## Problem
The `reviewdog/action-misspell` action was creating a separate check run via the GitHub Checks API that got incorrectly associated with other workflows' check suites. This caused confusing UI display like:
- "Build OP Succinct Lite Docker Images / misspell (push)" ❌ unexpected
- "Spell Checker / runner / misspell (pull_request)" ✅ expected

## Root Cause
The `github-pr-check` reporter creates a standalone check run that GitHub assigns to whatever check suite it chooses, often the wrong one.

## Solution
Switch to `github-pr-review` reporter which:
- Posts inline PR review comments for spelling errors (more useful!)
- Does not create a separate check run
- The workflow job `runner / misspell` still reports pass/fail status

## Test plan
- [ ] Verify no duplicate `misspell` check appears in CI after merge
- [ ] Verify spelling errors still cause CI failure
- [ ] Verify inline review comments appear on PRs with spelling issues