### PR TITLE
fix(ci): drop missing FOUNDRY_PROFILE=ci to unbreak Foundry Test

### DIFF
--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -17,9 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' }}
 
-env:
-  FOUNDRY_PROFILE: ci
-
 jobs:
   check:
     strategy:


### PR DESCRIPTION
## Summary
- `contracts/foundry.toml` only declares `[profile.default]` — no `[profile.ci]` has ever existed.
- The Foundry Test workflow set `FOUNDRY_PROFILE: ci`, which forge 1.5.x silently treated as a fallback to `default`.
- forge 1.6.0 (released between 2026-04-22 and 2026-04-28, pulled automatically via the toolchain action's `version: stable`) made profile selection strict and errors out:
  ```
  foundry config error: selected profile `ci` does not exist
  ```
- Result: every push to `main` since the upstream forge bump fails Foundry Test (first observed on commit `cdd54a6c`).

## Why dropping the env var (vs adding `[profile.ci]`)
The `ci` profile never existed; the env var was a no-op for forge 1.5.x. Removing it restores the effective prior behavior without introducing a placeholder profile that has no actual CI-specific config to carry.

## Test plan
- [ ] Foundry Test passes on this PR
- [ ] After merge, Foundry Test passes on the resulting `main` push