### PR TITLE
fix: avoid double CPU prover initialization in multi binary

### DIFF
--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -85,10 +85,9 @@ async fn main() -> Result<()> {
         generate_stdin().await?
     };
 
-    let prover = ProverClient::from_env();
-
     if args.prove {
         // If the prove flag is set, generate a proof.
+        let prover = ProverClient::from_env();
         let (pk, _) = prover.setup(get_range_elf_embedded());
         // Generate proofs in compressed mode for aggregation verification.
         let proof = prover.prove(&pk, &sp1_stdin).compressed().run().unwrap();


### PR DESCRIPTION
## Summary
- Move `ProverClient::from_env()` inside the `if args.prove` block in `scripts/prove/bin/multi.rs`
- Previously, running `multi` without `--prove` would initialize two CPU provers: one unconditionally at line 88 and another inside `execute_multi()` — wasting startup time
- Now the prover is only created when `--prove` is actually passed

## Test plan
- [ ] Run `RUST_LOG=info cargo run --bin multi --release -- --start <block> --end <block> --cache` (without `--prove`) and confirm only one "initializing cpu prover" log line appears