### PR TITLE
ci(sqlx): pin sqlx-cli to 0.8.x

### DIFF
--- a/.github/workflows/sqlx-check.yml
+++ b/.github/workflows/sqlx-check.yml
@@ -31,7 +31,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Install SQLx CLI
-        run: cargo install sqlx-cli --no-default-features --features native-tls,postgres
+        # Pin to the 0.8.x line: sqlx-cli 0.9.0 raised MSRV to 1.94, but this repo's
+        # rust-toolchain.toml pins nightly-2025-09-15 (= 1.92.0-nightly) for the SP1
+        # zkVM build, which cargo picks up here and rejects the 0.9.x install.
+        run: cargo install sqlx-cli --version '~0.8' --no-default-features --features native-tls,postgres
       
       - name: Verify SQLx query files
         run: cd validity && cargo sqlx prepare --check

--- a/.github/workflows/sqlx-check.yml
+++ b/.github/workflows/sqlx-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -31,10 +31,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Install SQLx CLI
-        # Pin to the 0.8.x line: sqlx-cli 0.9.0 raised MSRV to 1.94, but this repo's
-        # rust-toolchain.toml pins nightly-2025-09-15 (= 1.92.0-nightly) for the SP1
-        # zkVM build, which cargo picks up here and rejects the 0.9.x install.
         run: cargo install sqlx-cli --version '~0.8' --no-default-features --features native-tls,postgres
-      
+
       - name: Verify SQLx query files
         run: cd validity && cargo sqlx prepare --check


### PR DESCRIPTION
## Summary
- Pin the SQLx CLI install in `.github/workflows/sqlx-check.yml` to `~0.8`.
- Clean up workflow whitespace and remove the verbose inline rationale.

## Why
`sqlx-cli 0.9.0` requires Rust 1.94. This repo uses `nightly-2025-09-15` (`1.92.0-nightly`) for the checked-out toolchain, so unpinned `cargo install sqlx-cli` fails before `cargo sqlx prepare --check` can run.

## Validation
- `git diff --check origin/main...HEAD`
- Reported PR checks are passing or skipped; `SQLx Query Check` is path-filtered and does not run for this workflow-only change.
