### PR TITLE
docs: fix add_config typo in update-parameters page

### DIFF
--- a/book/validity/contracts/update-parameters.md
+++ b/book/validity/contracts/update-parameters.md
@@ -9,7 +9,7 @@ OP Succinct supports a rolling update process when [program binaries](../../adva
 ## Rolling update guide
 
 1. Generate new elfs, vkeys, and a rollup config hash by following [this guide](../../advanced/verify-binaries.md).
-2. From the project's root, run `just add_config my_upgrade`.
+2. From the project's root, run `just add-config my_upgrade`.
     - This will automatically fetch the `aggregationVkey` and `rangeVkeyCommitment` from the [`/elf`](https://github.com/succinctlabs/op-succinct/tree/main/elf) directory, and the `rollupConfigHash` from the `L2_RPC` set in the `.env`. The output will look like the following:
 
 ```bash


### PR DESCRIPTION
The `just add_config my_upgrade` example on line 12 used an underscore instead of
a hyphen. The actual recipe is `add-config`; the underscore version errors out
with `Justfile does not contain recipe add_config`. Lines 16 and 71 of the same
page already use the correct hyphen spelling.

Caught while validating PR #902 (Alt-DA Server docs page) ahead of next Tuesday's
launch — that page links to update-parameters.md as the rolling-update flow
reference.