### PR TITLE
fix(fault-proof): correct resolve() invariant comment

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -431,7 +431,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     ///         `CHALLENGER_WINS` when the proposer's claim has been challenged, but the proposer has not proven
     ///         its claim within the `MAX_PROVE_DURATION`.
     function resolve() external returns (GameStatus) {
-        // INVARIANT: Resolution cannot occur unless the game has already been resolved.
+        // INVARIANT: Resolution cannot occur if the game has already been resolved.
         if (status != GameStatus.IN_PROGRESS) revert ClaimAlreadyResolved();
 
         // INVARIANT: Cannot resolve a game if the parent game has not been resolved.


### PR DESCRIPTION
## Summary
Cherry-picks succinctlabs/op-succinct#871 (authored by @cuiweixie) so CI can run.

Corrects the `resolve()` INVARIANT comment in `OPSuccinctFaultDisputeGame`: the original said resolution cannot occur *unless* the game was already resolved, which contradicts the actual check (`status != IN_PROGRESS` → revert `ClaimAlreadyResolved`). The intended meaning is that resolution cannot occur *if* the game has already been resolved.

Closes succinctlabs/op-succinct#871

## Test plan
- [x] N/A (comment-only change)