### PR TITLE
backport(fault-proof): pin L1 block during sync to prevent RPC inconsistency (#865)

### DIFF
--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -173,6 +173,22 @@ All long-running work executes in dedicated Tokio tasks stored in a `TaskMap`, p
 
 Metrics are published by a separate background collector that samples the canonical head, finalized head, and active proving task count.
 
+### Proposer Metrics
+
+Use `op_succinct_fp_canonical_head_game_index` as the primary signal for whether the proposer has a cached canonical head.
+
+Values:
+- `>= 0`: cached canonical head game index
+- `-1`: no canonical head game is currently cached
+
+Do not use the canonical-head / latest-game L2 block metric as the head-clear signal. The proposer may preserve an anchor-derived L2 block baseline even when `op_succinct_fp_canonical_head_game_index = -1`, so it can create the first proposal.
+
+Useful dashboards and alerts:
+- sustained `op_succinct_fp_canonical_head_game_index = -1` after games should exist
+- decreases in `op_succinct_fp_canonical_head_game_index`, which can indicate canonical head rewind or orphaning
+- the gap between `op_succinct_fp_anchor_game_index` and `op_succinct_fp_canonical_head_game_index`
+- `op_succinct_fp_finalized_l2_block_number = 0`, which indicates that finalized lookup is currently unavailable
+
 ## Features
 
 ### State Synchronization

--- a/fault-proof/src/backup.rs
+++ b/fault-proof/src/backup.rs
@@ -7,7 +7,7 @@ use std::{io::Write, path::Path};
 
 use tempfile::NamedTempFile;
 
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
@@ -23,12 +23,28 @@ pub struct ProposerBackup {
     pub cursor: Option<U256>,
     pub games: Vec<Game>,
     pub anchor_game_index: Option<U256>,
+    /// L2 block of the most recently created game. Prevents duplicate creation after
+    /// restart when the pinned sync cache hasn't caught up. Defaults to 0 for backups
+    /// created before this field existed.
+    #[serde(default)]
+    pub last_created_game_l2_block: u64,
+    /// Address of the most recently created game. Used for precise CHALLENGER_WINS
+    /// guard reset. Defaults to Address::ZERO (no guard) for old backups.
+    #[serde(default)]
+    pub last_created_game_address: Address,
 }
 
 impl ProposerBackup {
     /// Create a new backup with the current version.
     pub fn new(cursor: Option<U256>, games: Vec<Game>, anchor_game_index: Option<U256>) -> Self {
-        Self { version: BACKUP_VERSION, cursor, games, anchor_game_index }
+        Self {
+            version: BACKUP_VERSION,
+            cursor,
+            games,
+            anchor_game_index,
+            last_created_game_l2_block: 0,
+            last_created_game_address: Address::ZERO,
+        }
     }
 
     /// Validate backup integrity. Rejects stale/corrupted backups but allows orphaned parent
@@ -165,7 +181,14 @@ mod tests {
 
         assert_eq!(
             keys,
-            vec!["anchor_game_index", "cursor", "games", "version"],
+            vec![
+                "anchor_game_index",
+                "cursor",
+                "games",
+                "last_created_game_address",
+                "last_created_game_l2_block",
+                "version"
+            ],
             "ProposerBackup schema changed! Bump BACKUP_VERSION in backup.rs"
         );
     }

--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use anyhow::{bail, Context, Result};
@@ -195,7 +195,8 @@ where
             }
         };
 
-        let Some(latest_index) = self.factory.fetch_latest_game_index().await? else {
+        let Some(latest_index) = self.factory.fetch_latest_game_index(BlockId::latest()).await?
+        else {
             return Ok(());
         };
 
@@ -258,6 +259,7 @@ where
                                         let parent_lost = is_parent_challenger_wins(
                                             game.parent_index,
                                             &self.factory,
+                                            BlockId::latest(),
                                         )
                                         .await?;
                                         game.is_invalid || parent_lost
@@ -267,7 +269,12 @@ where
                                 ProposalStatus::Challenged => {
                                     let is_own_game = claim_data.counteredBy == signer_address;
                                     let should_resolve = is_game_over && is_own_game && {
-                                        is_parent_resolved(game.parent_index, &self.factory).await?
+                                        is_parent_resolved(
+                                            game.parent_index,
+                                            &self.factory,
+                                            BlockId::latest(),
+                                        )
+                                        .await?
                                     };
                                     (false, should_resolve)
                                 }

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -79,6 +79,11 @@ pub struct ProposerConfig {
     /// Optional path to backup file for persisting proposer state across restarts.
     pub backup_path: Option<PathBuf>,
 
+    /// Number of L1 blocks behind `latest` to pin reads during sync cycles.
+    /// Provides a safety margin for load-balanced RPCs where backends may lag.
+    /// Default: 0 (use latest).
+    pub sync_l1_confirmations: u64,
+
     /// Maximum time (in seconds) to wait for an L1 transaction submitted by the proposer to
     /// reach the required number of confirmations before the watcher gives up. Setting this
     /// too low risks declaring "confirmation timeout" on transactions that actually land on
@@ -147,6 +152,9 @@ impl ProposerConfig {
                 .parse()?,
             proof_provider: ProofProviderConfig::from_env()?,
             backup_path: env::var("BACKUP_PATH").ok().map(PathBuf::from),
+            sync_l1_confirmations: env::var("SYNC_L1_CONFIRMATIONS")
+                .unwrap_or("0".to_string())
+                .parse()?,
             tx_confirmation_timeout: env::var("TX_CONFIRMATION_TIMEOUT")
                 .unwrap_or("60".to_string())
                 .parse()?,
@@ -186,6 +194,7 @@ impl ProposerConfig {
             min_auction_period = self.proof_provider.min_auction_period,
             whitelist = ?self.proof_provider.whitelist,
             backup_path = ?self.backup_path,
+            sync_l1_confirmations = self.sync_l1_confirmations,
             tx_confirmation_timeout = self.tx_confirmation_timeout,
             "Proposer configuration loaded"
         );

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -6,7 +6,7 @@ pub mod prometheus;
 pub mod proposer;
 pub mod prover;
 
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{address, keccak256, Address, FixedBytes, B256, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::Block;
@@ -129,7 +129,7 @@ where
     async fn fetch_init_bond(&self, game_type: u32) -> Result<U256>;
 
     /// Fetches the latest game index.
-    async fn fetch_latest_game_index(&self) -> Result<Option<U256>>;
+    async fn fetch_latest_game_index(&self, block: BlockId) -> Result<Option<U256>>;
 }
 
 #[async_trait]
@@ -157,8 +157,8 @@ where
     }
 
     /// Fetches the latest game index.
-    async fn fetch_latest_game_index(&self) -> Result<Option<U256>> {
-        let game_count = self.gameCount().call().await?;
+    async fn fetch_latest_game_index(&self, block: BlockId) -> Result<Option<U256>> {
+        let game_count = self.gameCount().block(block).call().await?;
 
         if game_count == U256::ZERO {
             tracing::debug!("No games exist yet");
@@ -175,6 +175,7 @@ where
 async fn is_parent_resolved<P>(
     parent_index: u32,
     factory: &DisputeGameFactoryInstance<P>,
+    pinned_block: BlockId,
 ) -> Result<bool>
 where
     P: Provider + Clone,
@@ -183,15 +184,17 @@ where
         return Ok(true);
     }
 
-    let parent_game_address = factory.gameAtIndex(U256::from(parent_index)).call().await?.proxy;
+    let parent_game_address =
+        factory.gameAtIndex(U256::from(parent_index)).block(pinned_block).call().await?.proxy;
     let parent_game_contract = IDisputeGame::new(parent_game_address, factory.provider());
 
-    Ok(parent_game_contract.status().call().await? != GameStatus::IN_PROGRESS)
+    Ok(parent_game_contract.status().block(pinned_block).call().await? != GameStatus::IN_PROGRESS)
 }
 
 async fn is_parent_challenger_wins<P>(
     parent_index: u32,
     factory: &DisputeGameFactoryInstance<P>,
+    pinned_block: BlockId,
 ) -> Result<bool>
 where
     P: Provider + Clone,
@@ -200,10 +203,12 @@ where
         return Ok(false);
     }
 
-    let parent_game_address = factory.gameAtIndex(U256::from(parent_index)).call().await?.proxy;
+    let parent_game_address =
+        factory.gameAtIndex(U256::from(parent_index)).block(pinned_block).call().await?.proxy;
     let parent_game_contract = IDisputeGame::new(parent_game_address, factory.provider());
 
-    Ok(parent_game_contract.status().call().await? == GameStatus::CHALLENGER_WINS)
+    Ok(parent_game_contract.status().block(pinned_block).call().await? ==
+        GameStatus::CHALLENGER_WINS)
 }
 
 /// Prefix used for transaction revert errors.

--- a/fault-proof/src/prometheus.rs
+++ b/fault-proof/src/prometheus.rs
@@ -22,6 +22,16 @@ pub enum ProposerGauge {
     )]
     AnchorGameL2BlockNumber,
     #[strum(
+        serialize = "op_succinct_fp_canonical_head_game_index",
+        message = "Canonical head game index (-1 when cleared)"
+    )]
+    CanonicalHeadGameIndex,
+    #[strum(
+        serialize = "op_succinct_fp_anchor_game_index",
+        message = "Anchor game index (-1 when cleared)"
+    )]
+    AnchorGameIndex,
+    #[strum(
         serialize = "op_succinct_fp_games_created",
         message = "Total number of games created by the proposer"
     )]

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -10,7 +10,7 @@ use std::{
 
 use tempfile::NamedTempFile;
 
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, FixedBytes, TxHash, B256, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_sol_types::{SolEvent, SolValue};
@@ -270,6 +270,15 @@ where
     /// Proposer identity with version and vkey information for monitoring and compatibility
     /// checks.
     pub identity: ProposerIdentity,
+    /// L1 block number used in the last successful sync cycle. Sync is skipped when the
+    /// pinned block hasn't advanced past this value.
+    last_synced_l1_block: Arc<AtomicU64>,
+    /// L2 block number of the most recently created game. Used to prevent duplicate
+    /// game creation when the pinned sync cache lags behind the chain tip.
+    last_created_game_l2_block: Arc<AtomicU64>,
+    /// Address of the most recently created game. Used to precisely identify
+    /// the guarded game for CHALLENGER_WINS subtree removal.
+    last_created_game_address: Arc<Mutex<Address>>,
 }
 
 impl<P, H> OPSuccinctProposer<P, H>
@@ -377,6 +386,9 @@ where
             state: Arc::new(RwLock::new(initial_state)),
             backup_semaphore: Arc::new(Semaphore::new(1)),
             identity,
+            last_synced_l1_block: Arc::new(AtomicU64::new(0)),
+            last_created_game_l2_block: Arc::new(AtomicU64::new(0)),
+            last_created_game_address: Arc::new(Mutex::new(Address::ZERO)),
         })
     }
 
@@ -549,7 +561,13 @@ where
                 .with_context(|| format!("backup path is not writable: {:?}", path))?;
 
             // Restore state from backup if available.
-            if let Some(restored) = ProposerState::try_restore(path) {
+            if let Some((restored, last_created_l2, last_created_addr)) =
+                ProposerState::try_restore(path)
+            {
+                // Restore the creation guard so duplicate-sibling protection survives restart.
+                self.last_created_game_l2_block.store(last_created_l2, Ordering::Relaxed);
+                *self.last_created_game_address.lock().await = last_created_addr;
+
                 let mut state = self.state.write().await;
                 state.cursor = restored.cursor;
                 state.games = restored.games;
@@ -623,14 +641,61 @@ where
     /// 2. `sync_anchor_game` aligns the cached anchor pointer with the registry contract.
     /// 3. `compute_canonical_head` recomputes the head game used for proposal selection.
     pub async fn sync_state(&self) -> Result<()> {
+        // Pin L1 block for the entire sync cycle so all state reads see a consistent
+        // snapshot. Without this, load-balanced RPCs can return data from different block
+        // heights, breaking atomicity between related reads (e.g. credit vs anchorGame).
+        // Ref: https://github.com/celo-org/op-succinct/issues/132
+        let latest_block = self
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .context("Failed to fetch latest L1 block")?;
+        let confirmed_number =
+            latest_block.header.number.saturating_sub(self.config.sync_l1_confirmations);
+
+        // If L1 hasn't advanced past the last synced block, all on-chain state is identical.
+        let prev = self.last_synced_l1_block.load(Ordering::Relaxed);
+        if confirmed_number > 0 && confirmed_number <= prev {
+            tracing::debug!(
+                confirmed_number,
+                last_synced = prev,
+                "L1 head unchanged, skipping sync"
+            );
+            return Ok(());
+        }
+
+        // When no confirmation offset, use the latest block directly (single RPC response).
+        // When offset > 0, fetch the confirmed block separately; if the backend hasn't
+        // caught up, skip this cycle rather than pinning forward.
+        let (pinned_block, pinned_timestamp) = if self.config.sync_l1_confirmations == 0 {
+            (BlockId::number(latest_block.header.number), latest_block.header.timestamp)
+        } else {
+            match self
+                .l1_provider
+                .get_block_by_number(BlockNumberOrTag::Number(confirmed_number))
+                .await?
+            {
+                Some(block) => (BlockId::number(block.header.number), block.header.timestamp),
+                None => {
+                    tracing::warn!(
+                        confirmed_number,
+                        "Confirmed block not available on this backend, skipping sync cycle"
+                    );
+                    return Ok(());
+                }
+            }
+        };
+
         // Pull new games and synchronize cached game statuses.
-        self.sync_games().await?;
+        self.sync_games(pinned_block, pinned_timestamp).await?;
 
         // Align anchor information after the cached game statuses have been synchronized.
-        self.sync_anchor_game().await?;
+        self.sync_anchor_game(pinned_block).await?;
 
         // With the cached game statuses and anchor synchronized, recompute the canonical head.
         self.compute_canonical_head().await;
+
+        self.last_synced_l1_block.store(confirmed_number, Ordering::Relaxed);
 
         Ok(())
     }
@@ -650,15 +715,54 @@ where
     /// 3. Evict games from the cache.
     ///    - Games that are finalized but there is no credit left to claim.
     ///    - The entire subtree of a CHALLENGER_WINS game.
-    pub async fn sync_games(&self) -> Result<()> {
+    pub async fn sync_games(&self, pinned_block: BlockId, pinned_timestamp: u64) -> Result<()> {
+        // 0. Prune cached games that don't exist at the pinned block. After a backup restore, the
+        //    cache may contain games created in tip blocks that are ahead of the pinned snapshot.
+        //    Reading their on-chain state at the pinned block would fail, and leaving them in the
+        //    cache would let compute_canonical_head pick a head that doesn't exist at the pinned
+        //    height.
+        let pinned_latest_index = self.factory.fetch_latest_game_index(pinned_block).await?;
+        {
+            let mut state = self.state.write().await;
+            let future_games: Vec<U256> = state
+                .games
+                .keys()
+                .filter(|idx| match pinned_latest_index {
+                    Some(max) => **idx > max,
+                    None => true,
+                })
+                .copied()
+                .collect();
+            if !future_games.is_empty() {
+                for idx in &future_games {
+                    state.games.remove(idx);
+                }
+                tracing::info!(
+                    count = future_games.len(),
+                    "Pruned games above pinned latest index"
+                );
+                // Clear anchor if it pointed to a pruned game.
+                let should_clear_anchor =
+                    state.anchor_game.as_ref().is_some_and(|a| !state.games.contains_key(&a.index));
+                if should_clear_anchor {
+                    state.anchor_game = None;
+                }
+            }
+        }
+
         // 1. Load new games.
-        let latest_index = if let Some(index) = self.factory.fetch_latest_game_index().await? {
+        let latest_index = if let Some(index) = pinned_latest_index {
             Cursor::from(index)
         } else {
+            // No games at pinned block. Reset cursor so future sync cycles can discover
+            // games once they become confirmed.
+            let mut state = self.state.write().await;
+            state.cursor = Cursor::none();
             return Ok(());
         };
 
-        let anchor_address = self.anchor_state_registry.anchorGame().call().await?;
+        let anchor_address =
+            self.anchor_state_registry.anchorGame().block(pinned_block).call().await?;
 
         let cursor = {
             let state = self.state.read().await;
@@ -689,7 +793,7 @@ where
             }
 
             let i = index.index().expect("must have an index here");
-            let fetch_result = self.fetch_game(i).await?;
+            let fetch_result = self.fetch_game(i, pinned_block).await?;
 
             match fetch_result {
                 GameFetchResult::ValidGame { game_address, deadline } => {
@@ -751,13 +855,7 @@ where
         };
 
         if !games.is_empty() {
-            let now_ts = self
-                .l1_provider
-                .get_block_by_number(BlockNumberOrTag::Latest)
-                .await?
-                .context("Failed to fetch latest L1 block timestamp")?
-                .header
-                .timestamp;
+            let now_ts = pinned_timestamp;
             let signer_address = self.signer.address();
 
             enum GameSyncAction {
@@ -778,26 +876,31 @@ where
             for (index, game_address) in games {
                 let contract =
                     OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
-                let claim_data = contract.claimData().call().await?;
-                let status = contract.status().call().await?;
+                let claim_data = contract.claimData().block(pinned_block).call().await?;
+                let status = contract.status().block(pinned_block).call().await?;
                 let deadline = U256::from(claim_data.deadline).to::<u64>();
                 let parent_index = claim_data.parentIndex;
 
-                let is_finalized =
-                    self.anchor_state_registry.isGameFinalized(game_address).call().await?;
+                let is_finalized = self
+                    .anchor_state_registry
+                    .isGameFinalized(game_address)
+                    .block(pinned_block)
+                    .call()
+                    .await?;
 
                 match status {
                     GameStatus::IN_PROGRESS => {
-                        let game_type = contract.gameType().call().await?;
+                        let game_type = contract.gameType().block(pinned_block).call().await?;
                         let parent_resolved =
-                            is_parent_resolved(parent_index, self.factory.as_ref()).await?;
+                            is_parent_resolved(parent_index, self.factory.as_ref(), pinned_block)
+                                .await?;
                         let is_game_over = match claim_data.status {
                             ProposalStatus::Unchallenged => now_ts >= deadline,
                             ProposalStatus::UnchallengedAndValidProofProvided |
                             ProposalStatus::ChallengedAndValidProofProvided => true,
                             _ => false,
                         };
-                        let creator = contract.gameCreator().call().await?;
+                        let creator = contract.gameCreator().block(pinned_block).call().await?;
                         let is_own_game = match claim_data.status {
                             ProposalStatus::Unchallenged => creator == signer_address,
                             ProposalStatus::UnchallengedAndValidProofProvided |
@@ -822,7 +925,8 @@ where
                         });
                     }
                     GameStatus::DEFENDER_WINS => {
-                        let credit = contract.credit(signer_address).call().await?;
+                        let credit =
+                            contract.credit(signer_address).block(pinned_block).call().await?;
 
                         if is_finalized && credit == U256::ZERO {
                             // Game removal policy:
@@ -841,20 +945,11 @@ where
                             let should_remove = if canonical_head_index == Some(index) {
                                 tracing::debug!(game_index = %index, "Retaining game: canonical head");
                                 false
+                            } else if anchor_address == game_address {
+                                tracing::debug!(game_index = %index, "Retaining game: anchor game");
+                                false
                             } else {
-                                let anchor_game_address = self
-                                    .anchor_state_registry
-                                    .anchorGame()
-                                    .call()
-                                    .await
-                                    .context("Failed to fetch anchor game for removal check")?;
-
-                                if anchor_game_address == game_address {
-                                    tracing::debug!(game_index = %index, "Retaining game: anchor game");
-                                    false
-                                } else {
-                                    true
-                                }
+                                true
                             };
 
                             if should_remove {
@@ -911,6 +1006,26 @@ where
                         tracing::debug!(game_index = %index, "Removed game from cache");
                     }
                     GameSyncAction::RemoveSubtree(index) => {
+                        // Reset the duplicate-creation guard if the subtree being
+                        // removed contains the exact game we created (matched by
+                        // address, which is globally unique and race-free).
+                        let guarded_addr = *self.last_created_game_address.lock().await;
+                        if guarded_addr != Address::ZERO {
+                            let subtree = state.descendants_of(index);
+                            let guard_in_subtree =
+                                std::iter::once(&index).chain(subtree.iter()).any(|idx| {
+                                    state.games.get(idx).is_some_and(|g| g.address == guarded_addr)
+                                });
+                            if guard_in_subtree {
+                                self.last_created_game_l2_block.store(0, Ordering::Relaxed);
+                                *self.last_created_game_address.lock().await = Address::ZERO;
+                                tracing::info!(
+                                    ?guarded_addr,
+                                    root_index = %index,
+                                    "Reset creation guard: tracked game removed by CHALLENGER_WINS"
+                                );
+                            }
+                        }
                         state.remove_subtree(index);
                     }
                 }
@@ -921,21 +1036,24 @@ where
     }
 
     /// Synchronizes the anchor game from the registry.
-    async fn sync_anchor_game(&self) -> Result<()> {
-        let anchor_address = self.anchor_state_registry.anchorGame().call().await?;
+    async fn sync_anchor_game(&self, pinned_block: BlockId) -> Result<()> {
+        let anchor_address =
+            self.anchor_state_registry.anchorGame().block(pinned_block).call().await?;
 
-        if anchor_address != Address::ZERO {
-            let mut state = self.state.write().await;
+        let mut state = self.state.write().await;
 
-            // Fetch the anchor game from the cache.
-            if let Some((_, anchor_game)) =
-                state.games.iter().find(|(_, game)| game.address == anchor_address)
-            {
-                state.anchor_game = Some(anchor_game.clone());
-                tracing::debug!(?anchor_address, "Anchor game updated in cache");
-            } else {
-                tracing::debug!(?anchor_address, "Anchor game not in cache yet");
-            }
+        if anchor_address == Address::ZERO {
+            state.anchor_game = None;
+        } else if let Some((_, anchor_game)) =
+            state.games.iter().find(|(_, game)| game.address == anchor_address)
+        {
+            state.anchor_game = Some(anchor_game.clone());
+            tracing::debug!(?anchor_address, "Anchor game updated in cache");
+        } else {
+            // Anchor not in cache (pruned or not yet fetched) — clear to prevent
+            // compute_canonical_head from following a stale subtree.
+            state.anchor_game = None;
+            tracing::debug!(?anchor_address, "Anchor game not in cache, clearing");
         }
 
         Ok(())
@@ -997,6 +1115,11 @@ where
             }
         } else {
             // Clear stale canonical head index when no valid games exist.
+            // canonical_head_l2_block is intentionally preserved — it serves as the anchor
+            // baseline for should_create_game() to propose the first game. Clearing it
+            // would permanently block proposals on fresh deployments or when the pinned
+            // snapshot has no games. The new canonical_head_index gauge (-1) provides
+            // observability for the "no head" state.
             state.canonical_head_index = None;
 
             if previous_canonical_index.is_some() {
@@ -1222,12 +1345,7 @@ where
             })
             .context("Could not find DisputeGameCreated event in transaction receipt logs")?;
 
-        // Fetch game index after creation
-        let game_count = self.factory.gameCount().call().await?;
-        let game_index = game_count - U256::from(1);
-
         tracing::info!(
-            game_index = %game_index,
             game_address = ?game_address,
             tx_hash = ?receipt.transaction_hash,
             "Game created successfully"
@@ -1395,7 +1513,7 @@ where
     /// - The game's anchor state registry does not match the configured registry.
     /// - The game type does not respect the expected type when created.
     /// - The output root claim is invalid.
-    pub async fn fetch_game(&self, index: U256) -> Result<GameFetchResult> {
+    pub async fn fetch_game(&self, index: U256, pinned_block: BlockId) -> Result<GameFetchResult> {
         {
             let state = self.state.read().await;
 
@@ -1404,7 +1522,7 @@ where
             }
         }
 
-        let game = self.factory.gameAtIndex(index).call().await?;
+        let game = self.factory.gameAtIndex(index).block(pinned_block).call().await?;
         let game_address = game.proxy;
         let game_type = game.gameType;
 
@@ -1424,7 +1542,7 @@ where
 
         // Drop games with a different anchor state registry. During hardfork transitions,
         // old ASR games must not enter the DAG or they can pollute canonical head selection.
-        let game_asr = contract.anchorStateRegistry().call().await?;
+        let game_asr = contract.anchorStateRegistry().block(pinned_block).call().await?;
         if game_asr != *self.anchor_state_registry.address() {
             tracing::warn!(
                 game_index = %index,
@@ -1436,12 +1554,13 @@ where
             return Ok(GameFetchResult::UnsupportedAnchorStateRegistry { game_address });
         }
 
-        let l2_block = contract.l2BlockNumber().call().await?;
+        let l2_block = contract.l2BlockNumber().block(pinned_block).call().await?;
         let output_root = self.l2_provider.compute_output_root_at_block(l2_block).await?;
-        let claim = contract.rootClaim().call().await?;
-        let was_respected = contract.wasRespectedGameTypeWhenCreated().call().await?;
-        let status = contract.status().call().await?;
-        let claim_data = contract.claimData().call().await?;
+        let claim = contract.rootClaim().block(pinned_block).call().await?;
+        let was_respected =
+            contract.wasRespectedGameTypeWhenCreated().block(pinned_block).call().await?;
+        let status = contract.status().block(pinned_block).call().await?;
+        let claim_data = contract.claimData().block(pinned_block).call().await?;
 
         let (parent_index, proposal_status, deadline) = (
             claim_data.parentIndex,
@@ -1449,9 +1568,12 @@ where
             U256::from(claim_data.deadline).to::<u64>(),
         );
 
-        let aggregation_vkey = B256::from(contract.aggregationVkey().call().await?.0);
-        let range_vkey_commitment = B256::from(contract.rangeVkeyCommitment().call().await?.0);
-        let rollup_config_hash = B256::from(contract.rollupConfigHash().call().await?.0);
+        let aggregation_vkey =
+            B256::from(contract.aggregationVkey().block(pinned_block).call().await?.0);
+        let range_vkey_commitment =
+            B256::from(contract.rangeVkeyCommitment().block(pinned_block).call().await?.0);
+        let rollup_config_hash =
+            B256::from(contract.rollupConfigHash().block(pinned_block).call().await?.0);
 
         // Drop games whose type does not respect the expected type.
         if !was_respected {
@@ -1557,17 +1679,29 @@ where
             "Creating game"
         );
 
-        self.create_game(output_root, extra_data).await?;
+        let game_address = self.create_game(output_root, extra_data).await?;
+
+        // Record the L2 block and address so should_create_game() skips duplicate
+        // creation while the pinned cache hasn't caught up to this game.
+        self.last_created_game_l2_block
+            .store(next_l2_block_number_for_proposal.to::<u64>(), Ordering::Relaxed);
+        *self.last_created_game_address.lock().await = game_address;
 
         Ok(())
     }
 
     /// Fetch the proposer metrics.
     async fn fetch_proposer_metrics(&self) -> Result<()> {
-        let (canonical_head_l2_block, anchor_game) = {
+        let (canonical_head_l2_block, canonical_head_index, anchor_game) = {
             let state = self.state.read().await;
-            (state.canonical_head_l2_block, state.anchor_game.clone())
+            (state.canonical_head_l2_block, state.canonical_head_index, state.anchor_game.clone())
         };
+
+        // Index-based metrics use -1 as sentinel for "cleared/absent" since index 0 is valid.
+        ProposerGauge::CanonicalHeadGameIndex
+            .set(canonical_head_index.map_or(-1.0, |idx| idx.to::<u64>() as f64));
+        ProposerGauge::AnchorGameIndex
+            .set(anchor_game.as_ref().map_or(-1.0, |g| g.index.to::<u64>() as f64));
 
         if let Some(canonical_head_l2_block) = canonical_head_l2_block {
             ProposerGauge::LatestGameL2BlockNumber.set(canonical_head_l2_block.to::<u64>() as f64);
@@ -1578,6 +1712,8 @@ where
                 .await?
             {
                 ProposerGauge::FinalizedL2BlockNumber.set(finalized_l2_block_number as f64);
+            } else {
+                ProposerGauge::FinalizedL2BlockNumber.set(0.0);
             }
 
             if let Some(anchor_game) = anchor_game {
@@ -1586,7 +1722,7 @@ where
                 ProposerGauge::AnchorGameL2BlockNumber.set(0.0);
             }
         } else {
-            tracing::warn!("canonical_head_l2_block is None; skipping metrics update");
+            tracing::warn!("canonical_head_l2_block is None; skipping L2 block metrics update");
         }
 
         // Update active proving tasks metric
@@ -1796,6 +1932,11 @@ where
             }
 
             ProposerGauge::GamesCreated.increment(1.0);
+
+            // Persist the creation guard immediately so a crash before the next periodic
+            // backup doesn't lose the duplicate-creation protection.
+            proposer.backup().await;
+
             Ok(())
         });
 
@@ -1823,7 +1964,7 @@ where
     /// proposal, and the parent game index.
     /// If a game should not be created, dummy values are returned for the next L2 block number for
     /// proposal and parent game index.
-    async fn should_create_game(&self) -> Result<(bool, U256, u32)> {
+    pub async fn should_create_game(&self) -> Result<(bool, U256, u32)> {
         // In fast finality mode, resume proving for existing games before creating new ones
         // TODO(fakedev9999): Consider unifying proving concurrency control for both fast finality
         // and defense proving with a priority system.
@@ -1976,6 +2117,19 @@ where
         let next_l2_block_number_for_proposal =
             canonical_head_l2_block + U256::from(self.config.proposal_interval_in_blocks);
 
+        // Guard against duplicate creation when the pinned cache lags behind the tip.
+        // If we recently created a game at or beyond this L2 block, skip until the
+        // cache catches up and advances canonical_head_l2_block.
+        let last_created = self.last_created_game_l2_block.load(Ordering::Relaxed);
+        if last_created > 0 && next_l2_block_number_for_proposal.to::<u64>() <= last_created {
+            tracing::debug!(
+                next_l2_block = %next_l2_block_number_for_proposal,
+                last_created,
+                "Skipping game creation: recently created game not yet visible in pinned cache"
+            );
+            return Ok((false, U256::ZERO, u32::MAX));
+        }
+
         let finalized_l2_head_block_number = self
             .host
             .get_finalized_l2_block_number(&self.fetcher, canonical_head_l2_block.to::<u64>())
@@ -2001,7 +2155,9 @@ where
             return;
         };
 
-        let backup = self.state.read().await.to_backup();
+        let mut backup = self.state.read().await.to_backup();
+        backup.last_created_game_l2_block = self.last_created_game_l2_block.load(Ordering::Relaxed);
+        backup.last_created_game_address = *self.last_created_game_address.lock().await;
         let path = path.clone();
         tokio::task::spawn_blocking(move || {
             if let Err(e) = backup.save(&path) {
@@ -2386,16 +2542,20 @@ impl ProposerState {
     }
 
     /// Try to restore state from a backup file. Returns None if file doesn't exist or is invalid.
-    pub fn try_restore(path: &Path) -> Option<Self> {
+    pub fn try_restore(path: &Path) -> Option<(Self, u64, Address)> {
         let backup = ProposerBackup::load(path)?;
+        let last_created_l2 = backup.last_created_game_l2_block;
+        let last_created_addr = backup.last_created_game_address;
         let state = Self::from_backup(backup);
         tracing::info!(
             ?path,
             games = state.games.len(),
             cursor = %state.cursor,
+            last_created_l2,
+            ?last_created_addr,
             "Proposer state restored from backup"
         );
-        Some(state)
+        Some((state, last_created_l2, last_created_addr))
     }
 }
 

--- a/fault-proof/tests/backup.rs
+++ b/fault-proof/tests/backup.rs
@@ -147,7 +147,10 @@ mod integration {
     use tokio::time::{sleep, Duration};
     use tracing::info;
 
-    use crate::common::{new_proposer, TestEnvironment};
+    use alloy_primitives::U256;
+    use fault_proof::backup::ProposerBackup;
+
+    use crate::common::TestEnvironment;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_proposer_backup_persistence() -> Result<()> {
@@ -159,17 +162,7 @@ mod integration {
         let backup_path = backup_dir.path().join("proposer_backup.json");
 
         // Phase 1: Start proposer with backup enabled
-        let proposer = Arc::new(
-            new_proposer(
-                &env.rpc_config,
-                env.private_keys.proposer,
-                &env.deployed.anchor_state_registry,
-                &env.deployed.factory,
-                env.game_type,
-                Some(backup_path.clone()),
-            )
-            .await?,
-        );
+        let proposer = Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 0).await?);
 
         let proposer_clone = proposer.clone();
         let proposer_handle = tokio::spawn(async move { proposer_clone.run().await });
@@ -192,17 +185,8 @@ mod integration {
         proposer_handle.abort();
 
         // Phase 2: Restart and verify backup load
-        let proposer2 = Arc::new(
-            new_proposer(
-                &env.rpc_config,
-                env.private_keys.proposer,
-                &env.deployed.anchor_state_registry,
-                &env.deployed.factory,
-                env.game_type,
-                Some(backup_path.clone()),
-            )
-            .await?,
-        );
+        let proposer2 =
+            Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 0).await?);
 
         proposer2.try_init().await?;
 
@@ -216,6 +200,224 @@ mod integration {
         );
 
         info!("Backup persistence test complete");
+        Ok(())
+    }
+
+    /// Tests that backup-restored games above the pinned latest index are pruned during
+    /// sync, while older games survive.
+    ///
+    /// Deterministic setup: create game 0, mine an empty L1 block, create game 1. Then
+    /// restart from backup with sync_l1_confirmations=1 so the pinned block is between
+    /// game 0 and game 1. Game 0 should survive; game 1 should be pruned.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_backup_partial_prune_with_confirmations() -> Result<()> {
+        info!("=== Test: Backup Partial Prune With Confirmations ===");
+
+        let env = TestEnvironment::setup().await?;
+        let starting_l2_block = env.anvil.starting_l2_block_number;
+
+        let backup_dir = TempDir::new()?;
+        let backup_path = backup_dir.path().join("proposer_backup.json");
+
+        // Phase 1: Create two games with an empty L1 block between them.
+        let factory = env.factory()?;
+        let init_bond = factory.initBonds(env.game_type).call().await?;
+
+        // Game 0 at L1 block B.
+        let block_0 = starting_l2_block + 1;
+        let root_claim_0 = env.compute_output_root_at_block(block_0).await?;
+        env.create_game(root_claim_0, block_0, u32::MAX, init_bond).await?;
+        info!("✓ Created game 0 at L2 block {}", block_0);
+
+        // Mine an empty L1 block to create a gap.
+        env.warp_time(0).await?;
+
+        // Game 1 at L1 block B+2 (after the gap).
+        let block_1 = starting_l2_block + 2;
+        let root_claim_1 = env.compute_output_root_at_block(block_1).await?;
+        env.create_game(root_claim_1, block_1, 0, init_bond).await?;
+        info!("✓ Created game 1 at L2 block {}", block_1);
+
+        // Phase 2: Construct and save backup containing both games.
+        // We build the backup directly rather than running the proposer loop, so the
+        // backup content is deterministic and guaranteed to exist.
+        let proposer_phase2 =
+            Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 0).await?);
+        proposer_phase2.try_init().await?;
+        proposer_phase2.sync_state().await?;
+
+        let snapshot = proposer_phase2.state_snapshot().await;
+        assert_eq!(snapshot.games.len(), 2, "Both games should be cached");
+
+        // Save backup from real cached games (with correct on-chain addresses).
+        let game_0 = proposer_phase2.get_game(U256::from(0)).await.expect("game 0 in cache");
+        let game_1 = proposer_phase2.get_game(U256::from(1)).await.expect("game 1 in cache");
+
+        let backup = ProposerBackup::new(
+            Some(U256::from(1)), // cursor at game 1
+            vec![game_0, game_1],
+            None, // no anchor yet
+        );
+        backup.save(&backup_path)?;
+        info!("Phase 2: backup saved with {} games", snapshot.games.len());
+
+        // Phase 3: Restart from backup with confirmations=1.
+        // latest is the block containing game 1. latest-1 is the gap block,
+        // where only game 0 exists in the factory.
+        let proposer3 =
+            Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 1).await?);
+        proposer3.try_init().await?;
+
+        // Verify: backup was restored with both games before sync prunes.
+        let snapshot_restored = proposer3.state_snapshot().await;
+        assert_eq!(
+            snapshot_restored.games.len(),
+            2,
+            "Both games should be restored from backup before sync"
+        );
+
+        proposer3.sync_state().await?;
+
+        let snapshot_after = proposer3.state_snapshot().await;
+        info!("Phase 3: {} games after sync with confirmations=1", snapshot_after.games.len());
+
+        // Game 0 should survive (exists at pinned block).
+        assert_eq!(snapshot_after.games.len(), 1, "Only game 0 should survive");
+        assert!(
+            snapshot_after.games.iter().any(|(idx, _)| *idx == U256::from(0)),
+            "Game 0 should be retained"
+        );
+
+        // Canonical head should be game 0, not game 1.
+        assert_eq!(
+            snapshot_after.canonical_head_index,
+            Some(U256::from(0)),
+            "Canonical head should be game 0"
+        );
+
+        info!("Backup partial prune test complete");
+        Ok(())
+    }
+
+    /// Tests that backup restore with pinned block having zero games clears all state.
+    ///
+    /// Saves a backup containing a game, then restarts with confirmations large enough
+    /// that the pinned block predates all game creation. Verifies the cache is fully cleared.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_backup_restore_pinned_block_no_games() -> Result<()> {
+        info!("=== Test: Backup Restore With Pinned Block Having Zero Games ===");
+
+        let env = TestEnvironment::setup().await?;
+        let starting_l2_block = env.anvil.starting_l2_block_number;
+
+        let backup_dir = TempDir::new()?;
+        let backup_path = backup_dir.path().join("proposer_backup.json");
+
+        // Phase 1: Create a game on-chain and sync it into the proposer.
+        let factory = env.factory()?;
+        let init_bond = factory.initBonds(env.game_type).call().await?;
+        let block = starting_l2_block + 1;
+        let root_claim = env.compute_output_root_at_block(block).await?;
+        env.create_game(root_claim, block, u32::MAX, init_bond).await?;
+        info!("✓ Created game 0");
+
+        let proposer_phase1 =
+            Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 0).await?);
+        proposer_phase1.try_init().await?;
+        proposer_phase1.sync_state().await?;
+        let game_0 = proposer_phase1.get_game(U256::from(0)).await.expect("game 0 in cache");
+
+        // Phase 2: Save backup with real game data.
+        let backup = ProposerBackup::new(Some(U256::from(0)), vec![game_0], None);
+        backup.save(&backup_path)?;
+
+        // Phase 3: Restart with huge confirmations so pinned block is before all games.
+        let proposer =
+            Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 1_000_000).await?);
+        proposer.try_init().await?;
+
+        // Verify: backup was restored with game 0.
+        let snapshot_restored = proposer.state_snapshot().await;
+        assert_eq!(snapshot_restored.games.len(), 1, "Game 0 should be restored from backup");
+
+        proposer.sync_state().await?;
+
+        let snapshot = proposer.state_snapshot().await;
+        assert!(snapshot.games.is_empty(), "Games should be empty");
+        assert!(snapshot.anchor_index.is_none(), "Anchor should be None");
+        assert!(snapshot.canonical_head_index.is_none(), "Canonical head should be None");
+        // Note: canonical_head_l2_block is intentionally not asserted — current semantics
+        // only clear canonical_head_index, not the stored baseline L2 block.
+
+        info!("Backup restore pinned block no games test complete");
+        Ok(())
+    }
+
+    /// Tests that games pruned due to confirmation lag are rediscovered once confirmed.
+    ///
+    /// With sync_l1_confirmations=1, the first sync pins to the block before game creation
+    /// — cache is empty and cursor is reset. After mining one more block, the second sync
+    /// pins to the game creation block and rediscovers the game.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_backup_prune_then_rediscover_after_confirmation() -> Result<()> {
+        info!("=== Test: Prune Then Rediscover After Confirmation ===");
+
+        let env = TestEnvironment::setup().await?;
+        let starting_l2_block = env.anvil.starting_l2_block_number;
+
+        let backup_dir = TempDir::new()?;
+        let backup_path = backup_dir.path().join("proposer_backup.json");
+
+        // Create game 0 on-chain.
+        let factory = env.factory()?;
+        let init_bond = factory.initBonds(env.game_type).call().await?;
+        let block_0 = starting_l2_block + 1;
+        let root_claim = env.compute_output_root_at_block(block_0).await?;
+        env.create_game(root_claim, block_0, u32::MAX, init_bond).await?;
+        info!("✓ Created game 0 at L2 block {}", block_0);
+
+        // Sync game 0 into proposer and save real backup.
+        let proposer_setup =
+            Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 0).await?);
+        proposer_setup.try_init().await?;
+        proposer_setup.sync_state().await?;
+        let game_0 = proposer_setup.get_game(U256::from(0)).await.expect("game 0");
+
+        let backup = ProposerBackup::new(Some(U256::from(0)), vec![game_0], None);
+        backup.save(&backup_path)?;
+
+        // Restart with confirmations=1. Latest is the game creation block,
+        // so pinned = latest - 1 = block before game 0. Game gets pruned.
+        let proposer = Arc::new(env.new_proposer_with_options(Some(backup_path.clone()), 1).await?);
+        proposer.try_init().await?;
+
+        let snapshot_restored = proposer.state_snapshot().await;
+        assert_eq!(snapshot_restored.games.len(), 1, "Game 0 restored from backup");
+
+        proposer.sync_state().await?;
+
+        let snapshot_pruned = proposer.state_snapshot().await;
+        assert!(snapshot_pruned.games.is_empty(), "Game 0 pruned (not yet confirmed)");
+        assert!(snapshot_pruned.canonical_head_index.is_none(), "No canonical head");
+
+        // Mine one empty block so pinned = latest - 1 = game creation block.
+        env.warp_time(0).await?;
+
+        proposer.sync_state().await?;
+
+        let snapshot_rediscovered = proposer.state_snapshot().await;
+        assert_eq!(
+            snapshot_rediscovered.games.len(),
+            1,
+            "Game 0 should be rediscovered after confirmation"
+        );
+        assert_eq!(
+            snapshot_rediscovered.canonical_head_index,
+            Some(U256::from(0)),
+            "Canonical head should be game 0"
+        );
+
+        info!("Prune then rediscover test complete");
         Ok(())
     }
 }

--- a/fault-proof/tests/common/env.rs
+++ b/fault-proof/tests/common/env.rs
@@ -1,5 +1,6 @@
 //! Common test environment setup utilities.
 use std::{
+    path::PathBuf,
     str::FromStr,
     sync::{Arc, OnceLock},
     time::Duration,
@@ -43,7 +44,8 @@ use tracing_subscriber::{filter::Targets, fmt, prelude::*, util::SubscriberInitE
 use crate::common::{
     constants::*,
     contracts::{deploy_mock_permissioned_game, send_contract_transaction},
-    new_challenger, new_proposer, start_challenger, start_proposer, warp_time, ANVIL,
+    new_challenger, new_proposer, new_proposer_with_confirmations, start_challenger,
+    start_proposer, warp_time, ANVIL,
 };
 
 use super::{
@@ -259,6 +261,23 @@ impl TestEnvironment {
             &self.deployed.factory,
             self.game_type,
             None,
+        )
+        .await
+    }
+
+    pub async fn new_proposer_with_options(
+        &self,
+        backup_path: Option<PathBuf>,
+        sync_l1_confirmations: u64,
+    ) -> Result<OPSuccinctProposer<fault_proof::L1Provider, impl OPSuccinctHost + Clone>> {
+        new_proposer_with_confirmations(
+            &self.rpc_config,
+            self.private_keys.proposer,
+            &self.deployed.anchor_state_registry,
+            &self.deployed.factory,
+            self.game_type,
+            backup_path,
+            sync_l1_confirmations,
         )
         .await
     }

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -27,6 +27,27 @@ pub async fn new_proposer(
     game_type: u32,
     backup_path: Option<PathBuf>,
 ) -> Result<OPSuccinctProposer<fault_proof::L1Provider, impl OPSuccinctHost + Clone>> {
+    new_proposer_with_confirmations(
+        rpc_config,
+        private_key,
+        anchor_state_registry_address,
+        factory_address,
+        game_type,
+        backup_path,
+        0,
+    )
+    .await
+}
+
+pub async fn new_proposer_with_confirmations(
+    rpc_config: &RPCConfig,
+    private_key: &str,
+    anchor_state_registry_address: &Address,
+    factory_address: &Address,
+    game_type: u32,
+    backup_path: Option<PathBuf>,
+    sync_l1_confirmations: u64,
+) -> Result<OPSuccinctProposer<fault_proof::L1Provider, impl OPSuccinctHost + Clone>> {
     // Create signer directly from private key
     let signer = SignerLock::new(op_succinct_signer_utils::Signer::new_local_signer(private_key)?);
 
@@ -65,6 +86,7 @@ pub async fn new_proposer(
             min_auction_period: 1,
             whitelist: None,
         },
+        sync_l1_confirmations,
     };
 
     let l1_provider = ProviderBuilder::default().connect_http(rpc_config.l1_rpc.clone());

--- a/fault-proof/tests/sync.rs
+++ b/fault-proof/tests/sync.rs
@@ -70,6 +70,7 @@ mod proposer_sync {
         },
         TestEnvironment,
     };
+    use alloy_eips::BlockId;
     use alloy_primitives::{Bytes, FixedBytes, Uint, U256};
     use alloy_sol_types::{SolCall, SolValue};
     use anyhow::{Context, Result};
@@ -261,7 +262,7 @@ mod proposer_sync {
         proposer.sync_state().await?;
 
         for i in 0..10 {
-            let fetch_result = proposer.fetch_game(U256::from(i)).await?;
+            let fetch_result = proposer.fetch_game(U256::from(i), BlockId::latest()).await?;
             assert!(matches!(fetch_result, GameFetchResult::AlreadyExists));
         }
 
@@ -287,7 +288,7 @@ mod proposer_sync {
 
         proposer.sync_state().await?;
 
-        let fetch_result = proposer.fetch_game(U256::from(0)).await?;
+        let fetch_result = proposer.fetch_game(U256::from(0), BlockId::latest()).await?;
         assert!(matches!(fetch_result, GameFetchResult::InvalidGame { .. }));
 
         let snapshot = proposer.state_snapshot().await;
@@ -495,7 +496,7 @@ mod proposer_sync {
 
         // Verify: fetch_game on legacy games returns UnsupportedType
         for (index, (_, is_valid)) in game_sequence.iter().enumerate() {
-            let fetch_result = proposer.fetch_game(U256::from(index)).await?;
+            let fetch_result = proposer.fetch_game(U256::from(index), BlockId::latest()).await?;
             if *is_valid {
                 assert!(
                     matches!(fetch_result, GameFetchResult::AlreadyExists),
@@ -551,14 +552,15 @@ mod proposer_sync {
         snapshot.assert_canonical_head(Some(1), 3, starting_l2_block);
 
         // Verify: fetch_game on non-respected game returns InvalidGame
-        let non_respected_fetch_result = proposer.fetch_game(U256::from(0)).await?;
+        let non_respected_fetch_result =
+            proposer.fetch_game(U256::from(0), BlockId::latest()).await?;
         assert!(
             matches!(non_respected_fetch_result, GameFetchResult::InvalidGame { .. }),
             "Game created with non-respected type should be filtered as InvalidGame"
         );
 
         // Verify: fetch_game on the latest valid game returns AlreadyExists
-        let valid_fetch_result = proposer.fetch_game(U256::from(1)).await?;
+        let valid_fetch_result = proposer.fetch_game(U256::from(1), BlockId::latest()).await?;
         assert!(
             matches!(valid_fetch_result, GameFetchResult::AlreadyExists),
             "Valid game at index 1 should be cached"
@@ -1565,6 +1567,150 @@ mod proposer_sync {
         );
 
         tracing::info!("✓ Defense task correctly spawned for game 1: {:?}", game_addresses[1]);
+
+        Ok(())
+    }
+
+    /// Tests that the duplicate-creation guard in should_create_game() is specifically
+    /// what prevents sibling games when the pinned cache hasn't caught up.
+    ///
+    /// Isolation: calls should_create_game BEFORE and AFTER handle_game_creation with
+    /// the same stale cache state. The only difference between the two calls is the
+    /// guard value, proving the guard is the cause of the false return.
+    #[tokio::test]
+    async fn test_duplicate_creation_guard_blocks_stale_cache() -> Result<()> {
+        let (env, proposer, init_bond) = setup().await?;
+        let starting_l2_block = env.anvil.starting_l2_block_number;
+
+        // Create game 0 as anchor/canonical head.
+        let block_0 = starting_l2_block + 1;
+        let root_claim_0 = env.compute_output_root_at_block(block_0).await?;
+        env.create_game(root_claim_0, block_0, M, init_bond).await?;
+
+        proposer.sync_state().await?;
+        let snapshot = proposer.state_snapshot().await;
+        assert_eq!(snapshot.canonical_head_index, Some(U256::from(0)));
+
+        // Baseline: should_create_game BEFORE setting the guard.
+        // Record what it returns with the current (non-guarded) state.
+        let (should_create_before, _, _) = proposer.should_create_game().await?;
+
+        // Create game 1 via handle_game_creation — this sets the guard.
+        let proposal_interval = proposer.config.proposal_interval_in_blocks;
+        let next_block = block_0 + proposal_interval;
+
+        // Precondition: baseline must allow creation so we can isolate the guard.
+        // In the test environment (mock mode + anvil), finalization should not block.
+        assert!(
+            should_create_before,
+            "Precondition failed: should_create_game must return true before guard is set"
+        );
+
+        proposer.handle_game_creation(U256::from(next_block), 0).await?;
+
+        // DO NOT sync — cache is stale, still sees only game 0.
+        // The only state change since baseline is the guard being set.
+        let (should_create_after, _, _) = proposer.should_create_game().await?;
+        assert!(
+            !should_create_after,
+            "Guard should block creation: baseline returned true, guard is the only change"
+        );
+
+        // Sync to catch up, then verify guard clears.
+        proposer.sync_state().await?;
+
+        let snapshot_after = proposer.state_snapshot().await;
+        assert_eq!(snapshot_after.games.len(), 2, "Both games should be in cache after sync");
+
+        // After sync, canonical head advances to game 1. should_create_game now computes
+        // next_l2_block = game_1.l2_block + interval > last_created, so the guard no
+        // longer blocks (even though the guard value is still set). This proves the full
+        // lifecycle: set on creation → blocks while stale → naturally bypassed when head
+        // advances past the created game.
+        let (should_create_after_sync, _, _) = proposer.should_create_game().await?;
+        assert_eq!(
+            should_create_after_sync, should_create_before,
+            "After sync, canonical head should advance past guard so creation is allowed again"
+        );
+
+        Ok(())
+    }
+
+    /// Tests that the CHALLENGER_WINS subtree removal clears the creation guard when the
+    /// guarded game is in the removed subtree.
+    ///
+    /// Scenario:
+    /// 1. Create game 0 (anchor), sync.
+    /// 2. Create game 1 via handle_game_creation (sets guard, blocks further creation).
+    /// 3. Sync — game 1 enters cache. Guard still set but naturally bypassed.
+    /// 4. Challenge game 1, warp past deadline, resolve as CHALLENGER_WINS.
+    /// 5. Sync — RemoveSubtree fires, guard is cleared because game 1's address matches.
+    /// 6. should_create_game returns true with a fresh target block.
+    ///
+    /// Without the address-based invalidation, the guard would stay set and permanently
+    /// block creation after the branch switch.
+    #[tokio::test]
+    async fn test_challenger_wins_clears_creation_guard() -> Result<()> {
+        let (env, proposer, init_bond) = setup().await?;
+        let starting_l2_block = env.anvil.starting_l2_block_number;
+
+        // Step 1: Create game 0 as anchor.
+        let block_0 = starting_l2_block + 1;
+        let root_claim_0 = env.compute_output_root_at_block(block_0).await?;
+        env.create_game(root_claim_0, block_0, M, init_bond).await?;
+        let (_, game_0_address) = env.last_game_info().await?;
+
+        proposer.sync_state().await?;
+        let snapshot = proposer.state_snapshot().await;
+        assert_eq!(snapshot.canonical_head_index, Some(U256::from(0)));
+
+        // Step 2: Verify baseline allows creation.
+        let (baseline, _, _) = proposer.should_create_game().await?;
+        assert!(baseline, "Precondition: creation must be allowed before guard is set");
+
+        // Create game 1 via handle_game_creation (sets the guard).
+        let proposal_interval = proposer.config.proposal_interval_in_blocks;
+        let next_block = block_0 + proposal_interval;
+        proposer.handle_game_creation(U256::from(next_block), 0).await?;
+
+        let (_, game_1_address) = env.last_game_info().await?;
+
+        // Verify guard blocks.
+        let (blocked, _, _) = proposer.should_create_game().await?;
+        assert!(!blocked, "Guard should block creation with stale cache");
+
+        // Step 3: Sync so game 1 enters cache.
+        proposer.sync_state().await?;
+        let snapshot = proposer.state_snapshot().await;
+        assert_eq!(snapshot.games.len(), 2);
+
+        // Step 4: Challenge game 1, then resolve parent (game 0) first.
+        // The contract requires the parent to be resolved before a child can resolve.
+        env.challenge_game(game_1_address).await?;
+        env.warp_time(MAX_CHALLENGE_DURATION + 1).await?;
+        env.resolve_game(game_0_address).await?;
+
+        // Now resolve game 1 as CHALLENGER_WINS (challenged + prove deadline expired).
+        env.warp_time(MAX_PROVE_DURATION + 1).await?;
+        env.resolve_game(game_1_address).await?;
+
+        // Step 5: Sync — CHALLENGER_WINS triggers RemoveSubtree.
+        // The guard should be cleared because game 1's address matches.
+        proposer.sync_state().await?;
+
+        let snapshot = proposer.state_snapshot().await;
+        assert!(
+            !snapshot.games.iter().any(|(_, addr)| *addr == game_1_address),
+            "Game 1 should be removed (CHALLENGER_WINS)"
+        );
+
+        // Step 6: Verify creation is unblocked.
+        // After CHALLENGER_WINS, canonical head reverts to game 0. The guard was cleared
+        // by the subtree removal, so should_create_game uses game 0 as head and computes
+        // a fresh next_l2_block. Without the address-based clear, the guard would still
+        // be set at next_block and would block this.
+        let (unblocked, _, _) = proposer.should_create_game().await?;
+        assert!(unblocked, "Creation should be unblocked after CHALLENGER_WINS clears the guard");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
Backport of PR #865 (merged to main) to `release/v3.x`.

Fixes the Celo March 26 incident root cause: with load-balanced RPCs (proxyd, Alchemy, etc.), different `eth_call` requests within the same sync cycle can hit backends at different block heights, breaking atomicity between related state reads and causing canonical head to be incorrectly cleared (~470 orphaned games).

Key changes:
- **L1 block pinning**: Fetch L1 block once at start of `sync_state()` and thread through all downstream reads. Pinned paths: `sync_games`, `fetch_game`, `sync_anchor_game`, `is_parent_resolved` / `is_parent_challenger_wins`. Not pinned: `prove_game`, `resolve_game`, `claim_bond`, `create_game` tx submission paths.
- **Confirmation offset (`SYNC_L1_CONFIRMATIONS`)**: New env var (default `0`). Pins reads to `latest - N` for deployments with unstable backends.
- **Skip sync when head unchanged**: `last_synced_l1_block` tracks last successful sync; skip cycle when confirmed block hasn't advanced.
- **Backup-restore safety**: Prune future games above `pinned_latest_index`, clear stale anchor, reset cursor when pinned snapshot has zero games, preserve anchor baseline.
- **Duplicate game creation prevention**: `last_created_game_l2_block` + `last_created_game_address` guard against sibling games with the same parent when `sync_l1_confirmations > 0`. Persisted in backup; cleared on CHALLENGER_WINS subtree removal matching exact guarded address.
- **Metrics**: New `op_succinct_fp_canonical_head_game_index` and `op_succinct_fp_anchor_game_index` gauges; `FinalizedL2BlockNumber` now resets to 0.0 when `None`.
- **RPC call reduction**: Single `get_block_by_number(Latest)`; reuse `anchor_address` in `sync_games`; remove race-prone `gameCount()` from creation log path; O(1) anchor check.

Tracking: [cloud-ops#98](https://github.com/succinctlabs/cloud-ops/issues/98). Follow-up validation: [cloud-ops#102](https://github.com/succinctlabs/cloud-ops/issues/102), [cloud-ops#103](https://github.com/succinctlabs/cloud-ops/issues/103).

## Backport-specific changes
None — clean cherry-pick (2 files auto-merged: `config.rs`, `tests/common/env.rs`). No branch-specific adaptations required.

## Equivalence verification
- [x] File-by-file diff comparison against source PR — identical modulo git index hashes and hunk line numbers
- [x] 11 files touched, +735/-116 (matches source PR exactly)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features` passes
- [ ] CI passes

## Test plan
- [ ] CI (Fault Proof sync + sysgo e2e)
- [ ] Backup partial-prune test
- [ ] Backup zero-games test
- [ ] Backup rediscovery test
- [ ] Duplicate creation guard test
- [ ] CHALLENGER_WINS guard invalidation test
- [ ] Celo Sepolia deployment for extended testing