### PR TITLE
fix: update sp1-contracts and DeployVerifier to v6.1.0

### DIFF
--- a/tests/scripts/DeployVerifier.s.sol
+++ b/tests/scripts/DeployVerifier.s.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 import {Script, console} from "forge-std/Script.sol";
-import {SP1Verifier as SP1VerifierPlonk} from "@sp1-contracts/src/v6.0.0/SP1VerifierPlonk.sol";
-import {SP1Verifier as SP1VerifierGroth16} from "@sp1-contracts/src/v6.0.0/SP1VerifierGroth16.sol";
+import {SP1Verifier as SP1VerifierPlonk} from "@sp1-contracts/src/v6.1.0/SP1VerifierPlonk.sol";
+import {SP1Verifier as SP1VerifierGroth16} from "@sp1-contracts/src/v6.1.0/SP1VerifierGroth16.sol";
 
-/// @notice Deploys SP1VerifierPlonk (v6.0.0) for E2E testing.
+/// @notice Deploys SP1VerifierPlonk (v6.1.0) for E2E testing.
 /// @dev For production deployments, use the canonical sp1-contracts scripts:
 ///      https://github.com/succinctlabs/sp1-contracts
 contract DeployVerifierPlonk is Script {
@@ -18,7 +18,7 @@ contract DeployVerifierPlonk is Script {
     }
 }
 
-/// @notice Deploys SP1VerifierGroth16 (v6.0.0) for E2E testing.
+/// @notice Deploys SP1VerifierGroth16 (v6.1.0) for E2E testing.
 /// @dev For production deployments, use the canonical sp1-contracts scripts:
 ///      https://github.com/succinctlabs/sp1-contracts
 contract DeployVerifierGroth16 is Script {


### PR DESCRIPTION
## Summary
Fix `WrongVerifierSelector` error in e2e network prover tests after SP1 v6.1.0 bump (#872).

## Changes
- Update `tests/sp1-contracts` submodule to `v6.1.0` tag (includes v6.1.0 verifier contracts from succinctlabs/sp1-contracts#75)
- Update `contracts/lib/sp1-contracts` submodule to `v6.1.0` tag (consistent)
- Update `tests/scripts/DeployVerifier.s.sol` imports from `v6.0.0` → `v6.1.0`

## Why
SP1 6.1.0 proofs use different verifier hash/selectors than 6.0.0. The e2e tests were deploying v6.0.0 verifiers which reject v6.1.0 proofs with `WrongVerifierSelector`.

## Test plan
- [x] `forge build` passes
- [ ] E2e network prover tests pass