### PR TITLE
ci(pr-title): add backport as valid PR title type

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,3 +25,17 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            backport


### PR DESCRIPTION
## Summary
Adds `backport` as a valid conventional commit type for PR titles.

This allows backport PRs to use the format `backport: <original title>` and pass the PR title check.

## Context
- Previous backport PRs had to be force-merged due to title check failures
- Examples: #790, #791