### PR TITLE
fix(host): surface real RPC failures in is_safe_db_activated

### DIFF
--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -52,6 +52,45 @@ async fn l2_to_l1_message_passer_storage_root(
     }
 }
 
+/// JSON-RPC "method not found" error code defined by the JSON-RPC 2.0 spec.
+const JSON_RPC_METHOD_NOT_FOUND: i64 = -32601;
+
+/// Classify a raw JSON-RPC response body from `optimism_safeHeadAtL1Block` as either
+/// "SafeDB active", "SafeDB genuinely unavailable", or an unclassified error to propagate.
+///
+/// See [`OPSuccinctDataFetcher::is_safe_db_activated`] for the caller-visible contract.
+fn classify_safe_db_probe_outcome(response: &serde_json::Value) -> Result<bool> {
+    if let Some(error) = response.get("error") {
+        let code = error.get("code").and_then(|v| v.as_i64());
+        let message = error.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error");
+
+        if code == Some(JSON_RPC_METHOD_NOT_FOUND) {
+            return Ok(false);
+        }
+        // op-node's `disabledSafeDB` returns a generic-code error whose message identifies
+        // SafeDB (e.g. "safeDB is not enabled"). Match on the token to cover op-node versions
+        // without relying on a code that upstream does not assign.
+        if message.to_lowercase().contains("safedb") {
+            return Ok(false);
+        }
+        return Err(anyhow!("Error calling optimism_safeHeadAtL1Block: {message}"));
+    }
+
+    let Some(result) = response.get("result") else {
+        return Err(anyhow!(
+            "Malformed JSON-RPC response for optimism_safeHeadAtL1Block: neither `result` nor `error` present"
+        ));
+    };
+
+    // "Active" means the node returned a parseable SafeHeadResponse, not merely that a
+    // `result` field exists. A malformed / null / empty result is treated as an error so
+    // callers do not conclude SafeDB is active on a degraded / mock upstream.
+    let _: SafeHeadResponse = serde_json::from_value(result.clone()).with_context(|| {
+        "Malformed optimism_safeHeadAtL1Block result: expected SafeHeadResponse".to_string()
+    })?;
+    Ok(true)
+}
+
 #[derive(Clone)]
 /// The OPSuccinctDataFetcher struct is used to fetch the L2 output data and L2 claim data for a
 /// given block number. It is used to generate the boot info for the native host program.
@@ -557,6 +596,32 @@ impl OPSuccinctDataFetcher {
         serde_json::from_value(response["result"].clone()).map_err(Into::into)
     }
 
+    /// Execute a JSON-RPC call and return the raw response body without collapsing
+    /// JSON-RPC-level `error` objects into `Err`. HTTP status failures (4xx/5xx) are
+    /// surfaced explicitly via [`reqwest::Response::error_for_status`] so callers can
+    /// distinguish transport / auth / upstream health failures from protocol errors.
+    async fn fetch_rpc_data_raw(
+        url: &Url,
+        method: &str,
+        params: Vec<Value>,
+    ) -> Result<serde_json::Value> {
+        let client = reqwest::Client::new();
+        let response = client
+            .post(url.clone())
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+                "id": 1
+            }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?;
+        Ok(response)
+    }
+
     /// Fetch arbitrary data from the RPC.
     pub async fn fetch_rpc_data_with_mode<T>(
         &self,
@@ -788,17 +853,26 @@ impl OPSuccinctDataFetcher {
     }
 
     /// Check if the safeDB is activated on the L2 node.
+    ///
+    /// Probes `optimism_safeHeadAtL1Block` and classifies the outcome into three buckets:
+    /// - `Ok(true)` if the node returns a parseable [`SafeHeadResponse`].
+    /// - `Ok(false)` only if the node explicitly reports that SafeDB is unavailable — either the
+    ///   JSON-RPC method is unknown (`-32601`) or the error message mentions SafeDB (covering
+    ///   op-node's `disabledSafeDB` path, which returns messages like `"safeDB is not enabled"`).
+    /// - `Err(..)` for transport, HTTP (5xx / auth), deserialization, and any other RPC error, so
+    ///   callers that reclassified those as "SafeDB inactive" (e.g. startup validation) now surface
+    ///   the real failure instead.
     pub async fn is_safe_db_activated(&self) -> Result<bool> {
         let finalized_l1_header = self.get_l1_header(BlockId::finalized()).await?;
         let l1_block_number_hex = format!("0x{:x}", finalized_l1_header.number);
-        let result: Result<SafeHeadResponse, _> = self
-            .fetch_rpc_data_with_mode(
-                RPCMode::L2Node,
-                "optimism_safeHeadAtL1Block",
-                vec![l1_block_number_hex.into()],
-            )
-            .await;
-        Ok(result.is_ok())
+        let url = self.get_rpc_url(RPCMode::L2Node)?;
+        let response = Self::fetch_rpc_data_raw(
+            url,
+            "optimism_safeHeadAtL1Block",
+            vec![l1_block_number_hex.into()],
+        )
+        .await?;
+        classify_safe_db_probe_outcome(&response)
     }
 
     /// Get the L2 output data for a given block number and save the boot info to a file in the data
@@ -926,5 +1000,73 @@ mod tests {
         config_b.block_time = config_a.block_time + 1;
 
         assert_ne!(hash_rollup_config(&config_a), hash_rollup_config(&config_b));
+    }
+
+    #[test]
+    fn safe_db_classifier_active_on_parseable_result() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "l1Block": {
+                    "hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "number": 100,
+                },
+                "safeHead": {
+                    "hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "number": 42,
+                },
+            },
+        });
+        assert!(classify_safe_db_probe_outcome(&response).unwrap());
+    }
+
+    #[test]
+    fn safe_db_classifier_inactive_on_method_not_found() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32601, "message": "the method optimism_safeHeadAtL1Block does not exist" },
+        });
+        assert!(!classify_safe_db_probe_outcome(&response).unwrap());
+    }
+
+    #[test]
+    fn safe_db_classifier_inactive_on_disabled_safedb_message() {
+        // op-node `disabledSafeDB` returns a generic-code error with a SafeDB-specific message.
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32000, "message": "safeDB is not enabled" },
+        });
+        assert!(!classify_safe_db_probe_outcome(&response).unwrap());
+    }
+
+    #[test]
+    fn safe_db_classifier_errs_on_unrelated_rpc_error() {
+        // Transport / auth / upstream health failures must not be collapsed into SafeDB-off.
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": { "code": -32000, "message": "unauthorized" },
+        });
+        let err = classify_safe_db_probe_outcome(&response).unwrap_err();
+        assert!(err.to_string().contains("unauthorized"), "error = {err}");
+    }
+
+    #[test]
+    fn safe_db_classifier_errs_on_malformed_response() {
+        let response = json!({ "jsonrpc": "2.0", "id": 1 });
+        assert!(classify_safe_db_probe_outcome(&response).is_err());
+    }
+
+    #[test]
+    fn safe_db_classifier_errs_on_malformed_result_shape() {
+        // A `null` or empty `result` must not be misread as "SafeDB active".
+        let response = json!({ "jsonrpc": "2.0", "id": 1, "result": null });
+        assert!(classify_safe_db_probe_outcome(&response).is_err());
+
+        let response = json!({ "jsonrpc": "2.0", "id": 1, "result": {} });
+        assert!(classify_safe_db_probe_outcome(&response).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- `is_safe_db_activated()` returned `Ok(result.is_ok())`, collapsing transport, auth, HTTP 5xx, and unrelated JSON-RPC errors into `Ok(false)`. Under non-default L1 block selection (op-succinct#883), startup validation then reported a misleading `enable SafeDB` error even when the real issue was an unreachable or unhealthy L2 node.
- Split the probe into a raw JSON-RPC helper that calls `error_for_status()` and a pure classifier `classify_safe_db_probe_outcome`. Success now requires the `result` to deserialize into a `SafeHeadResponse`; `-32601` (method not found) and op-node's `disabledSafeDB` message map to `Ok(false)`; everything else propagates as `Err` so operators see the real failure.
- Added 6 unit tests covering the classifier buckets (active, method-not-found, SafeDB-disabled-by-message, unrelated RPC error, malformed body, malformed `result` shape).

Tracks succinctlabs/apps-ops#4. Unblocks op-succinct#883's startup validation path; follow-up: `get_l1_head` (fetcher.rs:721) still has a similar collapsed-classification fallback that is out of scope here.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- [x] `cargo test -p op-succinct-host-utils --lib` (8 passed, incl. 6 new classifier tests)
- [ ] Real op-node integration verification (no fixture available locally)