### PR TITLE
fix(fault-proof): robustness follow-ups to #865 + cost-estimator parity

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -747,6 +747,20 @@ where
                 .copied()
                 .collect();
             if !future_games.is_empty() {
+                // Determine if the duplicate-creation guard's tracked game is among the
+                // entries this prune is about to remove. Must be evaluated BEFORE the
+                // removal loop while state.games still holds them. Checking "absent from
+                // post-prune cache" instead would over-clear the guard when the just-
+                // created game has not yet been added to the cache (e.g., right after
+                // creation, or after a backup restore that prunes unrelated entries),
+                // allowing should_create_game to re-submit a duplicate at the same L2
+                // block before the cache catches up.
+                let guarded_addr = *self.last_created_game_address.lock().await;
+                let guard_in_pruned = guarded_addr != Address::ZERO &&
+                    future_games.iter().any(|idx| {
+                        state.games.get(idx).is_some_and(|g| g.address == guarded_addr)
+                    });
+
                 for idx in &future_games {
                     state.games.remove(idx);
                 }
@@ -759,6 +773,14 @@ where
                     state.anchor_game.as_ref().is_some_and(|a| !state.games.contains_key(&a.index));
                 if should_clear_anchor {
                     state.anchor_game = None;
+                }
+                if guard_in_pruned {
+                    self.last_created_game_l2_block.store(0, Ordering::Relaxed);
+                    *self.last_created_game_address.lock().await = Address::ZERO;
+                    tracing::warn!(
+                        ?guarded_addr,
+                        "Reset creation guard: tracked game was among pruned entries"
+                    );
                 }
             }
         }

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -654,13 +654,26 @@ where
             latest_block.header.number.saturating_sub(self.config.sync_l1_confirmations);
 
         // If L1 hasn't advanced past the last synced block, all on-chain state is identical.
+        //
+        // `confirmed_number < prev` indicates backend regression from a load-balanced RPC, or a
+        // deep L1 reorg past `sync_l1_confirmations`. This case should be logged at WARN so
+        // operators can detect unhealthy backends or L1 reorg; the equal case stays at DEBUG since
+        // it's the normal "L1 hasn't ticked" path.
         let prev = self.last_synced_l1_block.load(Ordering::Relaxed);
         if confirmed_number > 0 && confirmed_number <= prev {
-            tracing::debug!(
-                confirmed_number,
-                last_synced = prev,
-                "L1 head unchanged, skipping sync"
-            );
+            if confirmed_number < prev {
+                tracing::warn!(
+                    confirmed_number,
+                    last_synced = prev,
+                    "L1 confirmed head moved backwards (backend regression or deep reorg), skipping sync"
+                );
+            } else {
+                tracing::debug!(
+                    confirmed_number,
+                    last_synced = prev,
+                    "L1 head unchanged, skipping sync"
+                );
+            }
             return Ok(());
         }
 

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1413,6 +1413,31 @@ where
         };
 
         for game in candidates {
+            // Pre-flight on-chain status check at `latest`. The cached `should_attempt_to_resolve`
+            // is derived from the pinned (lagged) snapshot, so a recently confirmed `resolve()` tx
+            // may not yet be reflected. Querying at `latest` avoids re-submitting a resolution
+            // that would only revert on chain.
+            let contract = OPSuccinctFaultDisputeGame::new(game.address, self.l1_provider.clone());
+            match contract.status().call().await {
+                Ok(status) if status != GameStatus::IN_PROGRESS => {
+                    tracing::info!(
+                        game_index = %game.index,
+                        game_address = ?game.address,
+                        ?status,
+                        "Skipping resolve: game already resolved on chain"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        game_address = ?game.address,
+                        error = ?e,
+                        "Pre-flight status check failed, proceeding with resolve"
+                    );
+                }
+                _ => {}
+            }
+
             if let Err(error) = self.submit_resolution_transaction(&game).await {
                 if error.is_revert() {
                     tracing::error!(
@@ -1455,7 +1480,33 @@ where
                 .collect::<Vec<_>>()
         };
 
+        let signer_address = self.signer.address();
         for game in candidates {
+            // Pre-flight on-chain credit check at `latest`. The cached
+            // `should_attempt_to_claim_bond` is derived from the pinned (lagged)
+            // snapshot, so a recently confirmed `claimCredit()` tx may not yet be
+            // reflected. Querying at `latest` avoids re-submitting a claim that
+            // would only revert on chain.
+            let contract = OPSuccinctFaultDisputeGame::new(game.address, self.l1_provider.clone());
+            match contract.credit(signer_address).call().await {
+                Ok(credit) if credit == U256::ZERO => {
+                    tracing::info!(
+                        game_index = %game.index,
+                        game_address = ?game.address,
+                        "Skipping claim: bond already claimed on chain"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        game_address = ?game.address,
+                        error = ?e,
+                        "Pre-flight credit check failed, proceeding with claim"
+                    );
+                }
+                _ => {}
+            }
+
             if let Err(error) = self.submit_bond_claim_transaction(&game).await {
                 if error.is_revert() {
                     tracing::error!(
@@ -2360,6 +2411,7 @@ where
     /// Returns `Ok(true)` if proving should be skipped:
     /// - Game not found in cache
     /// - Game not owned (vkeys don't match)
+    /// - Game is already proven or resolved on chain (pre-flight check at `latest`)
     /// - Deadline has passed
     ///
     /// Returns `Ok(false)` if proving should proceed.
@@ -2385,6 +2437,39 @@ where
                     return Ok(true);
                 }
                 _ => {}
+            }
+        }
+
+        // Pre-flight on-chain status check at `latest`. The cached `proposal_status` is read
+        // from the pinned (lagged) block, so a recently confirmed prove() or resolve() tx may
+        // not yet be reflected. Querying at `latest` avoids expensive proof regeneration that
+        // would only revert on submission. Skip when:
+        // - ProposalStatus is *ValidProofProvided (proof already submitted), or
+        // - ProposalStatus is Resolved (game concluded — set whenever GameStatus moves out of
+        //   IN_PROGRESS, including timeout default-loss).
+        let contract = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
+        match contract.claimData().call().await {
+            Ok(claim_data) => {
+                if matches!(
+                    claim_data.status,
+                    ProposalStatus::UnchallengedAndValidProofProvided |
+                        ProposalStatus::ChallengedAndValidProofProvided |
+                        ProposalStatus::Resolved
+                ) {
+                    tracing::info!(
+                        ?game_address,
+                        proposal_status = ?claim_data.status,
+                        "Skipping proving: game already proven or resolved on chain"
+                    );
+                    return Ok(true);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    ?game_address,
+                    error = ?e,
+                    "Pre-flight proposal status check failed, proceeding with proving"
+                );
             }
         }
 

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -256,7 +256,7 @@ async fn main() -> Result<()> {
     // splitting algorithm. Otherwise, we use the simple range splitting algorithm.
     let safe_db_activated = data_fetcher.is_safe_db_activated().await?;
 
-    let split_ranges = if safe_db_activated {
+    let split_ranges = if safe_db_activated && !args.no_safe_head_split {
         split_range_based_on_safe_heads(l2_start_block, l2_end_block, args.effective_batch_size())
             .await?
     } else {

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -39,6 +39,12 @@ pub struct HostExecutorArgs {
     /// Cluster proving timeout in seconds (only used when SP1_PROVER=cluster).
     #[arg(long, default_value = "21600")]
     pub cluster_timeout: u64,
+    /// Bypass span-batch-aligned splitting even when SafeDB is active. Forces the basic
+    /// fixed-size splitter so the range is partitioned solely by `--batch-size`. Useful for
+    /// estimating per-segment cost as the proposer sees it (one zkVM execution per
+    /// `RANGE_SPLIT_COUNT` segment) rather than per span batch.
+    #[arg(long)]
+    pub no_safe_head_split: bool,
 }
 
 /// Fallback batch size used when the user provides neither `--batch-size`
@@ -92,6 +98,7 @@ mod tests {
             prove: false,
             safe_db_fallback: false,
             cluster_timeout: 21600,
+            no_safe_head_split: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Three independent follow-ups to #865 in the proposer, plus a cost-estimator flag that builds on #869 to align the estimator's split behavior with how the proposer actually proves.

### 1. `fault-proof: warn-log L1 head regression in sync_state`

Distinguish the two skip cases: WARN when `confirmed_number` moves backwards (load-balanced backend regression or deep reorg) so operators can detect unhealthy backends, DEBUG for the normal "L1 hasn't ticked" path. Pure observability; no behavior change.

### 2. `fault-proof: reset creation guard when tracked game is pruned`

When `sync_games` prunes future games due to abnormal cache states (backup restore into a shorter chain, deep L1 reorg, factory reset), the duplicate-creation guard could point at a game that no longer exists. Without resetting, `should_create_game` blocks indefinitely. Reset is gated on the guarded address being among the entries this prune actually removes — checking "absent from post-prune cache" instead would over-clear when a just-created game hasn't been added to the cache yet, allowing duplicate submission.

### 3. `fault-proof: pre-flight on-chain status check before prove/resolve/claim`

With `sync_l1_confirmations > 0`, the cache lags by ~`sync_l1_confirmations × block_time`. During that window, recently confirmed prove/resolve/claimCredit txs are invisible to the cache, so `should_*` flags re-fire and the proposer re-submits — wasting prover-network spend (full range + agg proof regeneration) and gas (reverted txs).

Each path now does one `eth_call` at `latest` before submission:
- `resolve_games`: skip if `GameStatus != IN_PROGRESS`
- `claim_bonds`: skip if `credit(signer) == 0`
- `should_skip_proving`: skip if `ProposalStatus` is `*ValidProofProvided` or `Resolved` (covers both already-proven and timeout default-loss; `Resolved` is set whenever GameStatus moves out of IN_PROGRESS)

On RPC failure the check logs `warn` and proceeds, so transient backend issues don't block legitimate work.

### 4. `scripts: add --no-safe-head-split to cost-estimator` (follow-up to #869)

#869 fixed `--batch-size` precedence so the flag is honored when explicit `--start`/`--end` are given. But with SafeDB active, the splitter still cuts at span batch boundaries via `split_range_based_on_safe_heads`, regardless of the now-correct `effective_batch_size`. The proposer with `RANGE_SPLIT_COUNT=1` (default) does not split that way — it produces one range proof per proposal interval. `--no-safe-head-split` forces `split_range_basic` so the estimator partitions only by `--batch-size`, giving a closer estimate of the per-segment cost the proposer actually incurs on the prover network.

## Test plan

- [x] `cargo check --all-targets --all-features --tests && cargo fmt --all -- --check && cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- [x] Manual: cost-estimator with `--no-safe-head-split` produces a single batch instead of N span-batch-aligned chunks