### PR TITLE
backport(ci): run eigenda-proxy ephemerally inside CI jobs (#897)

### DIFF
--- a/.github/actions/start-eigenda-proxy/action.yml
+++ b/.github/actions/start-eigenda-proxy/action.yml
@@ -1,0 +1,65 @@
+name: Start EigenDA Proxy
+description: |
+  Spin up an ephemeral eigenda-proxy container on the runner so EigenDA-feature
+  tests have a local read-path to Sepolia EigenDA blobs without depending on
+  long-lived shared infrastructure.
+inputs:
+  l1_rpc:
+    description: Sepolia L1 RPC URL (proxy uses this for cert verification + disperser eth client)
+    required: true
+  port:
+    description: Local TCP port to bind the proxy to
+    required: false
+    default: "4242"
+  image:
+    description: eigenda-proxy image reference
+    required: false
+    default: "ghcr.io/layr-labs/eigenda-proxy:2.4.1"
+runs:
+  using: composite
+  steps:
+    - name: Start eigenda-proxy container
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run -d --rm --name eigenda-proxy \
+          -p ${{ inputs.port }}:4242 \
+          -e EIGENDA_PROXY_ADDR=0.0.0.0 \
+          -e EIGENDA_PROXY_PORT=4242 \
+          -e EIGENDA_PROXY_APIS_TO_ENABLE=op-generic,standard,metrics \
+          -e EIGENDA_PROXY_STORAGE_BACKENDS_TO_ENABLE=V1,V2 \
+          -e EIGENDA_PROXY_STORAGE_DISPERSAL_BACKEND=V2 \
+          -e EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH=1MiB \
+          -e EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB \
+          -e EIGENDA_PROXY_EIGENDA_DISPERSER_RPC=disperser-testnet-sepolia.eigenda.xyz:443 \
+          -e EIGENDA_PROXY_EIGENDA_V2_NETWORK=sepolia_testnet \
+          -e EIGENDA_PROXY_EIGENDA_ETH_RPC="${{ inputs.l1_rpc }}" \
+          -e EIGENDA_PROXY_EIGENDA_V2_ETH_RPC="${{ inputs.l1_rpc }}" \
+          -e EIGENDA_PROXY_EIGENDA_SERVICE_MANAGER_ADDR=0x3a5acf46ba6890B8536420F4900AC9BC45Df4764 \
+          -e EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ROUTER_OR_IMMUTABLE_VERIFIER_ADDR=0x17ec4112c4BbD540E2c1fE0A49D264a280176F0D \
+          -e EIGENDA_PROXY_EIGENDA_V2_RBN_RECENCY_WINDOW_SIZE=0 \
+          -e EIGENDA_PROXY_EIGENDA_CONFIRMATION_DEPTH=6 \
+          -e EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX=0000000000000000000100000000000000000000000000000000000000000000 \
+          -e EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX=0000000000000000000100000000000000000000000000000000000000000000 \
+          ${{ inputs.image }}
+
+    - name: Wait for proxy to listen
+      shell: bash
+      run: |
+        set -euo pipefail
+        for i in $(seq 1 60); do
+          if curl -sS -o /dev/null --connect-timeout 2 "http://localhost:${{ inputs.port }}/" 2>/dev/null; then
+            echo "EigenDA proxy is reachable on port ${{ inputs.port }}"
+            exit 0
+          fi
+          if ! docker ps --format '{{.Names}}' | grep -q '^eigenda-proxy$'; then
+            echo "::error::eigenda-proxy container exited. Logs:"
+            docker logs eigenda-proxy || true
+            exit 1
+          fi
+          echo "Waiting for proxy ($i/60)..."
+          sleep 2
+        done
+        echo "::error::eigenda-proxy did not become reachable in time. Logs:"
+        docker logs eigenda-proxy || true
+        exit 1

--- a/.github/workflows/cycle-count-diff-eigenda.yml
+++ b/.github/workflows/cycle-count-diff-eigenda.yml
@@ -80,6 +80,11 @@ jobs:
           cp -r ./srs/resources ./new_code/scripts/prove
           cp -r ./srs/resources ./old_code/scripts/prove
 
+      - name: Start ephemeral EigenDA proxy
+        uses: ./.github/actions/start-eigenda-proxy
+        with:
+          l1_rpc: ${{ secrets.L1_RPC }}
+
       - name: Run Test On New Branch
         run: |
           RUST_LOG=info NEW_BRANCH=true cargo test -p op-succinct-prove --features eigenda test_cycle_count_diff --release -- --exact --nocapture
@@ -89,7 +94,7 @@ jobs:
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_EIGENDA_RPC }}
-          EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+          EIGENDA_PROXY_ADDRESS: http://localhost:4242
           OP_SUCCINCT_MOCK: true
 
       - name: Copy Stats File For Old Branch
@@ -106,7 +111,7 @@ jobs:
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_EIGENDA_RPC }}
-          EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+          EIGENDA_PROXY_ADDRESS: http://localhost:4242
           OP_SUCCINCT_MOCK: true
 
       - name: Compare Results And Post To Github

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,7 @@ on:
       - v[0-9]+.*
     branches:
       - main
+      - release/v3.x
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -81,6 +82,12 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@v3
 
+    - name: Start ephemeral EigenDA proxy
+      if: matrix.da == 'eigenda'
+      uses: ./.github/actions/start-eigenda-proxy
+      with:
+        l1_rpc: ${{ secrets.L1_RPC }}
+
     - name: Run tests
       run: just fp-integration-tests ${{ matrix.test }} ${{ matrix.da }}
       env:
@@ -88,7 +95,7 @@ jobs:
         L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
         L2_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_RPC }}
         L2_NODE_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_NODE_RPC }}
-        EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+        EIGENDA_PROXY_ADDRESS: http://localhost:4242
 
     - name: Upload test logs on failure
       if: failure()
@@ -149,6 +156,12 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@v3
 
+    - name: Start ephemeral EigenDA proxy
+      if: matrix.da == 'eigenda'
+      uses: ./.github/actions/start-eigenda-proxy
+      with:
+        l1_rpc: ${{ secrets.L1_RPC }}
+
     - name: Run tests
       run: just da-integration-tests ${{ matrix.da }}
       env:
@@ -156,7 +169,7 @@ jobs:
         L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
         L2_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_RPC }}
         L2_NODE_RPC: ${{ matrix.da == 'eigenda' && secrets.L2_EIGENDA_RPC || secrets.L2_NODE_RPC }}
-        EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+        EIGENDA_PROXY_ADDRESS: http://localhost:4242
         OP_SUCCINCT_MOCK: 'true'
 
     - name: Upload test logs on failure


### PR DESCRIPTION
## Summary
Backport of [#897](https://github.com/succinctlabs/op-succinct/pull/897) (merged to `main`) to `release/v3.x`.

- Replaces the long-lived shared eigenda-proxy (referenced via the `EIGENDA_PROXY_ADDRESS` secret) with a per-job container started via a new local composite action `.github/actions/start-eigenda-proxy`.
- All EigenDA CI matrix entries on `release/v3.x` now use `EIGENDA_PROXY_ADDRESS=http://localhost:4242`. Ethereum-DA matrix entries are unchanged (proxy step gated on `matrix.da == 'eigenda'`).

## Why
This unblocks tearing down the shared proxy infrastructure on `op-succinct-infra`. After this lands, the `EIGENDA_PROXY_ADDRESS` secret and `OPSuccinct-EigenDAProxy` CDK stack are removable.

## Branch-specific changes
- `release/v3.x` `integration-tests.yml` has only `fp-integration-tests` and `da-integration-tests` jobs (main has additional `-pr`/merge-queue split). The proxy step is added in 2 places instead of 3.
- Added `release/v3.x` to the `push:` trigger branches in `integration-tests.yml` so post-merge runs validate this path on the release branch (mirrors main's behavior).

## Equivalence verification
- [x] `.github/actions/start-eigenda-proxy/action.yml` is byte-identical to the version merged in #897
- [x] `cycle-count-diff-eigenda.yml` diff identical to source PR (proxy step + 2 env line edits)
- [x] `integration-tests.yml` adapted for v3.x's simpler job topology (2 proxy step insertions vs 3 on main)
- [x] No source code, no Cargo changes, no ELF rebuild required (CI-only PR)
- [ ] CI passes

## Test plan
- [ ] Existing PR-event CI passes
- [ ] Post-merge `release/v3.x` push run executes the new `Start ephemeral EigenDA proxy` step and passes for `Fault Proof (integration - eigenda)` + `DA Host (eigenda)`
- [ ] `Cycle Count Diff (EigenDA)` is path-gated and not exercised by this PR (unchanged on this branch); validate on next ELF rebuild

## Merge note
Do not remove the shared proxy secret or destroy `OPSuccinct-EigenDAProxy` until the post-merge run on `release/v3.x` passes with the new step in both EigenDA jobs. Same gate as #897 on `main`.