### PR TITLE
fix: close finalized dispute games before claiming bonds

### DIFF
--- a/fault-proof/src/backup.rs
+++ b/fault-proof/src/backup.rs
@@ -143,6 +143,7 @@ mod tests {
             proposal_status: ProposalStatus::Unchallenged,
             deadline: 0,
             should_attempt_to_resolve: false,
+            should_attempt_to_close_game: false,
             should_attempt_to_claim_bond: false,
             aggregation_vkey: B256::ZERO,
             range_vkey_commitment: B256::ZERO,

--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -16,7 +16,7 @@ use crate::{
     contract::{
         AnchorStateRegistry::AnchorStateRegistryInstance,
         DisputeGameFactory::DisputeGameFactoryInstance, GameStatus, OPSuccinctFaultDisputeGame,
-        ProposalStatus,
+        ProposalStatus, BOND_DISTRIBUTION_MODE_UNDECIDED, MAX_CLOSE_GAME_FAILURES,
     },
     is_parent_challenger_wins, is_parent_resolved,
     prometheus::ChallengerGauge,
@@ -36,6 +36,7 @@ where
     anchor_state_registry: AnchorStateRegistryInstance<P>,
     factory: DisputeGameFactoryInstance<P>,
     challenger_bond: OnceLock<U256>,
+    close_game_failures: Arc<Mutex<HashMap<Address, u8>>>,
     state: Arc<Mutex<ChallengerState>>,
 }
 
@@ -61,6 +62,7 @@ where
             anchor_state_registry,
             factory,
             challenger_bond: OnceLock::new(),
+            close_game_failures: Arc::new(Mutex::new(HashMap::new())),
             state: Arc::new(Mutex::new(ChallengerState {
                 cursor: U256::ZERO,
                 games: HashMap::new(),
@@ -103,6 +105,10 @@ where
 
             if let Err(e) = self.handle_game_resolution().await {
                 tracing::warn!("Failed to handle game resolution: {:?}", e);
+            }
+
+            if let Err(e) = self.handle_game_closing().await {
+                tracing::warn!("Failed to handle game closing: {:?}", e);
             }
 
             if let Err(e) = self.handle_bond_claiming().await {
@@ -180,9 +186,10 @@ where
     ///      wins.
     ///    - Games are marked for resolution if the parent is resolved, the game is over, and it's
     ///      own game.
-    ///    - Games are marked for bond claim if they are finalized and there is credit to claim.
-    ///    - Games are evicted once finalized with no remaining credit or whenever resolves as
-    ///      defender wins.
+    ///    - Finalized UNDECIDED challenger-won games are marked for close.
+    ///    - Closed challenger-won games are marked for bond claim if there is credit to claim.
+    ///    - Closed challenger-won games with no remaining credit are evicted, as are games that
+    ///      resolve as defender wins.
     pub async fn sync_state(&self) -> Result<()> {
         // 1. Load new games.
         let mut next_index = {
@@ -228,6 +235,7 @@ where
                     proposal_status: ProposalStatus,
                     should_attempt_to_challenge: bool,
                     should_attempt_to_resolve: bool,
+                    should_attempt_to_close_game: bool,
                     should_attempt_to_claim_bond: bool,
                 },
                 Remove(U256),
@@ -287,15 +295,45 @@ where
                             proposal_status,
                             should_attempt_to_challenge,
                             should_attempt_to_resolve,
+                            should_attempt_to_close_game: false,
                             should_attempt_to_claim_bond: false,
                         });
                     }
                     GameStatus::CHALLENGER_WINS => {
                         let is_finalized =
                             self.anchor_state_registry.isGameFinalized(game.address).call().await?;
-                        let credit = contract.credit(signer_address).call().await?;
 
-                        if is_finalized && credit == U256::ZERO {
+                        if !is_finalized {
+                            actions.push(GameSyncAction::Update {
+                                index: game.index,
+                                status,
+                                proposal_status,
+                                should_attempt_to_challenge: false,
+                                should_attempt_to_resolve: false,
+                                should_attempt_to_close_game: false,
+                                should_attempt_to_claim_bond: false,
+                            });
+                            continue;
+                        }
+
+                        let bond_distribution_mode = contract.bondDistributionMode().call().await?;
+                        if bond_distribution_mode == BOND_DISTRIBUTION_MODE_UNDECIDED {
+                            actions.push(GameSyncAction::Update {
+                                index: game.index,
+                                status,
+                                proposal_status,
+                                should_attempt_to_challenge: false,
+                                should_attempt_to_resolve: false,
+                                should_attempt_to_close_game: true,
+                                should_attempt_to_claim_bond: false,
+                            });
+                            continue;
+                        }
+
+                        self.close_game_failures.lock().await.remove(&game.address);
+
+                        let credit = contract.credit(signer_address).call().await?;
+                        if credit == U256::ZERO {
                             actions.push(GameSyncAction::Remove(game.index));
                         } else {
                             actions.push(GameSyncAction::Update {
@@ -304,7 +342,8 @@ where
                                 proposal_status,
                                 should_attempt_to_challenge: false,
                                 should_attempt_to_resolve: false,
-                                should_attempt_to_claim_bond: is_finalized && credit > U256::ZERO,
+                                should_attempt_to_close_game: false,
+                                should_attempt_to_claim_bond: true,
                             });
                         }
                     }
@@ -324,6 +363,7 @@ where
                         proposal_status,
                         should_attempt_to_challenge,
                         should_attempt_to_resolve,
+                        should_attempt_to_close_game,
                         should_attempt_to_claim_bond,
                     } => {
                         if let Some(game) = state.games.get_mut(&index) {
@@ -331,6 +371,7 @@ where
                             game.proposal_status = proposal_status;
                             game.should_attempt_to_challenge = should_attempt_to_challenge;
                             game.should_attempt_to_resolve = should_attempt_to_resolve;
+                            game.should_attempt_to_close_game = should_attempt_to_close_game;
                             game.should_attempt_to_claim_bond = should_attempt_to_claim_bond;
                         }
                     }
@@ -385,6 +426,7 @@ where
                     proposal_status: claim_data.status,
                     should_attempt_to_challenge: false,
                     should_attempt_to_resolve: false,
+                    should_attempt_to_close_game: false,
                     should_attempt_to_claim_bond: false,
                 },
             );
@@ -598,6 +640,91 @@ where
         Ok(())
     }
 
+    /// Closes finalized challenger-won games before any bond-claim or eviction decision.
+    #[tracing::instrument(skip(self), level = "info", name = "[[Closing Challenger Games]]")]
+    async fn handle_game_closing(&self) -> Result<()> {
+        let candidates = {
+            let state = self.state.lock().await;
+            state
+                .games
+                .values()
+                .filter(|game| game.should_attempt_to_close_game)
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        for game in candidates {
+            let failure_count =
+                self.close_game_failures.lock().await.get(&game.address).copied().unwrap_or(0);
+            if failure_count >= MAX_CLOSE_GAME_FAILURES {
+                tracing::error!(
+                    game_index = %game.index,
+                    game_address = ?game.address,
+                    failures = failure_count,
+                    "Skipping game close after repeated failures; restart resets this in-memory guard"
+                );
+                continue;
+            }
+
+            if let Err(error) = self.submit_close_game_transaction(&game).await {
+                let mut failures = self.close_game_failures.lock().await;
+                let count = failures.entry(game.address).or_default();
+                *count = count.saturating_add(1);
+                ChallengerGauge::GameCloseError.increment(1.0);
+
+                if error.is_revert() {
+                    tracing::error!(
+                        game_index = %game.index,
+                        game_address = ?game.address,
+                        failures = *count,
+                        ?error,
+                        "Close game tx included but reverted on-chain"
+                    );
+                } else {
+                    tracing::warn!(
+                        game_index = %game.index,
+                        game_address = ?game.address,
+                        failures = *count,
+                        ?error,
+                        "Close game tx unconfirmed (may be on-chain), will verify next cycle"
+                    );
+                }
+                continue;
+            }
+
+            self.close_game_failures.lock().await.remove(&game.address);
+        }
+
+        Ok(())
+    }
+
+    async fn submit_close_game_transaction(&self, game: &Game) -> Result<()> {
+        let contract = OPSuccinctFaultDisputeGame::new(game.address, self.l1_provider.clone());
+        let transaction_request = contract.closeGame().gas(200_000).into_transaction_request();
+        let receipt = self
+            .signer
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
+            .await?;
+
+        if !receipt.status() {
+            bail!("{TX_REVERTED_PREFIX} {receipt:?}");
+        }
+
+        tracing::info!(
+            game_index = %game.index,
+            game_address = ?game.address,
+            l2_block_end = %game.l2_block_number,
+            tx_hash = ?receipt.transaction_hash,
+            "Game closed successfully"
+        );
+
+        Ok(())
+    }
+
     /// Claims bonds from games flagged for claiming.
     #[tracing::instrument(skip(self), level = "info", name = "[[Claiming Challenger Bonds]]")]
     pub async fn handle_bond_claiming(&self) -> Result<()> {
@@ -702,6 +829,7 @@ pub struct Game {
     pub proposal_status: ProposalStatus,
     pub should_attempt_to_challenge: bool,
     pub should_attempt_to_resolve: bool,
+    pub should_attempt_to_close_game: bool,
     pub should_attempt_to_claim_bond: bool,
 }
 

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -1,6 +1,12 @@
 use alloy_sol_macro::sol;
 use serde::{Deserialize, Serialize};
 
+/// `BondDistributionMode.UNDECIDED` in the Optimism dispute-game contracts.
+pub const BOND_DISTRIBUTION_MODE_UNDECIDED: u8 = 0;
+
+/// Maximum consecutive close-game failures before automatic retries pause until restart.
+pub const MAX_CLOSE_GAME_FAILURES: u8 = 5;
+
 sol! {
     type GameType is uint32;
     type Claim is bytes32;
@@ -123,6 +129,12 @@ sol! {
 
         /// @notice Claim the credit belonging to the recipient address.
         function claimCredit(address _recipient) external;
+
+        /// @notice Closes out the game and determines the bond distribution mode.
+        function closeGame() external;
+
+        /// @notice Returns the bond distribution mode.
+        function bondDistributionMode() external view returns (uint8);
 
         /// @notice Returns the credit balance of a given recipient.
         function credit(address _recipient) external view returns (uint256 credit_);

--- a/fault-proof/src/prometheus.rs
+++ b/fault-proof/src/prometheus.rs
@@ -88,6 +88,11 @@ pub enum ProposerGauge {
     )]
     GameResolutionError,
     #[strum(
+        serialize = "op_succinct_fp_game_close_error",
+        message = "Total number of game close errors encountered by the proposer"
+    )]
+    GameCloseError,
+    #[strum(
         serialize = "op_succinct_fp_bond_claiming_error",
         message = "Total number of bond claiming errors encountered by the proposer"
     )]
@@ -187,6 +192,11 @@ pub enum ChallengerGauge {
         message = "Total number of game resolution errors encountered by the challenger"
     )]
     GameResolutionError,
+    #[strum(
+        serialize = "op_succinct_fp_challenger_game_close_error",
+        message = "Total number of game close errors encountered by the challenger"
+    )]
+    GameCloseError,
     #[strum(
         serialize = "op_succinct_fp_challenger_bond_claiming_error",
         message = "Total number of bond claiming errors encountered by the challenger"

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -42,7 +42,8 @@ use crate::{
     contract::{
         AnchorStateRegistry::AnchorStateRegistryInstance,
         DisputeGameFactory::{DisputeGameCreated, DisputeGameFactoryInstance},
-        GameStatus, OPSuccinctFaultDisputeGame, ProposalStatus,
+        GameStatus, OPSuccinctFaultDisputeGame, ProposalStatus, BOND_DISTRIBUTION_MODE_UNDECIDED,
+        MAX_CLOSE_GAME_FAILURES,
     },
     is_parent_resolved,
     prometheus::ProposerGauge,
@@ -82,6 +83,7 @@ pub enum TaskInfo {
     GameCreation { block_number: U256 },
     GameProving { game_address: Address, is_defense: bool },
     GameResolution,
+    GameClose,
     BondClaim,
 }
 
@@ -157,6 +159,8 @@ pub struct Game {
     pub proposal_status: ProposalStatus,
     pub deadline: u64,
     pub should_attempt_to_resolve: bool,
+    #[serde(skip)]
+    pub should_attempt_to_close_game: bool,
     pub should_attempt_to_claim_bond: bool,
     pub aggregation_vkey: B256,
     pub range_vkey_commitment: B256,
@@ -264,6 +268,7 @@ where
     fetcher: Arc<OPSuccinctDataFetcher>,
     host: Arc<H>,
     tasks: Arc<Mutex<TaskMap>>,
+    close_game_failures: Arc<Mutex<HashMap<Address, u8>>>,
     next_task_id: Arc<AtomicU64>,
     state: Arc<RwLock<ProposerState>>,
     backup_semaphore: Arc<Semaphore>,
@@ -382,6 +387,7 @@ where
             fetcher: fetcher.clone(),
             host,
             tasks: Arc::new(Mutex::new(HashMap::new())),
+            close_game_failures: Arc::new(Mutex::new(HashMap::new())),
             next_task_id: Arc::new(AtomicU64::new(1)),
             state: Arc::new(RwLock::new(initial_state)),
             backup_semaphore: Arc::new(Semaphore::new(1)),
@@ -711,9 +717,11 @@ where
     ///    - Games are removed (along with their subtree) if their parent is not in the cache.
     ///    - Games are marked for resolution if the parent is resolved, the game is over, and it's
     ///      own game.
-    ///    - Games are marked for bond claim if they are finalized and there is credit to claim.
+    ///    - Finalized UNDECIDED defender-won games are marked for close.
+    ///    - Closed defender-won games are marked for bond claim if there is credit to claim.
     /// 3. Evict games from the cache.
-    ///    - Games that are finalized but there is no credit left to claim.
+    ///    - Closed defender-won games with no remaining credit, subject to anchor/canonical
+    ///      retention.
     ///    - The entire subtree of a CHALLENGER_WINS game.
     pub async fn sync_games(&self, pinned_block: BlockId, pinned_timestamp: u64) -> Result<()> {
         // 0. Prune cached games that don't exist at the pinned block. After a backup restore, the
@@ -865,6 +873,7 @@ where
                     proposal_status: ProposalStatus,
                     deadline: u64,
                     should_attempt_to_resolve: bool,
+                    should_attempt_to_close_game: bool,
                     should_attempt_to_claim_bond: bool,
                 },
                 Remove(U256),
@@ -921,49 +930,82 @@ where
                             proposal_status: claim_data.status,
                             deadline,
                             should_attempt_to_resolve,
+                            should_attempt_to_close_game: false,
                             should_attempt_to_claim_bond: false,
                         });
                     }
                     GameStatus::DEFENDER_WINS => {
+                        if !is_finalized {
+                            actions.push(GameSyncAction::Update {
+                                index,
+                                status,
+                                proposal_status: claim_data.status,
+                                deadline,
+                                should_attempt_to_resolve: false,
+                                should_attempt_to_close_game: false,
+                                should_attempt_to_claim_bond: false,
+                            });
+                            continue;
+                        }
+
+                        let bond_distribution_mode =
+                            contract.bondDistributionMode().block(pinned_block).call().await?;
+
+                        if bond_distribution_mode == BOND_DISTRIBUTION_MODE_UNDECIDED {
+                            actions.push(GameSyncAction::Update {
+                                index,
+                                status,
+                                proposal_status: claim_data.status,
+                                deadline,
+                                should_attempt_to_resolve: false,
+                                should_attempt_to_close_game: true,
+                                should_attempt_to_claim_bond: false,
+                            });
+                            continue;
+                        }
+
+                        self.close_game_failures.lock().await.remove(&game_address);
+
                         let credit =
                             contract.credit(signer_address).block(pinned_block).call().await?;
 
-                        if is_finalized && credit == U256::ZERO {
-                            // Game removal policy:
-                            // - Canonical head games are retained even with zero credit to maintain
-                            //   chain consistency.
-                            // - Anchor games are retained as they serve as the root of the dispute
-                            //   game tree.
-                            // - All other games with bonds already claimed are removed to free
-                            //   cache memory.
+                        if credit > U256::ZERO {
+                            actions.push(GameSyncAction::Update {
+                                index,
+                                status,
+                                proposal_status: claim_data.status,
+                                deadline,
+                                should_attempt_to_resolve: false,
+                                should_attempt_to_close_game: false,
+                                should_attempt_to_claim_bond: true,
+                            });
+                            continue;
+                        }
 
-                            let canonical_head_index = {
-                                let state = self.state.read().await;
-                                state.canonical_head_index
-                            };
+                        // Game removal policy:
+                        // - Canonical head games are retained even with zero credit to maintain
+                        //   chain consistency.
+                        // - Anchor games are retained as they serve as the root of the dispute game
+                        //   tree.
+                        // - All other closed games with no remaining credit are removed to free
+                        //   cache memory.
+                        let canonical_head_index = {
+                            let state = self.state.read().await;
+                            state.canonical_head_index
+                        };
 
-                            let should_remove = if canonical_head_index == Some(index) {
-                                tracing::debug!(game_index = %index, "Retaining game: canonical head");
-                                false
-                            } else if anchor_address == game_address {
-                                tracing::debug!(game_index = %index, "Retaining game: anchor game");
-                                false
-                            } else {
-                                true
-                            };
+                        let should_remove = if canonical_head_index == Some(index) {
+                            tracing::debug!(game_index = %index, "Retaining game: canonical head");
+                            false
+                        } else if anchor_address == game_address {
+                            tracing::debug!(game_index = %index, "Retaining game: anchor game");
+                            false
+                        } else {
+                            true
+                        };
 
-                            if should_remove {
-                                actions.push(GameSyncAction::Remove(index));
-                            } else {
-                                actions.push(GameSyncAction::Update {
-                                    index,
-                                    status,
-                                    proposal_status: claim_data.status,
-                                    deadline,
-                                    should_attempt_to_resolve: false,
-                                    should_attempt_to_claim_bond: false,
-                                });
-                            }
+                        if should_remove {
+                            actions.push(GameSyncAction::Remove(index));
                         } else {
                             actions.push(GameSyncAction::Update {
                                 index,
@@ -971,7 +1013,8 @@ where
                                 proposal_status: claim_data.status,
                                 deadline,
                                 should_attempt_to_resolve: false,
-                                should_attempt_to_claim_bond: is_finalized && credit > U256::ZERO,
+                                should_attempt_to_close_game: false,
+                                should_attempt_to_claim_bond: false,
                             });
                         }
                     }
@@ -991,6 +1034,7 @@ where
                         proposal_status,
                         deadline,
                         should_attempt_to_resolve,
+                        should_attempt_to_close_game,
                         should_attempt_to_claim_bond,
                     } => {
                         if let Some(game) = state.games.get_mut(&index) {
@@ -998,6 +1042,7 @@ where
                             game.proposal_status = proposal_status;
                             game.deadline = deadline;
                             game.should_attempt_to_resolve = should_attempt_to_resolve;
+                            game.should_attempt_to_close_game = should_attempt_to_close_game;
                             game.should_attempt_to_claim_bond = should_attempt_to_claim_bond;
                         }
                     }
@@ -1449,6 +1494,68 @@ where
         Ok(())
     }
 
+    /// Attempt to close finalized games before any bond-claim or eviction decision.
+    async fn close_games(&self) -> Result<()> {
+        let candidates = {
+            let state = self.state.read().await;
+            state
+                .games
+                .values()
+                // Only close games the proposer owns; challenger-won branches are handled by the
+                // challenger, and foreign games are tracked only for DAG continuity.
+                .filter(|game| game.is_owned(&self.identity))
+                .filter(|game| game.should_attempt_to_close_game)
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        for game in candidates {
+            let failure_count =
+                self.close_game_failures.lock().await.get(&game.address).copied().unwrap_or(0);
+            if failure_count >= MAX_CLOSE_GAME_FAILURES {
+                tracing::error!(
+                    game_index = %game.index,
+                    game_address = ?game.address,
+                    failures = failure_count,
+                    "Skipping game close after repeated failures; restart resets this in-memory guard"
+                );
+                continue;
+            }
+
+            if let Err(error) = self.submit_close_game_transaction(&game).await {
+                let mut failures = self.close_game_failures.lock().await;
+                let count = failures.entry(game.address).or_default();
+                *count = count.saturating_add(1);
+                ProposerGauge::GameCloseError.increment(1.0);
+
+                if error.is_revert() {
+                    tracing::error!(
+                        game_index = %game.index,
+                        game_address = ?game.address,
+                        l2_block_end = %game.l2_block,
+                        failures = *count,
+                        ?error,
+                        "Close game tx included but reverted on-chain"
+                    );
+                } else {
+                    tracing::warn!(
+                        game_index = %game.index,
+                        game_address = ?game.address,
+                        l2_block_end = %game.l2_block,
+                        failures = *count,
+                        ?error,
+                        "Close game tx unconfirmed (may be on-chain), will verify next cycle"
+                    );
+                }
+                continue;
+            }
+
+            self.close_game_failures.lock().await.remove(&game.address);
+        }
+
+        Ok(())
+    }
+
     pub async fn submit_resolution_transaction(&self, game: &Game) -> Result<()> {
         let contract = OPSuccinctFaultDisputeGame::new(game.address, self.l1_provider.clone());
         let transaction_request = contract.resolve().into_transaction_request();
@@ -1471,6 +1578,35 @@ where
             l2_block_end = %game.l2_block,
             tx_hash = ?receipt.transaction_hash,
             "Game resolved successfully"
+        );
+
+        Ok(())
+    }
+
+    /// Submit the on-chain transaction to close a finalized game.
+    #[tracing::instrument(name = "[[Closing Proposer Game]]", skip(self, game))]
+    pub async fn submit_close_game_transaction(&self, game: &Game) -> Result<()> {
+        let contract = OPSuccinctFaultDisputeGame::new(game.address, self.l1_provider.clone());
+        let transaction_request = contract.closeGame().gas(200_000).into_transaction_request();
+        let receipt = self
+            .signer
+            .send_transaction_request_with_timeout(
+                self.config.l1_rpc.clone(),
+                transaction_request,
+                self.config.tx_confirmation_timeout,
+            )
+            .await?;
+
+        if !receipt.status() {
+            bail!("{TX_REVERTED_PREFIX} {receipt:?}");
+        }
+
+        tracing::info!(
+            game_index = %game.index,
+            game_address = ?game.address,
+            l2_block_end = %game.l2_block,
+            tx_hash = ?receipt.transaction_hash,
+            "Game closed successfully"
         );
 
         Ok(())
@@ -1619,6 +1755,7 @@ where
             proposal_status,
             deadline,
             should_attempt_to_resolve: false,
+            should_attempt_to_close_game: false,
             should_attempt_to_claim_bond: false,
             aggregation_vkey,
             range_vkey_commitment,
@@ -1820,6 +1957,9 @@ where
             TaskInfo::GameResolution => {
                 ProposerGauge::GameResolutionError.increment(1.0);
             }
+            TaskInfo::GameClose => {
+                ProposerGauge::GameCloseError.increment(1.0);
+            }
             TaskInfo::BondClaim => {
                 ProposerGauge::BondClaimingError.increment(1.0);
             }
@@ -1857,6 +1997,18 @@ where
             } else {
                 tracing::info!("Successfully spawned game resolution task");
             }
+        }
+
+        // Spawn game close task before bond claiming. The sync logic makes close and claim flags
+        // disjoint by construction: UNDECIDED games close first, closed games may claim later.
+        if !self.has_active_task_of_type(&TaskInfo::GameClose).await {
+            if let Err(e) = self.spawn_game_close_task().await {
+                tracing::warn!("Failed to spawn game close task: {:?}", e);
+            } else {
+                tracing::info!("Successfully spawned game close task");
+            }
+        } else {
+            tracing::info!("Game close task already active");
         }
 
         // Spawn bond claim task (only operates on owned games via is_owned() filter)
@@ -1897,6 +2049,7 @@ where
                         "GameProving"
                     }
                     TaskInfo::GameResolution => "GameResolution",
+                    TaskInfo::GameClose => "GameClose",
                     TaskInfo::BondClaim => "BondClaim",
                 };
                 *task_counts.entry(task_type).or_insert(0) += 1;
@@ -2415,6 +2568,19 @@ where
         let task_info = TaskInfo::GameResolution;
         self.tasks.lock().await.insert(task_id, (handle, task_info));
         tracing::info!("Spawned game resolution task {}", task_id);
+        Ok(())
+    }
+
+    /// Spawn a game close task.
+    async fn spawn_game_close_task(&self) -> Result<()> {
+        let proposer = self.clone();
+        let task_id = self.next_task_id.fetch_add(1, Ordering::Relaxed);
+
+        let handle = tokio::spawn(async move { proposer.close_games().await });
+
+        let task_info = TaskInfo::GameClose;
+        self.tasks.lock().await.insert(task_id, (handle, task_info));
+        tracing::info!("Spawned game close task {}", task_id);
         Ok(())
     }
 

--- a/fault-proof/tests/backup.rs
+++ b/fault-proof/tests/backup.rs
@@ -21,6 +21,7 @@ fn test_game(index: u64, parent_index: u32) -> Game {
         proposal_status: ProposalStatus::Unchallenged,
         deadline: 0,
         should_attempt_to_resolve: false,
+        should_attempt_to_close_game: false,
         should_attempt_to_claim_bond: false,
         aggregation_vkey: B256::ZERO,
         range_vkey_commitment: B256::ZERO,

--- a/fault-proof/tests/common/env.rs
+++ b/fault-proof/tests/common/env.rs
@@ -565,6 +565,18 @@ impl TestEnvironment {
         Ok(receipt)
     }
 
+    pub async fn close_game(&self, game_address: Address) -> Result<TransactionReceipt> {
+        let game = self.fault_dispute_game(game_address).await?;
+        let receipt =
+            game.closeGame().send().await?.with_required_confirmations(1).get_receipt().await?;
+        Ok(receipt)
+    }
+
+    pub async fn get_bond_distribution_mode(&self, game_address: Address) -> Result<u8> {
+        let game = self.fault_dispute_game(game_address).await?;
+        Ok(game.bondDistributionMode().call().await?)
+    }
+
     pub async fn get_credit(&self, game_address: Address, recipient: Address) -> Result<U256> {
         let provider = &self.anvil.provider;
         let game = OPSuccinctFaultDisputeGame::new(game_address, provider);

--- a/fault-proof/tests/integration.rs
+++ b/fault-proof/tests/integration.rs
@@ -829,6 +829,7 @@ mod integration {
             proposal_status: ProposalStatus::Unchallenged,
             should_attempt_to_challenge: true,
             should_attempt_to_resolve: false,
+            should_attempt_to_close_game: false,
             should_attempt_to_claim_bond: false,
         };
         challenger.submit_challenge_transaction(&game_to_challenge).await?;

--- a/fault-proof/tests/sync.rs
+++ b/fault-proof/tests/sync.rs
@@ -18,6 +18,7 @@ mod asr_filtering {
             proposal_status: ProposalStatus::Unchallenged,
             deadline: 0,
             should_attempt_to_resolve: false,
+            should_attempt_to_close_game: false,
             should_attempt_to_claim_bond: false,
             aggregation_vkey: B256::ZERO,
             range_vkey_commitment: B256::ZERO,
@@ -75,7 +76,7 @@ mod proposer_sync {
     use alloy_sol_types::{SolCall, SolValue};
     use anyhow::{Context, Result};
     use fault_proof::{
-        contract::ProposalStatus,
+        contract::{ProposalStatus, BOND_DISTRIBUTION_MODE_UNDECIDED},
         proposer::{
             Game, GameFetchResult, OPSuccinctProposer, ProposerStateSnapshot, MAX_GAME_DEADLINE_LAG,
         },
@@ -1408,13 +1409,12 @@ mod proposer_sync {
         Ok(())
     }
 
-    /// Tests the `should_attempt_to_claim_bond` flag logic for finalized games.
+    /// Tests close-before-claim flag logic for finalized games.
     ///
-    /// Verifies that the flag is correctly set based on:
-    /// - Finality (finalized vs not finalized)
-    /// - Credit availability (credit > 0 vs credit = 0)
+    /// A finalized game is not necessarily closed. The proposer must close an UNDECIDED
+    /// DEFENDER_WINS game before using credit to decide claim or eviction.
     #[tokio::test]
-    async fn test_bond_claim_marking() -> Result<()> {
+    async fn test_close_and_bond_claim_marking() -> Result<()> {
         let (env, proposer, init_bond) = setup().await?;
 
         let starting_l2_block = env.anvil.starting_l2_block_number;
@@ -1435,6 +1435,10 @@ mod proposer_sync {
         // === Case 1: DEFENDER_WINS + not finalized ===
         let game_0 = cached_game(&proposer, 0).await?;
         assert!(
+            !game_0.should_attempt_to_close_game,
+            "Game 0: should_attempt_to_close_game should be false (not finalized)"
+        );
+        assert!(
             !game_0.should_attempt_to_claim_bond,
             "Game 0: should_attempt_to_claim_bond should be false (not finalized)"
         );
@@ -1446,25 +1450,112 @@ mod proposer_sync {
         env.warp_time(DISPUTE_GAME_FINALITY_DELAY_SECONDS + 1).await?;
         proposer.sync_state().await?;
 
-        // === Case 2: DEFENDER_WINS + finalized + credit > 0 ===
+        // === Case 2: DEFENDER_WINS + finalized + UNDECIDED ===
+        let game_0 = cached_game(&proposer, 0).await?;
+        assert_eq!(
+            env.get_bond_distribution_mode(address).await?,
+            BOND_DISTRIBUTION_MODE_UNDECIDED,
+            "Game 0 should not be closed before closeGame"
+        );
+        assert!(
+            game_0.should_attempt_to_close_game,
+            "Game 0: should_attempt_to_close_game should be true (finalized + UNDECIDED)"
+        );
+        assert!(
+            !game_0.should_attempt_to_claim_bond,
+            "Game 0: should_attempt_to_claim_bond should be false before close"
+        );
+        tracing::info!("✓ Case 2: DEFENDER_WINS + finalized + UNDECIDED → close, not claim");
+
+        // Close game before claiming. Once closed, the proposer may claim credit.
+        env.close_game(address).await?;
+        proposer.sync_state().await?;
+
+        // === Case 3: DEFENDER_WINS + closed + credit > 0 ===
         let game_0 = cached_game(&proposer, 0).await?;
         assert!(
-            game_0.should_attempt_to_claim_bond,
-            "Game 0: should_attempt_to_claim_bond should be true (finalized + credit > 0)"
+            !game_0.should_attempt_to_close_game,
+            "Game 0: should_attempt_to_close_game should be false after close"
         );
-        tracing::info!("✓ Case 2: DEFENDER_WINS + finalized + credit > 0 → should_attempt_to_claim_bond = true");
+        assert!(
+            game_0.should_attempt_to_claim_bond,
+            "Game 0: should_attempt_to_claim_bond should be true (closed + credit > 0)"
+        );
+        tracing::info!("✓ Case 3: DEFENDER_WINS + closed + credit > 0 → claim");
 
         // Claim bond for game 0 to set credit = 0
         env.claim_bond(address, PROPOSER_ADDRESS).await?;
         proposer.sync_state().await?;
 
-        // === Case 3: DEFENDER_WINS + finalized + credit = 0 ===
+        // === Case 4: DEFENDER_WINS + closed + credit = 0 ===
         let game_0 = cached_game(&proposer, 0).await?;
         assert!(
-            !game_0.should_attempt_to_claim_bond,
-            "Game 0: should_attempt_to_claim_bond should be false (credit = 0)"
+            !game_0.should_attempt_to_close_game,
+            "Game 0: should_attempt_to_close_game should be false (closed + credit = 0)"
         );
-        tracing::info!("✓ Case 3: DEFENDER_WINS + finalized + credit = 0 → should_attempt_to_claim_bond = false");
+        assert!(
+            !game_0.should_attempt_to_claim_bond,
+            "Game 0: should_attempt_to_claim_bond should be false (closed + credit = 0)"
+        );
+        tracing::info!("✓ Case 4: DEFENDER_WINS + closed + credit = 0 → no claim");
+
+        Ok(())
+    }
+
+    /// Verifies zero-init-bond games are closed before eviction.
+    #[tokio::test]
+    async fn test_zero_init_bond_finalized_game_closes_before_eviction() -> Result<()> {
+        let (env, proposer, _init_bond) = setup().await?;
+
+        let set_init_call = DisputeGameFactory::setInitBondCall {
+            _gameType: TEST_GAME_TYPE,
+            _initBond: U256::ZERO,
+        };
+        env.send_factory_tx(set_init_call.abi_encode(), None).await?;
+
+        let block = env.anvil.starting_l2_block_number + 1;
+        let root_claim = env.compute_output_root_at_block(block).await?;
+        env.create_game(root_claim, block, M, U256::ZERO).await?;
+        let (_, address) = env.last_game_info().await?;
+
+        env.warp_time(MAX_CHALLENGE_DURATION + 1).await?;
+        env.resolve_game(address).await?;
+        env.warp_time(DISPUTE_GAME_FINALITY_DELAY_SECONDS + 1).await?;
+
+        proposer.sync_state().await?;
+
+        let game = cached_game(&proposer, 0).await?;
+        assert_eq!(
+            env.get_credit(address, PROPOSER_ADDRESS).await?,
+            U256::ZERO,
+            "zero init bond should leave proposer credit at zero"
+        );
+        assert_eq!(
+            env.get_bond_distribution_mode(address).await?,
+            BOND_DISTRIBUTION_MODE_UNDECIDED,
+            "zero-bond game should still be unclosed"
+        );
+        assert!(
+            game.should_attempt_to_close_game,
+            "zero-credit finalized game should be marked for close"
+        );
+        assert!(
+            !game.should_attempt_to_claim_bond,
+            "zero-credit unclosed game must not be claimed"
+        );
+
+        env.close_game(address).await?;
+        proposer.sync_state().await?;
+
+        let game = cached_game(&proposer, 0).await?;
+        assert!(
+            !game.should_attempt_to_close_game,
+            "already closed zero-credit game should not be marked for close after restart/sync"
+        );
+        assert!(
+            !game.should_attempt_to_claim_bond,
+            "closed zero-credit game should not be marked for claim"
+        );
 
         Ok(())
     }
@@ -1730,7 +1821,7 @@ mod challenger_sync {
     use anyhow::{Context, Result};
     use fault_proof::{
         challenger::{Game, OPSuccinctChallenger},
-        contract::{GameStatus, ProposalStatus},
+        contract::{GameStatus, ProposalStatus, BOND_DISTRIBUTION_MODE_UNDECIDED},
     };
     use op_succinct_bindings::dispute_game_factory::DisputeGameFactory;
     use rand::Rng;
@@ -2146,20 +2237,22 @@ mod challenger_sync {
 
     // ==================== Bond Claim Marking Tests ====================
 
-    /// Verifies `should_attempt_to_claim_bond` flag across different states.
+    /// Verifies close-before-claim flags across different challenger states.
     ///
     /// Conditions for bond claim:
     /// - Game status is CHALLENGER_WINS
     /// - Game is finalized (past finality delay)
+    /// - Game has been closed
     /// - Credit > 0
     #[rstest]
-    #[case::finalized_with_credit(true, false, true)]
-    #[case::not_finalized(false, false, false)]
-    #[case::finalized_no_credit(true, true, false)]
+    #[case::not_finalized(false, false, false, false)]
+    #[case::finalized_unclosed(true, false, true, false)]
+    #[case::finalized_closed_no_credit(true, true, false, false)]
     #[tokio::test]
-    async fn test_bond_claim_marking(
+    async fn test_close_and_bond_claim_marking(
         #[case] finalized: bool,
         #[case] claim_bond: bool,
+        #[case] expected_should_close: bool,
         #[case] expected_should_claim: bool,
     ) -> Result<()> {
         let (env, challenger, init_bond) = setup().await?;
@@ -2194,10 +2287,49 @@ mod challenger_sync {
             let game = cached_game(&challenger, 0).await?;
             assert_eq!(game.status, GameStatus::CHALLENGER_WINS);
             assert_eq!(
+                game.should_attempt_to_close_game, expected_should_close,
+                "should_attempt_to_close_game mismatch"
+            );
+            assert_eq!(
                 game.should_attempt_to_claim_bond, expected_should_claim,
                 "should_attempt_to_claim_bond mismatch"
             );
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_challenger_claims_only_after_close() -> Result<()> {
+        let (env, challenger, init_bond) = setup().await?;
+
+        let block = env.anvil.starting_l2_block_number + 1;
+        env.create_game(random_invalid_root(), block, M, init_bond).await?;
+        let (_, game_address) = env.last_game_info().await?;
+
+        env.challenge_game(game_address).await?;
+        env.warp_time(MAX_PROVE_DURATION + 1).await?;
+        env.resolve_game(game_address).await?;
+        env.warp_time(DISPUTE_GAME_FINALITY_DELAY_SECONDS + 1).await?;
+
+        challenger.sync_state().await?;
+        let game = cached_game(&challenger, 0).await?;
+        assert_eq!(
+            env.get_bond_distribution_mode(game_address).await?,
+            BOND_DISTRIBUTION_MODE_UNDECIDED,
+            "challenger-won game should be unclosed before closeGame"
+        );
+        assert!(game.should_attempt_to_close_game, "unclosed finalized game should close first");
+        assert!(
+            !game.should_attempt_to_claim_bond,
+            "unclosed finalized game should not claim before close"
+        );
+
+        env.close_game(game_address).await?;
+        challenger.sync_state().await?;
+        let game = cached_game(&challenger, 0).await?;
+        assert!(!game.should_attempt_to_close_game, "closed game should not close again");
+        assert!(game.should_attempt_to_claim_bond, "closed game with credit should claim");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Add `closeGame()` and `bondDistributionMode()` bindings for fault dispute games.
- Change proposer/challenger sync so finalized games in `BondDistributionMode.UNDECIDED` are closed before bond claim or cache eviction decisions.
- Add bounded in-memory retries for close-game transactions, close-failure metrics, stale retry-counter cleanup, and sync coverage for zero-init-bond and close-before-claim cases.

## Motivation
`credit == U256::ZERO` is not a reliable lifecycle signal before a game is closed. With a zero init bond, a finalized game can still have zero credit while `bondDistributionMode` remains `UNDECIDED`, so evicting or skipping it leaves the game unclosed.

## Behavior change
This intentionally splits the common nonzero-bond flow from `claimCredit()` implicitly closing and claiming in one transaction to `closeGame()` first, then claiming after the mode is known. That adds one extra transaction for eligible games, but avoids using pre-close `credit()` as a lifecycle oracle.

## Review response
- Added proposer/challenger close-failure Prometheus gauges.
- Clear close retry counters when sync observes a game has left `UNDECIDED`.
- Moved the close retry cap into a shared contract constant to avoid proposer/challenger drift.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- `cargo test -p op-succinct-fp --test backup -- --nocapture`
- `git diff --check`

## Notes
- The proposer close flag is not persisted; it is re-derived from chain state on sync.
- Targeted `sync` integration tests were retried locally after initializing contract submodules, but the run was aborted after remaining CPU-bound in heavy setup before assertions completed.
