### PR TITLE
feat: support compressed proofs and add fetch-l2oo-config

### DIFF
--- a/validity/Dockerfile
+++ b/validity/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-
+ENV SQLX_OFFLINE=true
 WORKDIR /build
 
 # Install SP1
@@ -25,8 +25,9 @@ COPY . .
 RUN --mount=type=ssh \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/build/target \
-    cargo build --bin validity --release && \
-    cp target/release/validity /build/validity-proposer
+    cargo build --bin validity --bin fetch-l2oo-config --release && \
+    cp target/release/validity /build/validity-proposer && \
+    cp target/release/fetch-l2oo-config /build/fetch-l2oo-config
 
 # Final stage
 FROM rust:1.85-slim
@@ -52,6 +53,7 @@ RUN curl -L https://sp1.succinct.xyz | bash && \
 
 # Copy only the built binaries from builder
 COPY --from=builder /build/validity-proposer /usr/local/bin/validity-proposer
+COPY --from=builder /build/fetch-l2oo-config /usr/local/bin/fetch-l2oo-config
 
 # Run the server from its permanent location
 CMD ["/usr/local/bin/validity-proposer"]

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -98,10 +98,11 @@ pub async fn read_proposer_env() -> Result<EnvironmentConfig> {
 
     // Parse proof mode
     let agg_proof_mode =
-        if get_env_var("AGG_PROOF_MODE", Some("plonk".to_string()))?.to_lowercase() == "groth16" {
-            SP1ProofMode::Groth16
-        } else {
-            SP1ProofMode::Plonk
+        match get_env_var("AGG_PROOF_MODE", Some("plonk".to_string()))?.to_lowercase().as_str() {
+            "plonk" => SP1ProofMode::Plonk,
+            "groth16" => SP1ProofMode::Groth16,
+            "compressed" => SP1ProofMode::Compressed,
+            _ => SP1ProofMode::Plonk, // Default to Plonk if no match
         };
 
     // Optional loop interval


### PR DESCRIPTION
Set SQLX_OFFLINE=true in the Dockerfile to enable offline sqlx builds.

When compressed proof mode is selected, serialize the full proof struct with bincode (big-endian, fixint encoding) before storing it in the DB; other modes continue to use proof.bytes().

Also build and include the additional helper binary in the final image.