### PR TITLE
fix(logger): let RUST_LOG override default log suppressions

### DIFF
--- a/utils/host/src/logger.rs
+++ b/utils/host/src/logger.rs
@@ -13,11 +13,8 @@ use tracing_subscriber::{
 static INIT: OnceLock<Result<()>> = OnceLock::new();
 
 fn build_env_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env()
-        .unwrap_or_else(|e| {
-            println!("failed to setup env filter: {e:?}");
-            EnvFilter::new("info")
-        })
+    // Defaults first: suppress noisy internal modules from kona/sp1.
+    let mut filter = EnvFilter::new("info")
         .add_directive("single_hint_handler=error".parse().unwrap())
         .add_directive("execute=error".parse().unwrap())
         .add_directive("sp1_prover=error".parse().unwrap())
@@ -33,7 +30,19 @@ fn build_env_filter() -> EnvFilter {
         .add_directive("host_server=error".parse().unwrap())
         .add_directive("kona_protocol=error".parse().unwrap())
         .add_directive("sp1_core_executor=off".parse().unwrap())
-        .add_directive("sp1_core_machine=error".parse().unwrap())
+        .add_directive("sp1_core_machine=error".parse().unwrap());
+
+    // RUST_LOG directives added last so they override matching defaults.
+    if let Ok(var) = env::var(EnvFilter::DEFAULT_ENV) {
+        for directive in var.split(',') {
+            match directive.trim().parse() {
+                Ok(d) => filter = filter.add_directive(d),
+                Err(e) => eprintln!("ignoring invalid RUST_LOG directive {directive:?}: {e}"),
+            }
+        }
+    }
+
+    filter
 }
 
 /// Set up the logger with optional OpenTelemetry export.


### PR DESCRIPTION
## Summary

- Fix: `RUST_LOG` directives can now override the hardcoded noise-suppression defaults
- Previously, directives like `single_hint_handler=error` were added **after** `RUST_LOG` parsing, always winning — making `RUST_LOG=single_hint_handler=debug` ineffective ([current code](https://github.com/succinctlabs/op-succinct/blob/ca9ca00e8448079b3854fb969ad4ece4fd458a2c/utils/host/src/logger.rs#L15-L33))
- Now defaults are applied first, then `RUST_LOG` directives are layered on top — matching targets get overridden, everything else stays suppressed
- Invalid directives in `RUST_LOG` are logged to stderr and skipped (previously silently ignored)

Based on #770 by @kien-rise — same problem, different fix approach. #770 returns early when `RUST_LOG` is set, which drops all noise suppression. This PR preserves defaults while allowing overrides.

## Test plan

- [x] `cargo check -p op-succinct-host-utils`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI