### PR TITLE
fix(ci): use always() + explicit needs result checks for deploy-pages

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -102,11 +102,13 @@ jobs:
       - run: echo "Deploy only runs on push to main"
 
   # Real GitHub Pages deploy — push to main only.
-  # `success()` is required to break transitive skip propagation from the
-  # PR-only `changes` job through `lint`/`build` (which use `if: always()`)
-  # down to this job. Without it, GitHub auto-skips this job on push to main.
+  # `always()` is required to break transitive skip propagation from the
+  # PR-only `changes` job (skipped on push) through `lint`/`build`
+  # (which use `if: always()`) down to this job. `success()` alone does
+  # not override the skip, so we use `always()` plus explicit result
+  # checks to ensure we only deploy when the build actually succeeded.
   deploy-pages:
-    if: success() && github.ref_name == 'main' && github.event_name == 'push'
+    if: always() && needs.lint.result == 'success' && needs.build.result == 'success' && github.ref_name == 'main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [lint, build]
     name: deploy


### PR DESCRIPTION
Follow-up to #909. The `success()` fix didn't actually unblock deploys — direct verification on the post-#909 main push showed `deploy-pages` still being auto-skipped despite the new guard.

**Why `success()` failed:** `success()` at job level returns false when any job in the dependency chain is skipped (`changes` is skipped on push events). It does not break skip propagation, only `always()` does.

**Fix:** replace `success() && …` with `always() && needs.lint.result == 'success' && needs.build.result == 'success' && …`. `always()` forces the conditional to evaluate; the explicit result checks preserve the previous safety property (only deploy when both upstream jobs actually succeeded).