### PR TITLE
feat(fault-proof,validity): make L1 tx confirmation timeout configurable

### DIFF
--- a/book/fault_proofs/challenger.md
+++ b/book/fault_proofs/challenger.md
@@ -56,6 +56,7 @@ Either `PRIVATE_KEY` or both `SIGNER_URL` and `SIGNER_ADDRESS` must be set for t
 | `FETCH_INTERVAL` | Polling interval in seconds | `30` |
 | `CHALLENGER_METRICS_PORT` | The port to expose metrics on. Update prometheus.yml to use this port, if using docker compose. | `9001` |
 | `MALICIOUS_CHALLENGE_PERCENTAGE` | Percentage (0.0-100.0) of valid games to challenge for testing defense mechanisms | `0.0` |
+| `TX_CONFIRMATION_TIMEOUT` | Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Setting this too low risks timeout-triggered retries that can lead to redundant operations. | `60` |
 
 ```env
 # Required Configuration
@@ -72,6 +73,9 @@ CHALLENGER_METRICS_PORT=9001          # The port to expose metrics on
 
 # Testing Configuration (Optional)
 MALICIOUS_CHALLENGE_PERCENTAGE=0.0    # Percentage of valid games to challenge for testing (0.0 = disabled)
+
+# Transaction Configuration (Optional)
+TX_CONFIRMATION_TIMEOUT=60            # L1 tx confirmation timeout in seconds (raise for congested L1s)
 ```
 
 ## Running

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -108,6 +108,7 @@ Depending on the one you choose, you must provide the corresponding environment 
 | `AGG_GAS_LIMIT` | The gas limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `WHITELIST` | The list of prover addresses that are allowed to bid on proof requests. | `` |
 | `BACKUP_PATH` | Path to backup file for persisting proposer state across restarts. Enables faster recovery by restoring cached state instead of re-syncing from the factory. | (disabled) |
+| `TX_CONFIRMATION_TIMEOUT` | Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Setting this too low risks timeout-triggered retries that can produce duplicate sibling games. | `60` |
 
 ```env
 # Required Configuration
@@ -133,6 +134,7 @@ PROPOSAL_INTERVAL_IN_BLOCKS=1800 # Number of L2 blocks between proposals
 FETCH_INTERVAL=30                # Polling interval in seconds
 PROPOSER_METRICS_PORT=9000       # The port to expose metrics on
 BACKUP_PATH=                     # persist state across restarts (e.g. /backup/proposer_state.json)
+TX_CONFIRMATION_TIMEOUT=60       # L1 tx confirmation timeout in seconds (raise for congested L1s)
 ```
 
 ### Configuration Steps

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -9,7 +9,7 @@
 OP Succinct gives **every** OP Stack rollup the ability to become a ZK rollup.
 
 It combines a few key technologies:
-- [Kona](https://op-rs.github.io/kona/), Optimism's Rust implementation of the OP Stack's state transition function
+- [Kona](https://github.com/ethereum-optimism/optimism/tree/develop/rust/kona), Optimism's Rust implementation of the OP Stack's state transition function
 - [SP1](https://docs.succinct.xyz/docs/sp1/introduction), Succinct's state-of-the-art Rust zkVM
 - [Succinct Prover Network](https://docs.succinct.xyz/docs/sp1/prover-network/intro), Succinct's low-latency, cost-effective proving API
 

--- a/book/validity/proposer.md
+++ b/book/validity/proposer.md
@@ -73,6 +73,7 @@ Before starting the proposer, ensure you have deployed the relevant contracts an
 | `WHITELIST` | Default: ``. The list of prover addresses that are allowed to bid on proof requests. |
 | `MIN_AUCTION_PERIOD` | Default: `1`. The minimum auction period (in seconds). |
 | `AUCTION_TIMEOUT` | Default: `60` (1 minute). How long to wait before canceling a proof request that hasn't been assigned (in seconds). |
+| `TX_CONFIRMATION_TIMEOUT` | Default: `60`. Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Raise on congested L1s to avoid timeout-triggered retries. |
 
 ## Build the Proposer Service
 

--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -502,7 +502,11 @@ where
             contract.challenge().value(challenger_bond).into_transaction_request();
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {
@@ -565,7 +569,11 @@ where
         let transaction_request = contract.resolve().into_transaction_request();
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {
@@ -630,7 +638,11 @@ where
             contract.claimCredit(self.signer.address()).gas(200_000).into_transaction_request();
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -78,6 +78,14 @@ pub struct ProposerConfig {
 
     /// Optional path to backup file for persisting proposer state across restarts.
     pub backup_path: Option<PathBuf>,
+
+    /// Maximum time (in seconds) to wait for an L1 transaction submitted by the proposer to
+    /// reach the required number of confirmations before the watcher gives up. Setting this
+    /// too low risks declaring "confirmation timeout" on transactions that actually land on
+    /// chain, which can produce duplicate sibling games on retry. Defaults to 60 to preserve
+    /// the historical signer behavior; raise it (e.g. 180) on networks where mempool inclusion
+    /// plus the configured confirmation depth needs more headroom.
+    pub tx_confirmation_timeout: u64,
 }
 
 /// Helper function to parse a comma-separated list of addresses
@@ -139,6 +147,9 @@ impl ProposerConfig {
                 .parse()?,
             proof_provider: ProofProviderConfig::from_env()?,
             backup_path: env::var("BACKUP_PATH").ok().map(PathBuf::from),
+            tx_confirmation_timeout: env::var("TX_CONFIRMATION_TIMEOUT")
+                .unwrap_or("60".to_string())
+                .parse()?,
         })
     }
 
@@ -175,6 +186,7 @@ impl ProposerConfig {
             min_auction_period = self.proof_provider.min_auction_period,
             whitelist = ?self.proof_provider.whitelist,
             backup_path = ?self.backup_path,
+            tx_confirmation_timeout = self.tx_confirmation_timeout,
             "Proposer configuration loaded"
         );
     }
@@ -297,6 +309,14 @@ pub struct ChallengerConfig {
     /// Set to 0.0 (default) for production use (honest challenging only).
     /// Set to >0.0 for testing defense mechanisms.
     pub malicious_challenge_percentage: f64,
+
+    /// Maximum time (in seconds) to wait for an L1 transaction submitted by the challenger to
+    /// reach the required number of confirmations before the watcher gives up. Setting this
+    /// too low risks declaring "confirmation timeout" on transactions that actually land on
+    /// chain, which can lead to redundant retries. Defaults to 60 to preserve the historical
+    /// signer behavior; raise it (e.g. 180) on networks where mempool inclusion plus the
+    /// configured confirmation depth needs more headroom.
+    pub tx_confirmation_timeout: u64,
 }
 
 impl ChallengerConfig {
@@ -316,6 +336,9 @@ impl ChallengerConfig {
             malicious_challenge_percentage: env::var("MALICIOUS_CHALLENGE_PERCENTAGE")
                 .unwrap_or("0.0".to_string())
                 .parse()?,
+            tx_confirmation_timeout: env::var("TX_CONFIRMATION_TIMEOUT")
+                .unwrap_or("60".to_string())
+                .parse()?,
         })
     }
 
@@ -330,6 +353,7 @@ impl ChallengerConfig {
             fetch_interval = self.fetch_interval,
             metrics_port = self.metrics_port,
             malicious_challenge_percentage = self.malicious_challenge_percentage,
+            tx_confirmation_timeout = self.tx_confirmation_timeout,
             "Challenger configuration loaded"
         );
     }

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1138,7 +1138,11 @@ where
         let transaction_request = game.prove(agg_proof.bytes().into()).into_transaction_request();
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {
@@ -1198,7 +1202,11 @@ where
 
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {
@@ -1328,7 +1336,11 @@ where
         let transaction_request = contract.resolve().into_transaction_request();
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {
@@ -1354,7 +1366,11 @@ where
             contract.claimCredit(self.signer.address()).gas(200_000).into_transaction_request();
         let receipt = self
             .signer
-            .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
             .await?;
 
         if !receipt.status() {

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -49,6 +49,7 @@ pub async fn new_proposer(
         range_split_count: RangeSplitCount::one(),
         max_concurrent_range_proofs: NonZero::<usize>::MIN,
         backup_path,
+        tx_confirmation_timeout: 60,
         proof_provider: ProofProviderConfig {
             timeout: 14400, // 4 hours
             network_calls_timeout: 15,
@@ -119,6 +120,7 @@ pub async fn new_challenger(
         game_type,
         metrics_port: 9001,
         malicious_challenge_percentage: malicious_percentage.unwrap_or(0.0),
+        tx_confirmation_timeout: 60,
     };
 
     let l1_provider = ProviderBuilder::default().connect_http(rpc_config.l1_rpc.clone());

--- a/utils/signer/src/lib.rs
+++ b/utils/signer/src/lib.rs
@@ -93,11 +93,24 @@ impl Signer {
         }
     }
 
-    /// Sends a transaction request, signed by the configured `signer`.
+    /// Sends a transaction request, signed by the configured `signer`, using the default
+    /// confirmation timeout of [`TIMEOUT_SECONDS`].
     pub async fn send_transaction_request(
         &self,
         l1_rpc: Url,
+        transaction_request: TransactionRequest,
+    ) -> Result<TransactionReceipt> {
+        self.send_transaction_request_with_timeout(l1_rpc, transaction_request, TIMEOUT_SECONDS)
+            .await
+    }
+
+    /// Sends a transaction request, signed by the configured `signer`, with a caller-supplied
+    /// confirmation timeout (in seconds).
+    pub async fn send_transaction_request_with_timeout(
+        &self,
+        l1_rpc: Url,
         mut transaction_request: TransactionRequest,
+        timeout_secs: u64,
     ) -> Result<TransactionReceipt> {
         match self {
             Signer::Web3Signer(signer_url, signer_address) => {
@@ -126,7 +139,7 @@ impl Signer {
                     .await
                     .context("Failed to send transaction")?
                     .with_required_confirmations(NUM_CONFIRMATIONS)
-                    .with_timeout(Some(Duration::from_secs(TIMEOUT_SECONDS)))
+                    .with_timeout(Some(Duration::from_secs(timeout_secs)))
                     .get_receipt()
                     .await?;
 
@@ -151,7 +164,7 @@ impl Signer {
                     .await
                     .context("Failed to send transaction")?
                     .with_required_confirmations(NUM_CONFIRMATIONS)
-                    .with_timeout(Some(Duration::from_secs(TIMEOUT_SECONDS)))
+                    .with_timeout(Some(Duration::from_secs(timeout_secs)))
                     .get_receipt()
                     .await?;
 
@@ -177,7 +190,7 @@ impl Signer {
                     .await
                     .context("Failed to send KMS-signed transaction")?
                     .with_required_confirmations(NUM_CONFIRMATIONS)
-                    .with_timeout(Some(Duration::from_secs(TIMEOUT_SECONDS)))
+                    .with_timeout(Some(Duration::from_secs(timeout_secs)))
                     .get_receipt()
                     .await?;
 
@@ -212,8 +225,9 @@ impl SignerLock {
         self.cached_address
     }
 
-    /// Sends a transaction request, signed by the configured signer.
-    /// Transactions are serialized via a Mutex to prevent nonce conflicts.
+    /// Sends a transaction request, signed by the configured signer, using the default
+    /// confirmation timeout of [`TIMEOUT_SECONDS`]. Transactions are serialized via a Mutex
+    /// to prevent nonce conflicts.
     pub async fn send_transaction_request(
         &self,
         l1_rpc: Url,
@@ -221,6 +235,20 @@ impl SignerLock {
     ) -> Result<TransactionReceipt> {
         let signer = self.inner.lock().await;
         signer.send_transaction_request(l1_rpc, transaction_request).await
+    }
+
+    /// Sends a transaction request with a caller-supplied confirmation timeout (in seconds).
+    /// Transactions are serialized via a Mutex to prevent nonce conflicts.
+    pub async fn send_transaction_request_with_timeout(
+        &self,
+        l1_rpc: Url,
+        transaction_request: TransactionRequest,
+        timeout_secs: u64,
+    ) -> Result<TransactionReceipt> {
+        let signer = self.inner.lock().await;
+        signer
+            .send_transaction_request_with_timeout(l1_rpc, transaction_request, timeout_secs)
+            .await
     }
 }
 

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<()> {
         whitelist: env_config.whitelist,
         min_auction_period: env_config.min_auction_period,
         auction_timeout: env_config.auction_timeout,
+        tx_confirmation_timeout: env_config.tx_confirmation_timeout,
     };
     proposer_config.log();
 

--- a/validity/src/config.rs
+++ b/validity/src/config.rs
@@ -100,6 +100,14 @@ pub struct RequesterConfig {
 
     /// How long to wait before cancelling a proof request that hasn't been assigned.
     pub auction_timeout: u64,
+
+    /// Maximum time (in seconds) to wait for an L1 transaction submitted by the proposer to
+    /// reach the required number of confirmations before the watcher gives up. Setting this
+    /// too low risks declaring "confirmation timeout" on transactions that actually land on
+    /// chain, which can lead to redundant retries. Defaults to 60 to preserve the historical
+    /// signer behavior; raise it (e.g. 180) on networks where mempool inclusion plus the
+    /// configured confirmation depth needs more headroom.
+    pub tx_confirmation_timeout: u64,
 }
 
 impl RequesterConfig {
@@ -132,6 +140,7 @@ impl RequesterConfig {
             whitelist = ?self.whitelist,
             min_auction_period = self.min_auction_period,
             auction_timeout = self.auction_timeout,
+            tx_confirmation_timeout = self.tx_confirmation_timeout,
             "Validity proposer configuration loaded"
         );
     }

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -38,6 +38,7 @@ pub struct EnvironmentConfig {
     pub whitelist: Option<Vec<Address>>,
     pub min_auction_period: u64,
     pub auction_timeout: u64,
+    pub tx_confirmation_timeout: u64,
 }
 
 /// Helper function to get environment variables with a default value and parse them.
@@ -140,6 +141,7 @@ pub async fn read_proposer_env() -> Result<EnvironmentConfig> {
         whitelist: parse_whitelist(&get_env_var("WHITELIST", Some("".to_string()))?)?,
         min_auction_period: get_env_var("MIN_AUCTION_PERIOD", Some(1))?,
         auction_timeout: get_env_var("AUCTION_TIMEOUT", Some(60))?, // 1 minute
+        tx_confirmation_timeout: get_env_var("TX_CONFIRMATION_TIMEOUT", Some(60))?,
     };
 
     Ok(config)

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -965,9 +965,10 @@ where
                 let receipt = self
                     .driver_config
                     .signer
-                    .send_transaction_request(
+                    .send_transaction_request_with_timeout(
                         self.driver_config.fetcher.as_ref().rpc_config.l1_rpc.clone(),
                         transaction_request,
+                        self.requester_config.tx_confirmation_timeout,
                     )
                     .await?;
 
@@ -1355,9 +1356,10 @@ where
 
             self.driver_config
                 .signer
-                .send_transaction_request(
+                .send_transaction_request_with_timeout(
                     self.driver_config.fetcher.as_ref().rpc_config.l1_rpc.clone(),
                     transaction_request,
+                    self.requester_config.tx_confirmation_timeout,
                 )
                 .await
                 .map_err(|e| anyhow!("Failed to relay aggregation proof onchain. end_block: {}, checkpointed_l1_block_number: {}, error: {}", completed_agg_proof.end_block, completed_agg_proof.checkpointed_l1_block_number.unwrap(), e))?
@@ -1378,9 +1380,10 @@ where
 
             self.driver_config
                 .signer
-                .send_transaction_request(
+                .send_transaction_request_with_timeout(
                     self.driver_config.fetcher.as_ref().rpc_config.l1_rpc.clone(),
                     transaction_request,
+                    self.requester_config.tx_confirmation_timeout,
                 )
                 .await?
         };


### PR DESCRIPTION
## Summary

Closes https://github.com/celo-org/op-succinct/issues/88.
Based on #873 by @seolaoh — thank you!

- The signer's hardcoded `TIMEOUT_SECONDS=60` is too tight for 3 L1 confirmations on mainnet (~36s of pure block time leaves only ~24s for mempool inclusion). Under congestion the watcher gives up while the tx is still in flight, the caller retries, and the fault-proof proposer produces duplicate sibling games when the original eventually lands.
- Adds `send_transaction_request_with_timeout` to `Signer`/`SignerLock` and threads `tx_confirmation_timeout` (env: `TX_CONFIRMATION_TIMEOUT`) through all three L1-submitting clients: fault-proof proposer, fault-proof challenger, and validity proposer.
- Default stays at 60s to preserve historical behavior; operators on congested L1s can raise it (e.g. 180) without a code change.
- Documents `TX_CONFIRMATION_TIMEOUT` in fault-proof proposer, challenger, and validity proposer docs.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all` clean
- [x] `cargo clippy` clean on affected crates
- [ ] CI integration tests