### PR TITLE
fix(fault-proof): correct maxChallengeDuration return type to uint64

### DIFF
--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -101,7 +101,7 @@ sol! {
         function gameOver() external view returns (bool gameOver_);
 
         /// @notice Returns the max challenge duration.
-        function maxChallengeDuration() external view returns (uint256 maxChallengeDuration_);
+        function maxChallengeDuration() external view returns (uint64 maxChallengeDuration_);
 
         /// @notice Returns the max prove duration.
         function maxProveDuration() external view returns (uint64 maxProveDuration_);

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -523,7 +523,7 @@ where
 
         // Fetch contract params from game implementation.
         let game_impl = self.factory.game_impl(self.config.game_type).await?;
-        let max_challenge_duration = game_impl.maxChallengeDuration().call().await?.to::<u64>();
+        let max_challenge_duration = game_impl.maxChallengeDuration().call().await?;
         let max_prove_duration = game_impl.maxProveDuration().call().await?;
         let contract_params = ContractParams { max_challenge_duration, max_prove_duration };
 


### PR DESCRIPTION
## Summary
- The hand-written `sol!` binding in `fault-proof/src/contract.rs` declared `maxChallengeDuration()` as returning `uint256`, but the Solidity source returns `Duration` (= `uint64`). The sibling `maxProveDuration()` was already correctly typed as `uint64`, so the inconsistency was a pure typo from when the binding was originally added in #357.
- The wire ABI was unaffected (uint64 and uint256 both serialize to a 32-byte word for any value fitting in u64), and the call site at `proposer.rs:526` narrowed the result back with `.to::<u64>()`, so no production behavior changes — but the type-level binding now matches the contract.
- Reported by @kien-rise.

## Relation to #809
PR #809 supersedes this fix by replacing all hand-written `sol!` bindings with forge-generated ones, eliminating this entire class of drift. This is a small surgical patch landed first while #809 is rebased and reviewed.

## Test plan
- [x] `cargo check -p op-succinct-fp` — clean
- [x] `cargo clippy -p op-succinct-fp --all-targets -- -D warnings` — clean
- [x] grep confirms only one call site, which compiles without the `.to::<u64>()` cast