### PR TITLE
backport(contracts): update sp1-contracts and DeployVerifier to v6.1.0 (#878)

### DIFF
--- a/tests/scripts/DeployVerifier.s.sol
+++ b/tests/scripts/DeployVerifier.s.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 import {Script, console} from "forge-std/Script.sol";
-import {SP1Verifier as SP1VerifierPlonk} from "@sp1-contracts/src/v6.0.0/SP1VerifierPlonk.sol";
-import {SP1Verifier as SP1VerifierGroth16} from "@sp1-contracts/src/v6.0.0/SP1VerifierGroth16.sol";
+import {SP1Verifier as SP1VerifierPlonk} from "@sp1-contracts/src/v6.1.0/SP1VerifierPlonk.sol";
+import {SP1Verifier as SP1VerifierGroth16} from "@sp1-contracts/src/v6.1.0/SP1VerifierGroth16.sol";
 
-/// @notice Deploys SP1VerifierPlonk (v6.0.0) for E2E testing.
+/// @notice Deploys SP1VerifierPlonk (v6.1.0) for E2E testing.
 /// @dev For production deployments, use the canonical sp1-contracts scripts:
 ///      https://github.com/succinctlabs/sp1-contracts
 contract DeployVerifierPlonk is Script {
@@ -18,7 +18,7 @@ contract DeployVerifierPlonk is Script {
     }
 }
 
-/// @notice Deploys SP1VerifierGroth16 (v6.0.0) for E2E testing.
+/// @notice Deploys SP1VerifierGroth16 (v6.1.0) for E2E testing.
 /// @dev For production deployments, use the canonical sp1-contracts scripts:
 ///      https://github.com/succinctlabs/sp1-contracts
 contract DeployVerifierGroth16 is Script {


### PR DESCRIPTION
## Summary
Backport of PR #878 (merged to main) to `release/v3.x`.

- Update `tests/sp1-contracts` submodule to `v6.1.0` tag
- Update `tests/scripts/DeployVerifier.s.sol` imports from `v6.0.0` → `v6.1.0`

## Backport-specific changes
- None — cherry-pick applied cleanly with no conflicts

## Equivalence verification
- [x] File-by-file diff comparison against source PR — identical
- [x] No Rust code changes, no cargo checks needed
- [x] No ELF changes needed (only Solidity/submodule changes)
- [ ] CI passes

## Test plan
- [ ] CI (forge build, submodule resolution)
- [ ] E2e network prover tests pass with v6.1.0 verifiers