### PR TITLE
chore(contracts): bump semver for ABI-breaking changes

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -132,8 +132,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     AccessManager internal immutable ACCESS_MANAGER;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 2.0.0
+    string public constant version = "2.0.0";
 
     /// @notice The starting timestamp of the game.
     Timestamp public createdAt;

--- a/contracts/src/validity/OPSuccinctDisputeGame.sol
+++ b/contracts/src/validity/OPSuccinctDisputeGame.sol
@@ -33,8 +33,8 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
     bool public wasRespectedGameTypeWhenCreated;
 
     /// @notice Semantic version.
-    /// @custom:semver v3.0.0
-    string public constant version = "v3.0.0";
+    /// @custom:semver v4.0.0
+    string public constant version = "v4.0.0";
 
     constructor(address _l2OutputOracle, IAnchorStateRegistry _anchorStateRegistry) {
         L2_OUTPUT_ORACLE = _l2OutputOracle;


### PR DESCRIPTION
PR #774 introduced ABI-breaking changes without bumping contract versions:

- **OPSuccinctDisputeGame**: function rename (`l2BlockNumber()` → `l2SequenceNumber()`), constructor signature change
- **OPSuccinctFaultDisputeGame**: public state variable type change (`OutputRoot` → `Proposal`)

These changes break calling convention for any consumer expecting the old ABI. This PR bumps contract versions to reflect the breaking changes and align with semver policy:

- `OPSuccinctDisputeGame`: v3.0.0 → v4.0.0
- `OPSuccinctFaultDisputeGame`: 1.0.0 → 2.0.0

All tests pass; no logic changes.