### PR TITLE
docs: add Alt-DA Server page

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -23,7 +23,7 @@
     - [Celestia](./validity/data-availability/celestia.md)
     - [EigenDA](./validity/data-availability/eigenda.md)
   - [Experimental Features](./validity/experimental/experimental.md)
-    - [AltDA (Validium)](./validity/experimental/altda.md)
+    - [Alt-DA Server](./validity/experimental/altda.md)
 
 - [OP Succinct Lite (Fault Proofs)](./fault_proofs/intro.md)
   - [Architecture](./fault_proofs/fault_proof_architecture.md)

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -23,6 +23,7 @@
     - [Celestia](./validity/data-availability/celestia.md)
     - [EigenDA](./validity/data-availability/eigenda.md)
   - [Experimental Features](./validity/experimental/experimental.md)
+    - [AltDA (Validium)](./validity/experimental/altda.md)
 
 - [OP Succinct Lite (Fault Proofs)](./fault_proofs/intro.md)
   - [Architecture](./fault_proofs/fault_proof_architecture.md)

--- a/book/validity/experimental/altda.md
+++ b/book/validity/experimental/altda.md
@@ -8,7 +8,7 @@ This feature is under active development. Breaking changes to configuration and 
 
 ## Overview
 
-OP Succinct's AltDA mode supports OP Stack chains that use the [alt-DA spec](https://specs.optimism.io/experimental/alt-da.html) with a generic op-alt-da server. Specialized DA backends like Celestia and EigenDA also build on the alt-DA pathway but have their own integrations and pages; this page covers the generic-server case only. The most common deployment pattern is a **validium**: an L2 that posts batch data to an off-chain DA layer and only commitments to L1. The underlying transport does not require that trust model. The codebase uses "AltDA" / `altda` throughout, and so does this page.
+OP Succinct supports OP Stack chains that use the [alt-DA spec](https://specs.optimism.io/experimental/alt-da.html) with a generic op-alt-da server. Specialized DA backends like Celestia and EigenDA also build on the alt-DA pathway but have their own integrations and pages; this page covers the generic-server case only. The most common deployment pattern is a **validium**: an L2 that posts batch data to an off-chain DA layer and only commitments to L1. The underlying transport does not require that trust model. In this codebase the feature is named `altda`; this page uses "AltDA" to refer to the implementation ("Alt-DA Server" in the page title is the OP Stack spec terminology).
 
 In AltDA mode, chain-layer responsibilities (derivation, validity proving, on-chain settlement) are handled by op-succinct. The data availability layer (the alt-DA server that stores batch data and serves it by commitment) is operated separately and is out of scope for this repository.
 

--- a/book/validity/experimental/altda.md
+++ b/book/validity/experimental/altda.md
@@ -30,7 +30,7 @@ sequenceDiagram
     Proposer->>DA: GET /get/0x{hex(encoded_commitment)}
     DA-->>Proposer: batch data
     Proposer->>zkVM: witness with batch data + commitment
-    zkVM->>zkVM: verify keccak256(data) == commitment
+    zkVM->>zkVM: preimage oracle enforces keccak256(data) == key
     zkVM-->>Proposer: range proof
 ```
 
@@ -48,6 +48,8 @@ The OP Succinct proposer reads L1 calldata as usual. When a batcher transaction 
 |------|------|--------|
 | Keccak256 | `0x00` | Supported. Integrity is enforced inside the zkVM via the preimage oracle (`keccak256(data) == commitment`). |
 | Generic | `0x01` | Not supported in this release. The host rejects this commitment type. |
+
+> Note: the byte `0x01` appears in two distinct positions on the wire — as the `DerivationVersion1` prefix on the L1 batcher transaction (separating alt-DA from Ethereum DA) and as the commitment type byte inside the encoded commitment. The two positions are independent.
 
 ## Enabling AltDA Mode
 
@@ -72,7 +74,7 @@ The alt-DA server must implement the OP Stack alt-DA `GET` endpoint shape. Opera
 
 ## AltDA Contract Configuration
 
-Before deploying or updating contracts, generate the AltDA-specific range verification key, aggregation verification key, and rollup config hash with the correct feature flag. This ensures the range verification key commitment matches the AltDA range ELF:
+Before deploying or updating contracts, regenerate the range verification key commitment and rollup config hash with the `altda` feature flag so they match the AltDA range ELF. The aggregation verification key is shared across DA variants:
 
 ```bash
 # From the repository root
@@ -83,19 +85,19 @@ The command prints the `Range Verification Key Hash`, `Aggregation Verification 
 
 When you use the `just` helpers below, pass the `altda` feature so `fetch-l2oo-config` runs with the correct ELFs. If you call the binaries manually (`fetch-l2oo-config`, `config`, etc.), append `--features altda`; otherwise the script emits the default Ethereum DA values and your contracts will revert with `ProofInvalid()` when submitting proofs.
 
-## Deploying `OPSuccinctL2OutputOracle` with AltDA features
+## Deploying and Updating `OPSuccinctL2OutputOracle`
 
 ```bash
 just deploy-oracle .env altda
 ```
 
-## Updating `OPSuccinctL2OutputOracle` Parameters
+To register a new configuration with updated AltDA verification keys (e.g., after a range program change), use `add-config` with the `altda` feature:
 
 ```bash
-just update-parameters .env altda
+just add-config <config_name> .env altda
 ```
 
-For more details on the `just update-parameters` command, see the [Updating `OPSuccinctL2OutputOracle` Parameters](../contracts/update-parameters.md) section.
+See the [Updating `OPSuccinctL2OutputOracle` Parameters](../contracts/update-parameters.md) page for the full rolling-update flow (add new config → point the proposer at it via `OP_SUCCINCT_CONFIG_NAME` → remove the old config).
 
 ## Run the AltDA Proposer Service
 
@@ -129,19 +131,15 @@ This recipe rebuilds all DA-variant range ELFs (Ethereum, Celestia, EigenDA, Alt
 
 ## Limitations
 
-- **Experimental.** The AltDA feature is under active development. Configuration keys, feature flags, and on-disk artifacts may change without notice.
 - **Keccak256 commitments only.** Generic commitments (`0x01`) are not supported in this release.
-- **DA server availability assumption.** Proving stalls if the alt-DA server returns no data for a referenced commitment. The proposer cannot make progress past an unresolvable commitment.
+- **DA server availability assumption.** Proving stalls if the alt-DA server cannot return data for a referenced commitment.
 - **DA server is outside the op-succinct trust boundary.** Data availability and censorship resistance depend on the alt-DA server operator. op-succinct verifies that retrieved data matches its commitment but cannot force the server to serve data.
-- **Hardcoded HTTP timeout.** Requests to the alt-DA server use a 30s timeout that is not currently configurable.
+- **Hardcoded HTTP timeout.** Requests to the alt-DA server use a fixed 30s timeout.
 - **Standard L1 head logic.** AltDA uses the same L1 head selection as Ethereum DA. There is no Blobstream-style finality tracking.
-
-## OP Succinct Lite
-
-AltDA support also exists for OP Succinct Lite (fault-proof) mode behind the same `altda` Cargo feature flag. Full Lite-mode AltDA documentation will follow. See the [OP Succinct Lite (Fault Proofs)](../../fault_proofs/intro.md) section for the base setup.
 
 ## Where to Go Next
 
 - [Architecture](../../architecture.md)
+- AltDA also runs in [OP Succinct Lite](../../fault_proofs/intro.md) under the same `altda` feature flag.
 - [Proposer Configuration](../proposer.md)
 - [OP Stack alt-DA reference (`op-alt-da`)](https://github.com/ethereum-optimism/optimism/tree/develop/op-alt-da)

--- a/book/validity/experimental/altda.md
+++ b/book/validity/experimental/altda.md
@@ -1,0 +1,147 @@
+# AltDA (Validium)
+
+<div class="warning">
+
+This feature is experimental. Configuration keys, feature flags, and on-disk artifacts may change without notice.
+
+</div>
+
+## Overview
+
+OP Succinct's AltDA mode supports OP Stack chains that publish batch data off-chain and post only commitments to L1 — the architecture commonly called a **validium**. The codebase uses "AltDA" throughout, matching the OP Stack alt-DA pathway it builds on; the rest of this page uses that term.
+
+In AltDA mode, chain-layer responsibilities (derivation, validity proving, on-chain settlement) are handled by op-succinct. The data availability layer — the alt-DA server that stores batch data and serves it by commitment — is operated separately and is out of scope for this repository.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Batcher as op-batcher
+    participant DA as Alt-DA Server
+    participant L1 as L1
+    participant Proposer as op-succinct (AltDA)
+    participant zkVM as SP1 zkVM
+
+    Batcher->>DA: POST batch data
+    DA-->>Batcher: Keccak256 commitment
+    Batcher->>L1: post tx with DerivationVersion1 (0x01) prefix + commitment
+    Proposer->>L1: read batcher transactions
+    Proposer->>Proposer: detect 0x01 prefix, parse commitment
+    Proposer->>DA: GET /get/0x{hex(encoded_commitment)}
+    DA-->>Proposer: batch data
+    Proposer->>zkVM: witness with batch data + commitment
+    zkVM->>zkVM: verify keccak256(data) == commitment
+    zkVM-->>Proposer: range proof
+```
+
+The OP Succinct proposer reads L1 calldata as usual. When a batcher transaction is prefixed with the `DerivationVersion1` byte (`0x01`), the AltDA data source parses the commitment and emits an `altda-commitment` hint to the host. The host fetches the corresponding batch data from the configured alt-DA server. The resolved data is loaded into the preimage oracle, where the SP1 zkVM verifies that `keccak256(data) == commitment` before accepting it into derivation.
+
+### Out of scope
+
+- The alt-DA server itself (storage, replication, availability guarantees).
+- Generic-commitment-type encoding.
+- On-chain DA challenge / bonding logic.
+
+## Supported Commitment Types
+
+| Type | Byte | Status |
+|------|------|--------|
+| Keccak256 | `0x00` | Supported. Integrity is enforced inside the zkVM via the preimage oracle (`keccak256(data) == commitment`). |
+| Generic | `0x01` | Not supported in this release. The host rejects this commitment type. |
+
+## Enabling AltDA Mode
+
+AltDA mode is gated by the `altda` Cargo feature on the `validity` binary.
+
+```bash
+# From the repository root
+cargo build --bin validity --release --features altda
+```
+
+## Environment Setup
+
+Create a `.env` file with all base configuration variables from the [Proposer](../proposer.md) section, plus the AltDA-specific variable below.
+
+### Required Variables
+
+| Parameter | Description |
+|-----------|-------------|
+| `ALTDA_SERVER_URL` | Base URL of the alt-DA server (e.g., `http://localhost:8080`). The host fetches batch data via `GET {ALTDA_SERVER_URL}/get/0x{hex(encoded_commitment)}`. No default; required when running with the `altda` feature. |
+
+The alt-DA server must implement the OP Stack alt-DA `GET` endpoint shape. Operators are responsible for running this server and consulting their DA provider's documentation for setup.
+
+## AltDA Contract Configuration
+
+Before deploying or updating contracts, generate the AltDA-specific range verification key, aggregation verification key, and rollup config hash with the correct feature flag. This ensures the range verification key commitment matches the AltDA range ELF:
+
+```bash
+# From the repository root
+cargo run --bin config --release --features altda -- --env-file .env
+```
+
+The command prints the `Range Verification Key Hash`, `Aggregation Verification Key Hash`, and `Rollup Config Hash`; keep these values and ensure they match what you publish on-chain in `OPSuccinctL2OutputOracle`.
+
+When you use the `just` helpers below, pass the `altda` feature so `fetch-l2oo-config` runs with the correct ELFs. If you call the binaries manually (`fetch-l2oo-config`, `config`, etc.), append `--features altda`; otherwise the script emits the default Ethereum DA values and your contracts will revert with `ProofInvalid()` when submitting proofs.
+
+## Deploying `OPSuccinctL2OutputOracle` with AltDA features
+
+```bash
+just deploy-oracle .env altda
+```
+
+## Updating `OPSuccinctL2OutputOracle` Parameters
+
+```bash
+just update-parameters .env altda
+```
+
+For more details on the `just update-parameters` command, see the [Updating `OPSuccinctL2OutputOracle` Parameters](../contracts/update-parameters.md) section.
+
+## Run the AltDA Proposer Service
+
+Run the `op-succinct-altda` service.
+
+```bash
+docker compose -f docker-compose-altda.yml up -d
+```
+
+To see the logs of the `op-succinct-altda` service, run:
+
+```bash
+docker compose -f docker-compose-altda.yml logs -f
+```
+
+To stop the `op-succinct-altda` service, run:
+
+```bash
+docker compose -f docker-compose-altda.yml down
+```
+
+## Building the AltDA Range ELF
+
+The AltDA range ELF (`altda-range-elf-embedded`) is embedded into the proposer binary at build time. To rebuild it from source, run:
+
+```bash
+just build-range-elfs
+```
+
+This recipe rebuilds all DA-variant range ELFs (Ethereum, Celestia, EigenDA, AltDA).
+
+## Limitations
+
+- **Experimental.** The AltDA feature is under active development. Configuration keys, feature flags, and on-disk artifacts may change without notice.
+- **Keccak256 commitments only.** Generic commitments (`0x01`) are not supported in this release.
+- **DA server availability assumption.** Proving stalls if the alt-DA server returns no data for a referenced commitment. The proposer cannot make progress past an unresolvable commitment.
+- **DA server is outside the op-succinct trust boundary.** Data availability and censorship resistance depend on the alt-DA server operator. op-succinct verifies that retrieved data matches its commitment but cannot force the server to serve data.
+- **Hardcoded HTTP timeout.** Requests to the alt-DA server use a 30s timeout that is not currently configurable.
+- **Standard L1 head logic.** AltDA uses the same L1 head selection as Ethereum DA. There is no Blobstream-style finality tracking.
+
+## OP Succinct Lite
+
+AltDA support also exists for OP Succinct Lite (fault-proof) mode behind the same `altda` Cargo feature flag. Full Lite-mode AltDA documentation will follow. See the [OP Succinct Lite (Fault Proofs)](../../fault_proofs/intro.md) section for the base setup.
+
+## Where to Go Next
+
+- [Architecture](../../architecture.md)
+- [Proposer Configuration](../proposer.md)
+- [OP Stack alt-DA reference (`op-alt-da`)](https://github.com/ethereum-optimism/optimism/tree/develop/op-alt-da)

--- a/book/validity/experimental/altda.md
+++ b/book/validity/experimental/altda.md
@@ -1,8 +1,8 @@
-# AltDA (Validium)
+# Alt-DA Server
 
 <div class="warning">
 
-This feature is under active development. Breaking changes to configuration and on-chain parameters may occur between releases — review release notes before upgrading.
+This feature is under active development. Breaking changes to configuration and on-chain parameters may occur between releases. Review release notes before upgrading.
 
 </div>
 

--- a/book/validity/experimental/altda.md
+++ b/book/validity/experimental/altda.md
@@ -2,13 +2,13 @@
 
 <div class="warning">
 
-This feature is experimental. Configuration keys, feature flags, and on-disk artifacts may change without notice.
+This feature is under active development. Breaking changes to configuration and on-chain parameters may occur between releases — review release notes before upgrading.
 
 </div>
 
 ## Overview
 
-OP Succinct's AltDA mode supports OP Stack chains that publish batch data off-chain and post only commitments to L1 — the architecture commonly called a **validium**. The codebase uses "AltDA" throughout, matching the OP Stack alt-DA pathway it builds on; the rest of this page uses that term.
+OP Succinct's AltDA mode supports OP Stack chains that use the [alt-DA spec](https://specs.optimism.io/experimental/alt-da.html) with a generic op-alt-da server. Specialized DA backends like Celestia and EigenDA also build on the alt-DA pathway but have their own integrations and pages; this page covers the generic-server case only. The most common deployment pattern is a **validium** — an L2 that posts batch data to an off-chain DA layer and only commitments to L1 — though the underlying transport does not require that trust model. The codebase uses "AltDA" / `altda` throughout, and so does this page.
 
 In AltDA mode, chain-layer responsibilities (derivation, validity proving, on-chain settlement) are handled by op-succinct. The data availability layer — the alt-DA server that stores batch data and serves it by commitment — is operated separately and is out of scope for this repository.
 

--- a/book/validity/experimental/altda.md
+++ b/book/validity/experimental/altda.md
@@ -8,9 +8,9 @@ This feature is under active development. Breaking changes to configuration and 
 
 ## Overview
 
-OP Succinct's AltDA mode supports OP Stack chains that use the [alt-DA spec](https://specs.optimism.io/experimental/alt-da.html) with a generic op-alt-da server. Specialized DA backends like Celestia and EigenDA also build on the alt-DA pathway but have their own integrations and pages; this page covers the generic-server case only. The most common deployment pattern is a **validium** — an L2 that posts batch data to an off-chain DA layer and only commitments to L1 — though the underlying transport does not require that trust model. The codebase uses "AltDA" / `altda` throughout, and so does this page.
+OP Succinct's AltDA mode supports OP Stack chains that use the [alt-DA spec](https://specs.optimism.io/experimental/alt-da.html) with a generic op-alt-da server. Specialized DA backends like Celestia and EigenDA also build on the alt-DA pathway but have their own integrations and pages; this page covers the generic-server case only. The most common deployment pattern is a **validium**: an L2 that posts batch data to an off-chain DA layer and only commitments to L1. The underlying transport does not require that trust model. The codebase uses "AltDA" / `altda` throughout, and so does this page.
 
-In AltDA mode, chain-layer responsibilities (derivation, validity proving, on-chain settlement) are handled by op-succinct. The data availability layer — the alt-DA server that stores batch data and serves it by commitment — is operated separately and is out of scope for this repository.
+In AltDA mode, chain-layer responsibilities (derivation, validity proving, on-chain settlement) are handled by op-succinct. The data availability layer (the alt-DA server that stores batch data and serves it by commitment) is operated separately and is out of scope for this repository.
 
 ## Architecture
 
@@ -49,7 +49,7 @@ The OP Succinct proposer reads L1 calldata as usual. When a batcher transaction 
 | Keccak256 | `0x00` | Supported. Integrity is enforced inside the zkVM via the preimage oracle (`keccak256(data) == commitment`). |
 | Generic | `0x01` | Not supported in this release. The host rejects this commitment type. |
 
-> Note: the byte `0x01` appears in two distinct positions on the wire — as the `DerivationVersion1` prefix on the L1 batcher transaction (separating alt-DA from Ethereum DA) and as the commitment type byte inside the encoded commitment. The two positions are independent.
+> Note: the byte `0x01` appears in two distinct positions on the wire. It serves as the `DerivationVersion1` prefix on the L1 batcher transaction (separating alt-DA from Ethereum DA) and as the commitment type byte inside the encoded commitment. The two positions are independent.
 
 ## Enabling AltDA Mode
 

--- a/book/validity/experimental/experimental.md
+++ b/book/validity/experimental/experimental.md
@@ -2,8 +2,8 @@
 
 This section covers features for OP Succinct (Validity) that are under active development. APIs and configuration may change.
 
-## AltDA (Validium)
+## Alt-DA Server
 
 The `op-succinct-altda` service monitors the state of an OP Stack chain configured with alt-DA (validium), fetches batch data from an external alt-DA server, requests proofs from the [Succinct Prover Network](https://docs.succinct.xyz/docs/sp1/prover-network/intro) and submits them to L1.
 
-For detailed setup instructions, see the [AltDA (Validium)](./altda.md) section.
+For detailed setup instructions, see the [Alt-DA Server](./altda.md) section.

--- a/book/validity/experimental/experimental.md
+++ b/book/validity/experimental/experimental.md
@@ -1,3 +1,9 @@
 # Experimental Features
 
 This section covers features for OP Succinct (Validity) that are under active development. APIs and configuration may change.
+
+## AltDA (Validium)
+
+The `op-succinct-altda` service monitors the state of an OP Stack chain configured with alt-DA (validium), fetches batch data from an external alt-DA server, requests proofs from the [Succinct Prover Network](https://docs.succinct.xyz/docs/sp1/prover-network/intro) and submits them to L1.
+
+For detailed setup instructions, see the [AltDA (Validium)](./altda.md) section.


### PR DESCRIPTION
Adds `book/validity/experimental/altda.md` documenting OP Succinct's Alt-DA Server mode (the [alt-DA spec](https://specs.optimism.io/experimental/alt-da.html) with a generic op-alt-da server; most common deployment is a validium). Partner-neutral.

Also adds a SUMMARY.md sidebar entry and a one-paragraph reference in `experimental.md`.

Page covers: architecture (mermaid), Keccak256 commitments only, `altda` feature flag, `ALTDA_SERVER_URL`, contract config, Docker commands, ELF rebuild, limitations (incl. trust-boundary callout). Celestia/EigenDA out of scope (own pages); Lite-mode is a "Where to Go Next" pointer.

Rebased on #903. Related fixes from review: #904 (scripts/utils `altda` feature), #905 (`add_config` typo on linked update-parameters page).