### PR TITLE
feat: add backport automation for multi-version release management

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,44 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' }}
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-x64
+      - run-id=${{ github.run_id }}
+      - spot=false
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(toJSON(github.event.pull_request.labels.*.name), 'backport/')
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          label_pattern: "^backport/(?<base>([^ ]+))$"
+          title_template: "[Backport <%= base %>] <%= title %>"
+          body_template: |
+            Backport of #<%= number %> to `<%= base %>`.
+
+            Original PR: <%= mergeCommitSha %>
+
+            ---
+            <details>
+            <summary>Original description</summary>
+
+            <%= body %>
+            </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,45 @@ If you're experiencing an issue, please open a [GitHub Issue](https://github.com
 
 At this time, we will not be accepting contributions that only fix spelling or grammatical errors in documentation, code or elsewhere.
 
+## Backporting Changes
+
+OP Succinct maintains multiple release lines (e.g., `main` for v4.x development, `release/v3.x` for v3.x maintenance). When a fix or non-breaking feature should be applied to a maintenance branch, we use automated backporting.
+
+### How It Works
+
+1. **Add the label**: When creating a PR to `main`, add the `backport/v3.x` label if the change should also be applied to the v3.x release line.
+2. **Merge to main**: Get your PR reviewed and merged as usual.
+3. **Automation creates backport PR**: A GitHub Action automatically cherry-picks your changes and creates a PR targeting `release/v3.x`.
+4. **Review and merge**: Review the backport PR and merge it.
+
+### When to Use Labels
+
+| Label | When to Use |
+|-------|-------------|
+| `backport/v3.x` | Bug fixes, non-breaking features, documentation updates that should also be in v3.x |
+| `no-backport` | Breaking changes, features that depend on v4.x-only code, changes not applicable to v3.x |
+
+### Handling Conflicts
+
+If the cherry-pick fails due to conflicts:
+1. The automation will post a comment on your original PR explaining the conflict.
+2. You'll need to manually cherry-pick and resolve conflicts:
+   ```bash
+   git checkout release/v3.x
+   git checkout -b backport/your-pr-number
+   git cherry-pick <commit-sha>
+   # Resolve conflicts
+   git push origin backport/your-pr-number
+   ```
+3. Open a PR from your backport branch to `release/v3.x`.
+
+### Changes Requiring Modification
+
+Some changes may need modification when backported (e.g., different API names between versions). In these cases:
+1. Do not use the `backport/v3.x` label.
+2. Manually cherry-pick and adjust the code as needed.
+3. Open a PR with the modified backport.
+
 *Adapted from the [Reth contributing guide](https://github.com/paradigmxyz/reth/blob/main/CONTRIBUTING.md).*  
 
 


### PR DESCRIPTION
Implements GitHub label-based backport automation using tibdex/backport GitHub Action.

- Automatically cherry-picks changes from main to maintenance branches (e.g., release/v3.x)
- Detects backport/* labels on merged PRs and creates backport PRs
- Posts comments on original PRs when conflicts are detected
- Adds contributor documentation explaining when to use backport/v3.x and no-backport labels

Closes #784.