### PR TITLE
fix(fault-proof): use l2BlockNumber() for backward compatibility with v1.0.0 games

### DIFF
--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -354,7 +354,7 @@ where
             return Ok(());
         }
 
-        let l2_block_number = contract.l2SequenceNumber().call().await?;
+        let l2_block_number = contract.l2BlockNumber().call().await?;
         let computed_output_root =
             self.l2_provider.compute_output_root_at_block(l2_block_number).await?;
         let output_root = contract.rootClaim().call().await?;

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -63,6 +63,10 @@ sol! {
         /// @notice The L2 sequence number (block number) for which this game is proposing an output root.
         function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_);
 
+        /// @notice The L2 block number for which this game is proposing an output root.
+        /// @dev Alias for l2SequenceNumber() for backward compatibility.
+        function l2BlockNumber() public pure returns (uint256 l2BlockNumber_);
+
         /// @notice Only the starting block number of the game.
         function startingBlockNumber() external view returns (uint256 startingBlockNumber_);
 

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1382,7 +1382,7 @@ where
 
         let contract = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
 
-        let l2_block = contract.l2SequenceNumber().call().await?;
+        let l2_block = contract.l2BlockNumber().call().await?;
         let output_root = self.l2_provider.compute_output_root_at_block(l2_block).await?;
         let claim = contract.rootClaim().call().await?;
         let was_respected = contract.wasRespectedGameTypeWhenCreated().call().await?;
@@ -2034,7 +2034,7 @@ where
         // Get the game block number to include in logs
         let game = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
         let starting_l2_block_number = game.startingBlockNumber().call().await?;
-        let l2_block_number = game.l2SequenceNumber().call().await?;
+        let l2_block_number = game.l2BlockNumber().call().await?;
         let start_block = starting_l2_block_number.to::<u64>();
         let end_block = l2_block_number.to::<u64>();
 


### PR DESCRIPTION
## Problem

During the op-contracts v5.0.0 upgrade (#774), the contract function was renamed from `l2BlockNumber()` to `l2SequenceNumber()`. While the Solidity contract maintains `l2BlockNumber()` as a backward-compatible alias, the Rust code was updated to call `l2SequenceNumber()` directly.

This causes a **critical startup failure** during contract upgrades:

1. When upgrading from `OPSuccinctFaultDisputeGame` v1.0.0 to v2.0.0, the `DisputeGameFactory` contains only v1.0.0 games
2. At startup, the proposer/challenger calls `sync_state()` to fetch the v1.0.0 games
3. For v1.0.0 games, calling `l2SequenceNumber()` fails because this function doesn't exist
4. The error causes `sync_state()` to fail and retry in a loop
5. The proposer/challenger never starts successfully

## Solution

Revert to using `l2BlockNumber()` in the Rust code, which exists on:
- ✅ v1.0.0 games (original function)
- ✅ v2.0.0 games (backward compatibility alias)