### PR TITLE
ci(eigenda): run eigenda-proxy ephemerally inside CI jobs

### DIFF
--- a/.github/actions/start-eigenda-proxy/action.yml
+++ b/.github/actions/start-eigenda-proxy/action.yml
@@ -1,0 +1,65 @@
+name: Start EigenDA Proxy
+description: |
+  Spin up an ephemeral eigenda-proxy container on the runner so EigenDA-feature
+  tests have a local read-path to Sepolia EigenDA blobs without depending on
+  long-lived shared infrastructure.
+inputs:
+  l1_rpc:
+    description: Sepolia L1 RPC URL (proxy uses this for cert verification + disperser eth client)
+    required: true
+  port:
+    description: Local TCP port to bind the proxy to
+    required: false
+    default: "4242"
+  image:
+    description: eigenda-proxy image reference
+    required: false
+    default: "ghcr.io/layr-labs/eigenda-proxy:2.4.1"
+runs:
+  using: composite
+  steps:
+    - name: Start eigenda-proxy container
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run -d --rm --name eigenda-proxy \
+          -p ${{ inputs.port }}:4242 \
+          -e EIGENDA_PROXY_ADDR=0.0.0.0 \
+          -e EIGENDA_PROXY_PORT=4242 \
+          -e EIGENDA_PROXY_APIS_TO_ENABLE=op-generic,standard,metrics \
+          -e EIGENDA_PROXY_STORAGE_BACKENDS_TO_ENABLE=V1,V2 \
+          -e EIGENDA_PROXY_STORAGE_DISPERSAL_BACKEND=V2 \
+          -e EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH=1MiB \
+          -e EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB \
+          -e EIGENDA_PROXY_EIGENDA_DISPERSER_RPC=disperser-testnet-sepolia.eigenda.xyz:443 \
+          -e EIGENDA_PROXY_EIGENDA_V2_NETWORK=sepolia_testnet \
+          -e EIGENDA_PROXY_EIGENDA_ETH_RPC="${{ inputs.l1_rpc }}" \
+          -e EIGENDA_PROXY_EIGENDA_V2_ETH_RPC="${{ inputs.l1_rpc }}" \
+          -e EIGENDA_PROXY_EIGENDA_SERVICE_MANAGER_ADDR=0x3a5acf46ba6890B8536420F4900AC9BC45Df4764 \
+          -e EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ROUTER_OR_IMMUTABLE_VERIFIER_ADDR=0x17ec4112c4BbD540E2c1fE0A49D264a280176F0D \
+          -e EIGENDA_PROXY_EIGENDA_V2_RBN_RECENCY_WINDOW_SIZE=0 \
+          -e EIGENDA_PROXY_EIGENDA_CONFIRMATION_DEPTH=6 \
+          -e EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX=0000000000000000000100000000000000000000000000000000000000000000 \
+          -e EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX=0000000000000000000100000000000000000000000000000000000000000000 \
+          ${{ inputs.image }}
+
+    - name: Wait for proxy to listen
+      shell: bash
+      run: |
+        set -euo pipefail
+        for i in $(seq 1 60); do
+          if curl -sS -o /dev/null --connect-timeout 2 "http://localhost:${{ inputs.port }}/" 2>/dev/null; then
+            echo "EigenDA proxy is reachable on port ${{ inputs.port }}"
+            exit 0
+          fi
+          if ! docker ps --format '{{.Names}}' | grep -q '^eigenda-proxy$'; then
+            echo "::error::eigenda-proxy container exited. Logs:"
+            docker logs eigenda-proxy || true
+            exit 1
+          fi
+          echo "Waiting for proxy ($i/60)..."
+          sleep 2
+        done
+        echo "::error::eigenda-proxy did not become reachable in time. Logs:"
+        docker logs eigenda-proxy || true
+        exit 1

--- a/.github/workflows/cycle-count-diff-eigenda.yml
+++ b/.github/workflows/cycle-count-diff-eigenda.yml
@@ -80,6 +80,11 @@ jobs:
           cp -r ./srs/resources ./new_code/scripts/prove
           cp -r ./srs/resources ./old_code/scripts/prove
 
+      - name: Start ephemeral EigenDA proxy
+        uses: ./.github/actions/start-eigenda-proxy
+        with:
+          l1_rpc: ${{ secrets.L1_RPC }}
+
       - name: Run Test On New Branch
         run: |
           RUST_LOG=info NEW_BRANCH=true cargo test -p op-succinct-prove --features eigenda test_cycle_count_diff --release -- --exact --nocapture
@@ -89,7 +94,7 @@ jobs:
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_EIGENDA_RPC }}
-          EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+          EIGENDA_PROXY_ADDRESS: http://localhost:4242
           OP_SUCCINCT_MOCK: true
 
       - name: Copy Stats File For Old Branch
@@ -106,7 +111,7 @@ jobs:
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_EIGENDA_RPC }}
-          EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+          EIGENDA_PROXY_ADDRESS: http://localhost:4242
           OP_SUCCINCT_MOCK: true
 
       - name: Compare Results And Post To Github

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -114,6 +114,12 @@ jobs:
       if: matrix.run_real && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true')
       uses: extractions/setup-just@v3
 
+    - name: Start ephemeral EigenDA proxy
+      if: matrix.da == 'eigenda' && matrix.run_real && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true')
+      uses: ./.github/actions/start-eigenda-proxy
+      with:
+        l1_rpc: ${{ secrets.L1_RPC }}
+
     - name: Run tests
       if: matrix.run_real && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true')
       run: just fp-integration-tests ${{ matrix.test }} ${{ matrix.da }}
@@ -122,7 +128,7 @@ jobs:
         L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
         L2_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_RPC }}
         L2_NODE_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_NODE_RPC }}
-        EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+        EIGENDA_PROXY_ADDRESS: http://localhost:4242
 
     - name: Upload test logs on failure
       if: failure() && matrix.run_real
@@ -243,6 +249,12 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@v3
 
+    - name: Start ephemeral EigenDA proxy
+      if: matrix.da == 'eigenda'
+      uses: ./.github/actions/start-eigenda-proxy
+      with:
+        l1_rpc: ${{ secrets.L1_RPC }}
+
     - name: Run tests
       run: just fp-integration-tests ${{ matrix.test }} ${{ matrix.da }}
       env:
@@ -250,7 +262,7 @@ jobs:
         L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
         L2_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_RPC }}
         L2_NODE_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_NODE_RPC }}
-        EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+        EIGENDA_PROXY_ADDRESS: http://localhost:4242
 
     - name: Upload test logs on failure
       if: failure()
@@ -335,6 +347,12 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@v3
 
+    - name: Start ephemeral EigenDA proxy
+      if: matrix.da == 'eigenda'
+      uses: ./.github/actions/start-eigenda-proxy
+      with:
+        l1_rpc: ${{ secrets.L1_RPC }}
+
     - name: Run tests
       run: just da-integration-tests ${{ matrix.da }}
       env:
@@ -342,7 +360,7 @@ jobs:
         L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
         L2_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_RPC }}
         L2_NODE_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_NODE_RPC }}
-        EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+        EIGENDA_PROXY_ADDRESS: http://localhost:4242
         OP_SUCCINCT_MOCK: 'true'
 
     - name: Upload test logs on failure


### PR DESCRIPTION
## Summary
- Replace the shared, always-on `eigendaproxy-service` (currently referenced via the `EIGENDA_PROXY_ADDRESS` secret) with a per-job container started inside the runner.
- New composite action `.github/actions/start-eigenda-proxy` boots `ghcr.io/layr-labs/eigenda-proxy:2.4.1` with the same Sepolia testnet config as the existing always-on instance, then polls until it accepts connections on `localhost:4242`.
- All EigenDA CI matrix entries now use `EIGENDA_PROXY_ADDRESS=http://localhost:4242`. Ethereum-DA matrix entries are unchanged (proxy step gated on `matrix.da == 'eigenda'`).

## Why
The shared proxy on `op-succinct-infra` runs 24/7 on Fargate + ALB (~$52/mo) but is only exercised during EigenDA-feature CI bursts (CPU avg 0.4%, idle ~99%). The proxy is a stateless container — running it inside the CI job removes the always-on cost without changing test semantics.

If this is green, follow-ups:
1. Remove the `EIGENDA_PROXY_ADDRESS` secret from this repo.
2. `cdk destroy OPSuccinct-EigenDAProxy` and prune `config.yaml` in `op-succinct-infra`.

## Risk / unknowns
- `secrets.L1_RPC` is reused as the proxy's `EIGENDA_PROXY_EIGENDA_V2_ETH_RPC`. The previous AWS task definition used `https://sepolia-el.succinct.tools` for that field. They should be the same Sepolia RPC; if not, the proxy will fail cert verification and we'll see it in the EigenDA matrix run.
- Proxy startup adds a few seconds of warmup before each EigenDA-feature job.
- Liveness probe is a `curl` against `/`; permissive enough that any TCP listener counts as "ready". If the proxy is up but EigenDA-side handshake fails later, the test itself will surface it.

## Test plan
- [x] Existing PR CI passed.
- [x] `/integration` passed, confirming the current EigenDA integration path still works.
- [ ] Post-merge `main` Integration Tests should execute the new `.github/actions/start-eigenda-proxy` step and pass for:
  - `Fault Proof (integration - eigenda)`
  - `DA Host (eigenda)`
- [ ] `Cycle Count Diff (EigenDA)` is path-gated and not exercised by this PR (`elf/eigenda-range-elf-embedded` unchanged); validate on the next ELF rebuild PR.

## Merge note
This PR changes the CI execution path for EigenDA jobs from the shared `EIGENDA_PROXY_ADDRESS` service to a per-job localhost proxy. PR EigenDA checks are placeholder/deferred, and `/integration` uses the workflow definition from `main`, so the new composite action is expected to receive its first runtime validation on the post-merge `main` run.

Do not remove the shared proxy secret or destroy the infra stack until the post-merge `main` run passes with `Start ephemeral EigenDA proxy` present in both EigenDA jobs.