### PR TITLE
backport(fault-proof): remove orphan check from backup validation (#846)

### DIFF
--- a/fault-proof/src/backup.rs
+++ b/fault-proof/src/backup.rs
@@ -3,7 +3,7 @@
 //! On restart, the proposer can restore its cursor and game cache from a backup file,
 //! avoiding a full re-sync from the factory contract.
 
-use std::{collections::HashSet, io::Write, path::Path};
+use std::{io::Write, path::Path};
 
 use tempfile::NamedTempFile;
 
@@ -31,33 +31,22 @@ impl ProposerBackup {
         Self { version: BACKUP_VERSION, cursor, games, anchor_game_index }
     }
 
-    /// Validate backup integrity.
-    ///
-    /// Checks for:
-    /// - Cursor exists but no games (likely stale/corrupted)
-    /// - Anchor game index references a non-existent game
-    /// - Games with parent indices that don't exist in the backup (orphaned games)
+    /// Validate backup integrity. Rejects stale/corrupted backups but allows orphaned parent
+    /// references, which are normal when anchor-based fetching or ASR filtering produce partial
+    /// DAGs.
     pub fn validate(&self) -> Result<()> {
-        // Check: cursor exists but no games
+        // Cursor with no games indicates a stale or corrupted backup.
         if let Some(cursor) = self.cursor {
             if self.games.is_empty() && cursor > U256::ZERO {
                 bail!("cursor exists but no games");
             }
         }
 
-        // Check: anchor game index references non-existent game
+        // Anchor must reference a game that exists in the backup.
         if let Some(anchor_idx) = self.anchor_game_index {
             if !self.games.iter().any(|g| g.index == anchor_idx) {
                 bail!("anchor game index references non-existent game");
             }
-        }
-
-        // Check: games with orphaned parent references (parent_index == u32::MAX means genesis)
-        let game_indices: HashSet<U256> = self.games.iter().map(|g| g.index).collect();
-        if self.games.iter().any(|g| {
-            g.parent_index != u32::MAX && !game_indices.contains(&U256::from(g.parent_index))
-        }) {
-            bail!("games have orphaned parent references");
         }
 
         Ok(())

--- a/fault-proof/tests/backup.rs
+++ b/fault-proof/tests/backup.rs
@@ -35,13 +35,21 @@ mod validation {
     const M: u32 = u32::MAX;
 
     #[rstest]
+    // Valid cases
     #[case::empty(None, &[], None, true)]
     #[case::cursor_zero_no_games(Some(0), &[], None, true)]
     #[case::single_genesis_game(Some(0), &[(0, M)], None, true)]
     #[case::chain_with_anchor(Some(1), &[(0, M), (1, 0)], Some(1), true)]
+    // Orphan cases — valid because anchor-based fetch and ASR filtering create partial DAGs
+    #[case::orphaned_parent(Some(1), &[(0, M), (1, 99)], None, true)]
+    #[case::anchor_fetch_orphan(Some(5), &[(3, 2), (4, 3), (5, 4)], Some(3), true)]
+    #[case::asr_filtered_gap(Some(4), &[(2, 1), (4, 3)], Some(4), true)]
+    #[case::multiple_orphan_roots(Some(5), &[(2, 1), (5, 4)], None, true)]
+    #[case::single_orphan(Some(5), &[(5, 3)], None, true)]
+    #[case::all_genesis_rooted(Some(1), &[(0, M), (1, M)], Some(0), true)]
+    // Invalid cases — real corruption
     #[case::cursor_without_games(Some(5), &[], None, false)]
     #[case::invalid_anchor_index(Some(0), &[(0, M)], Some(99), false)]
-    #[case::orphaned_parent(Some(1), &[(0, M), (1, 99)], None, false)]
     fn test_validation(
         #[case] cursor: Option<u64>,
         #[case] games: &[(u64, u32)],


### PR DESCRIPTION
## Summary
Backport of PR #846 (merged to main) to `release/v3.x`.

- Remove the orphaned-parent check from `ProposerBackup::validate()`
- This check rejects any backup where a game's `parent_index` doesn't exist in the backup, but anchor-based fetching and ASR filtering both produce partial DAGs with legitimate orphans — making backup unusable in practice
- Adds test cases covering orphan scenarios that are now valid

## Backport-specific changes
- None — clean cherry-pick, diff is identical to source PR

## Equivalence verification
- [x] File-by-file diff comparison against source PR — identical
- [x] No dependency changes
- [x] No ELF rebuild needed

## Test plan
- [ ] CI passes