### PR TITLE
fix(fault-proof): correct resolve() invariant comment

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -431,7 +431,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     ///         `CHALLENGER_WINS` when the proposer's claim has been challenged, but the proposer has not proven
     ///         its claim within the `MAX_PROVE_DURATION`.
     function resolve() external returns (GameStatus) {
-        // INVARIANT: Resolution cannot occur unless the game has already been resolved.
+        // INVARIANT: Resolution cannot occur if the game has already been resolved.
         if (status != GameStatus.IN_PROGRESS) revert ClaimAlreadyResolved();
 
         // INVARIANT: Cannot resolve a game if the parent game has not been resolved.


### PR DESCRIPTION
## Summary
Corrects the `resolve()` INVARIANT comment in `OPSuccinctFaultDisputeGame`: it previously said resolution cannot occur *unless* the game was already resolved, which contradicts the check (`status != IN_PROGRESS` → revert when not in progress). The intended meaning is that resolution cannot occur *if* the game has already been resolved.

## Test plan
- [ ] N/A (comment-only change)