### PR TITLE
fix: use the optimized L1 head when generating range proof

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -913,8 +913,8 @@ where
         tracing::info!("Attempting to prove game {:?}", game_address);
 
         let game = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
-        let l1_head_hash = game.l1Head().call().await?.0;
-        tracing::debug!("L1 head hash: {:?}", hex::encode(l1_head_hash));
+        let l1_head_hash: B256 = game.l1Head().call().await?.0.into();
+        tracing::debug!("L1 head hash: {:?}", l1_head_hash);
 
         let ranges = self
             .config
@@ -928,7 +928,7 @@ where
             let this = self.clone();
             async move {
                 tracing::info!("Generating Range Proof for blocks {start} to {end}");
-                let sp1_stdin = this.range_proof_stdin(start, end, l1_head_hash.into()).await?;
+                let sp1_stdin = this.range_proof_stdin(start, end).await?;
                 let (range_proof, inst_cycles, sp1_gas) =
                     this.prover.generate_range_proof(&sp1_stdin).await?;
                 Ok::<_, anyhow::Error>((idx, range_proof, inst_cycles, sp1_gas))
@@ -976,9 +976,7 @@ where
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let latest_l1_head = boot_infos.last().context("No boot infos generated")?.l1Head;
-
-        let headers = match self.fetcher.get_header_preimages(&boot_infos, latest_l1_head).await {
+        let headers = match self.fetcher.get_header_preimages(&boot_infos, l1_head_hash).await {
             Ok(headers) => headers,
             Err(e) => {
                 tracing::error!("Failed to get header preimages: {e}");
@@ -992,7 +990,7 @@ where
             boot_infos,
             headers,
             &self.prover.keys().range_vk,
-            latest_l1_head,
+            l1_head_hash,
             self.signer.address(),
         ) {
             Ok(s) => s,
@@ -1017,15 +1015,10 @@ where
         Ok((receipt.transaction_hash, total_instruction_cycles, total_sp1_gas))
     }
 
-    async fn range_proof_stdin(
-        &self,
-        start_block: u64,
-        end_block: u64,
-        l1_head_hash: B256,
-    ) -> Result<SP1Stdin> {
+    async fn range_proof_stdin(&self, start_block: u64, end_block: u64) -> Result<SP1Stdin> {
         let host_args = self
             .host
-            .fetch(start_block, end_block, Some(l1_head_hash), self.config.safe_db_fallback)
+            .fetch(start_block, end_block, None, self.config.safe_db_fallback)
             .await
             .context("Failed to get host CLI args")?;
 


### PR DESCRIPTION
This PR prevents unnecessary L1 block headers from being added to the range proof, which is particularly beneficial when there is a large gap between the game creation time and the L2 end block.