### PR TITLE
backport(fault-proof): correct maxChallengeDuration return type to uint64 (#891)

### DIFF
--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -97,7 +97,7 @@ sol! {
         function gameOver() external view returns (bool gameOver_);
 
         /// @notice Returns the max challenge duration.
-        function maxChallengeDuration() external view returns (uint256 maxChallengeDuration_);
+        function maxChallengeDuration() external view returns (uint64 maxChallengeDuration_);
 
         /// @notice Returns the max prove duration.
         function maxProveDuration() external view returns (uint64 maxProveDuration_);

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -523,7 +523,7 @@ where
 
         // Fetch contract params from game implementation.
         let game_impl = self.factory.game_impl(self.config.game_type).await?;
-        let max_challenge_duration = game_impl.maxChallengeDuration().call().await?.to::<u64>();
+        let max_challenge_duration = game_impl.maxChallengeDuration().call().await?;
         let max_prove_duration = game_impl.maxProveDuration().call().await?;
         let contract_params = ContractParams { max_challenge_duration, max_prove_duration };
 


### PR DESCRIPTION
## Summary
Backport of [PR #891](https://github.com/succinctlabs/op-succinct/pull/891) (merged to `main`) to `release/v3.x`.

- The hand-written `sol!` binding in `fault-proof/src/contract.rs` declared `maxChallengeDuration()` as returning `uint256`, but the Solidity source returns `Duration` (= `uint64`). The sibling `maxProveDuration()` was already correctly typed as `uint64`.
- Wire ABI is unaffected (uint64 and uint256 both serialize to a 32-byte word for any value fitting in u64), and the call site at `proposer.rs:526` no longer needs the `.to::<u64>()` narrowing — no production behavior change, just type-level correctness.
- Reported by Kien Nguyen.

## Backport-specific changes
None — clean cherry-pick. Hunk offsets differ (line 100 on v3.x vs line 101 on main) due to surrounding code differences, but the change itself is identical.

## Equivalence verification
- [x] File-by-file diff comparison against source PR — only base-SHA / hunk-offset differences
- [x] No dependency, CI, or ELF changes involved
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p op-succinct-fp --all-targets --all-features -- -D warnings -A incomplete-features` clean
- [ ] CI passes

## Test plan
- [ ] CI (clippy, tests)