### PR TITLE
fix: register altda feature on op-succinct-scripts crate

### DIFF
--- a/scripts/utils/Cargo.toml
+++ b/scripts/utils/Cargo.toml
@@ -86,6 +86,7 @@ op-succinct-build-utils.workspace = true
 
 [features]
 default = ["ethereum"]
+altda = ["op-succinct-proof-utils/altda"]
 eigenda = ["op-succinct-proof-utils/eigenda"]
 celestia = ["op-succinct-proof-utils/celestia"]
 ethereum = ["op-succinct-proof-utils/ethereum"]


### PR DESCRIPTION
## Summary

The `op-succinct-scripts` crate (`scripts/utils/Cargo.toml`) is missing an `altda` feature flag, even though peer crates (`validity`, `fault-proof`, `utils/proof`) all expose one. As a result, the AltDA setup commands documented in #902 fail:

```
$ cargo run --bin config --release --features altda -- --env-file .env
error: none of the selected packages contains this feature: altda
```

This PR adds:

```toml
altda = ["op-succinct-proof-utils/altda"]
```

next to the existing `eigenda` / `celestia` / `ethereum` entries, mirroring the established pattern.

## Test plan

- [x] `cargo check --features altda -p op-succinct-scripts` — compiles cleanly, no "feature does not exist".
- [x] `cargo run --bin config --release --features altda -- --env-file .env` — past the feature-registration error and actually produced output (Range/Aggregation VK hashes + Rollup Config Hash).
- [x] Reviewer eyeball the one-line diff.