### PR TITLE
ci: add merge_group triggers and fix required check coverage

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,7 +14,6 @@ on:
     paths:
       - '.github/workflows/book.yml'
       - "book/**"
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -17,7 +17,7 @@ on:
       - 'scripts/**'
       - 'utils/**'
       - 'validity/**'
-
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/docker-build-lite.yml
+++ b/.github/workflows/docker-build-lite.yml
@@ -2,6 +2,7 @@ name: Build OP Succinct Lite Docker Images
 
 on:
   workflow_dispatch:
+  merge_group:
   push:
     paths-ignore:
       - '**/*.pdf'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,7 @@ name: Build OP Succinct Docker Images
 
 on:
   workflow_dispatch:
+  merge_group:
   push:
     paths-ignore:
       - '**/*.pdf'

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**/*.pdf'
       - '**/*.md'
+  merge_group:
   push:
     tags:
       - v[0-9]+.*

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -138,7 +138,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # sync is DA-agnostic (runs once), integration is DA-specific
+        # sync is DA-agnostic (runs once), integration is DA-specific.
+        # eigenda integration is excluded from merge_group (flaky due to
+        # external EigenDA dependency); it still runs on push-to-main and
+        # /integration comment triggers.
         include:
           - test: sync
             da: ethereum
@@ -146,6 +149,9 @@ jobs:
             da: ethereum
           - test: integration
             da: eigenda
+        exclude:
+          - test: ${{ github.event_name == 'merge_group' && 'integration' || 'NONE' }}
+            da: ${{ github.event_name == 'merge_group' && 'eigenda' || 'NONE' }}
 
     steps:
     - name: Get PR ref

--- a/.github/workflows/sqlx-check.yml
+++ b/.github/workflows/sqlx-check.yml
@@ -8,6 +8,7 @@ on:
       - 'sqlx-data.json'
       - 'Cargo.toml'
       - 'Cargo.lock'
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Add `merge_group` trigger to 5 workflows that previously only ran on PRs: Cargo Tests, SQLx Query Check, ELF, Docker Build, Docker Build Lite
- Remove `merge_group` from `book` workflow (docs-only, not a correctness gate)
- Exclude flaky eigenda integration test from merge queue matrix (still runs on push-to-main)

## Why

Only 4 checks were required in the merge queue ruleset, while 9+ checks ran without being required. This meant failures (like the `test_proposer_recovery_after_canonical_head_invalidation` eigenda flake) showed red but didn't block merges — confusing and noisy.

After this PR merges, the ruleset should be updated to require all merge queue checks:

```
Current required (4):
  Formatting & Clippy
  Fault Proof (sync)
  (./e2e/faultproof/bootstrap/...)
  (./e2e/validity/bootstrap/...)

Target required (all merge queue checks):
  + tests (Cargo Tests)
  + Verify SQLx queries
  + elf (ELF)
  + Build Docker Images
  + Build OP Succinct Lite Proposer
  + Build OP Succinct Lite Proposer Celestia
  + Build OP Succinct Lite Proposer EigenDA
  + Build OP Succinct Lite Challenger
  + (./e2e/faultproof/defense/...)
  + (./e2e/faultproof/recovery/...)
  + (./e2e/faultproof/fastfinality/...)
  + (./e2e/validity/recovery/...)
  + (./e2e/validity/proving/...)
  + Long Running (./e2e/faultproof/long-running/progress_test.go)
  + Long Running (./e2e/validity/long-running/progress_test.go)
  + Fault Proof (integration)
  + DA Host (eigenda)
```

## Test plan

- [ ] Verify merge queue triggers the new workflows correctly
- [ ] Update ruleset (Settings → Rules → Rulesets) after merge