### PR TITLE
fix: remove redundant rustup installs from fault-proof images

### DIFF
--- a/fault-proof/Dockerfile.challenger
+++ b/fault-proof/Dockerfile.challenger
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \

--- a/fault-proof/Dockerfile.proposer
+++ b/fault-proof/Dockerfile.proposer
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -55,7 +54,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
     
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.altda
+++ b/fault-proof/Dockerfile.proposer.altda
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -55,7 +54,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.celestia
+++ b/fault-proof/Dockerfile.proposer.celestia
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -55,7 +54,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
     
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.eigenda
+++ b/fault-proof/Dockerfile.proposer.eigenda
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -58,7 +57,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
     
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/


### PR DESCRIPTION
## Summary
- Remove redundant `rustup install stable && rustup default stable` steps after the rustup installer in fault-proof Dockerfiles.
- Apply the cleanup to the standard, Celestia, EigenDA, AltDA, and Challenger images so cached layers cannot hide the same rustup reinstall path.

## Context
- Investigated the latest failing PR #920 push checks in `Build OP Succinct Lite Docker Images`, run `26488481666`.
- The failing jobs were:
  - `Build OP Succinct Lite Proposer` (`78000923410`)
  - `Build OP Succinct Lite Proposer Celestia` (`78000923407`)
  - `Build OP Succinct Lite Proposer EigenDA` (`78000923439`)
- All three failures reached `RUN rustup install stable && rustup default stable` after `sh.rustup.rs -y` had already installed Rust, then failed with `Invalid cross-device link`.

## Validation
- `git diff --check`
- `docker buildx build --check -f fault-proof/Dockerfile.proposer .`
- `docker buildx build --check -f fault-proof/Dockerfile.proposer.celestia .`
- `docker buildx build --check -f fault-proof/Dockerfile.proposer.eigenda .`
- `docker buildx build --check -f fault-proof/Dockerfile.challenger .`
- `docker buildx build --check -f fault-proof/Dockerfile.proposer.altda .`

## Notes
- Dockerfile-only change; no Rust files changed, so `cargo fmt --all` and `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features` were not run.
- Created from `origin/main` to keep this separate from PR #920.
- Updated `fault-proof/Dockerfile.challenger` after review because it is built by the same lite workflow and had passed via a cached layer.
- Updated `fault-proof/Dockerfile.proposer.altda` because it contained the same redundant rustup reinstall pattern.
