### PR TITLE
fix(ci): unblock book deploy-pages by overriding transitive skip

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -102,8 +102,11 @@ jobs:
       - run: echo "Deploy only runs on push to main"
 
   # Real GitHub Pages deploy — push to main only.
+  # `success()` is required to break transitive skip propagation from the
+  # PR-only `changes` job through `lint`/`build` (which use `if: always()`)
+  # down to this job. Without it, GitHub auto-skips this job on push to main.
   deploy-pages:
-    if: github.ref_name == 'main' && github.event_name == 'push'
+    if: success() && github.ref_name == 'main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [lint, build]
     name: deploy


### PR DESCRIPTION
The Pages deploy has been silently skipped on every push to main since #885 (April 21). Three weeks of merged docs (#903, #905, #908, #902) never reached the live site.

**Root cause:** the PR-only `changes` job is skipped on push events. `lint`/`build` survive via `if: always()`, but `deploy-pages` did not override the skip propagation in its `if` block, so GitHub auto-skipped it despite the explicit `ref_name == 'main'` guard.

**Fix:** add `success()` to the conditional so the skip-propagation rule is overridden when the actual `needs` succeed.

Verified locally that no other job in this workflow has the same pattern.