### PR TITLE
feat(host): env-configurable debug_executePayload path for op-reth compat

### DIFF
--- a/book/advanced/node-setup.md
+++ b/book/advanced/node-setup.md
@@ -5,7 +5,7 @@
 To run OP Succinct or OP Succinct Lite, you will need the following RPCs in your `.env`:
 
 - `L1_RPC`: L1 Execution Archive Node
-- `L2_RPC`: L2 Execution Node (`op-geth`)
+- `L2_RPC`: L2 Execution Node (`op-geth` archive, or `op-reth` with proof-history)
 - `L2_NODE_RPC`: L2 Rollup Node (`op-node`)
 
 > Note: If your integration requires access to consensus-layer data, set the `L1_BEACON_RPC` (L1 Beacon Node). This is optional and not required by default.
@@ -21,14 +21,25 @@ The RPCs must support the following endpoints:
 | RPC | Endpoints | Description |
 |-----|-----------|-------------|
 | `L1_RPC` | `debug_getRawHeader`, `debug_getRawReceipts`, `debug_getRawBlock` | L1 Execution Archive Node |
-| `L2_RPC` | `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_dbGet` | L2 Execution Node (`op-geth`) |
+| `L2_RPC` (op-geth) | `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_dbGet` | L2 Execution Node (`op-geth` archive, hash state scheme) |
+| `L2_RPC` (op-reth) | `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_executePayload` | L2 Execution Node (`op-reth` ≥ v2.2.3 with `--proofs-history --proofs-history.storage-version=v2`). Requires `ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT=true` on the proposer. |
 | `L2_NODE_RPC` | `optimism_outputAtBlock`, `optimism_rollupConfig`, `optimism_syncStatus`, `optimism_safeHeadAtL1Block` | L2 Rollup Node (`op-node`) |
 
 ## External RPC Provider
 
 First, we'd recommend asking your RPC provider if they support these endpoints. If they do, you can use them.
 
-> **Note:** While some RPC providers (like Alchemy and Infura) support the required L1 endpoints after enabling them, most RPC providers do not support the `debug_dbGet` endpoint for external users. You will likely need to run your own L2 nodes for this reason.
+> **Note:** While some RPC providers (like Alchemy and Infura) support the required L1 endpoints after enabling them, most RPC providers do not support the `debug_dbGet` endpoint (op-geth) or run `op-reth` with the proof-history ExEx for external users. You will likely need to run your own L2 nodes for this reason.
+
+## op-reth Setup
+
+As an alternative to `op-geth`, you can run [`op-reth`](https://github.com/paradigmxyz/reth) (≥ v2.2.3) with the proof-history ExEx, which serves the historical `eth_getProof` and `debug_executePayload` endpoints kona requires.
+
+1. Initialize the proof store once: `op-reth proofs init --datadir <DATADIR>`.
+2. Start `op-reth` with `--proofs-history --proofs-history.storage-version=v2 --proofs-history.storage-path=<DIR> --proofs-history.window=<NUM_BLOCKS>` where `<NUM_BLOCKS>` covers your challenge/finality window with margin.
+3. Set `ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT=true` in the proposer environment so kona routes witness collection through `debug_executePayload` instead of `debug_dbGet`.
+
+See [OP Labs' op-reth historical proofs tutorial](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) for full setup, sizing guidance, and metrics.
 
 ## Running Your Own L2 Nodes
 

--- a/book/advanced/prerequisites.md
+++ b/book/advanced/prerequisites.md
@@ -11,15 +11,16 @@ You must have the following installed:
 You must have the following RPCs available:
 - L1 Archive Node
 - L1 Consensus (Beacon) Node
-- L2 Execution Node (`op-geth`)
+- L2 Execution Node (`op-geth` archive node, or `op-reth` with the proof-history ExEx)
 - L2 Rollup Node (`op-node`)
 
 The following RPC endpoints must be accessible:
 
 - L1 Archive Node.
   - `debug_getRawHeader`, `debug_getRawReceipts`, `debug_getRawBlock`
-- L2 Execution Node (`op-geth`): Archive node with hash state scheme.
-  - `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_dbGet`
+- L2 Execution Node — one of:
+  - **`op-geth`** archive node with hash state scheme: `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_dbGet`.
+  - **`op-reth`** (≥ v2.2.3) launched with `--proofs-history --proofs-history.storage-version=v2`: `debug_getRawHeader`, `debug_getRawTransaction`, `debug_getRawBlock`, `debug_executePayload`. Set `ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT=true` on the proposer to route witness collection through `debug_executePayload`. See [OP Labs' op-reth historical proofs tutorial](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs).
 - L2 Optimism Node (`op-node`)
   - `optimism_outputAtBlock`, `optimism_rollupConfig`, `optimism_syncStatus`, `optimism_safeHeadAtL1Block`.
 

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -1032,7 +1032,12 @@ impl OPSuccinctDataFetcher {
             server: true,
             rollup_config_path: self.rollup_config_path.clone(),
             l1_config_path: self.l1_config_path.clone(),
-            enable_experimental_witness_endpoint: false,
+            enable_experimental_witness_endpoint: std::env::var(
+                "ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT",
+            )
+            .ok()
+            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false),
         })
     }
 }


### PR DESCRIPTION
## Summary
- Adds `ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT` env var to opt into kona's `debug_executePayload` witness-preload path, enabling op-reth compatibility on the kona v1.2.14 line.
- Host-only change. No ELF rebuild, no vkey change. Op-geth users unaffected by default.
- Docs updated with op-reth setup requirements (op-reth ≥ v2.2.3 with `--proofs-history --proofs-history.storage-version=v2`).

## Why
Kona's default `L2StateNode` prefetch path calls `debug_dbGet` with a 32-byte trie-node hash, which op-reth rejects (only 33-byte bytecode keys supported). Kona already includes the alternative `L2PayloadWitness` handler that proactively calls `debug_executePayload`, but op-succinct hard-codes `enable_experimental_witness_endpoint: false`, blocking that path. This PR exposes the flag as an env var.

This mirrors upstream [ethereum-optimism/optimism#20498](https://github.com/ethereum-optimism/optimism/pull/20498) (which made the path default-on in kona v1.5.x), implemented on top of v1.2.14 without a kona bump (the SP1 zkVM toolchain is currently at Rust 1.93; kona v1.5.x requires 1.94 — separate track).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features` clean (full workspace + targeted `-p op-succinct-host-utils`)
- [x] ELF bytes unchanged (`git diff --stat` confirms no `elf/*` files touched)
- [ ] Integration tests (eigenda matrix) on `succinct-eigenda-c5k55r7jhl` — op-reth since 2026-05-21 — provide first end-to-end exercise of v1.2.14 + op-reth path
- [ ] Follow-up: env-set run (`ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT=true`) to validate the treatment path; control run (env unset) verifies no regression on the unchanged code path

## Out of scope
- Kona v1.5.x bump (gated on SP1 toolchain MSRV 1.93 → 1.94 readiness).
- `release/v3.x` backport (follow-up PR, MINOR bump `v3.N.0`).
- Karst hardfork support.