### PR TITLE
fix(cost-estimator): avoid the op-node safeDB when the caller doesn't need it

### DIFF
--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use anyhow::Result;
 use clap::Parser;
 use futures::StreamExt;
@@ -18,8 +19,8 @@ use op_succinct_proof_utils::{get_range_elf_embedded, initialize_host};
 use op_succinct_scripts::HostExecutorArgs;
 
 // Cost-estimator-specific CLI args. Wraps `HostExecutorArgs` and adds the estimator-only
-// `--no-safe-head-split` flag so unrelated host binaries (e.g. `multi`,
-// `gen-sp1-test-artifacts`) don't advertise a flag they ignore.
+// `--no-safe-head-split` and `--l1-head` flags so unrelated host binaries (e.g. `multi`,
+// `gen-sp1-test-artifacts`) don't advertise flags they ignore.
 #[derive(Debug, Clone, Parser)]
 #[command(about = "Estimate OP Succinct execution costs over an L2 block range")]
 struct CostEstimatorArgs {
@@ -31,6 +32,12 @@ struct CostEstimatorArgs {
     /// `RANGE_SPLIT_COUNT` segment) rather than per span batch.
     #[arg(long)]
     no_safe_head_split: bool,
+    /// L1 head block hash to derive the L2 range from. When set, it is used directly instead of
+    /// looking it up via the op-node safeDB, so a caller that already knows the L1 head can skip
+    /// the safeDB binary search (and the `--safe-db-fallback` timestamp estimation). This matches
+    /// the fault-proof proposer, which anchors each range to the L1 head committed on-chain.
+    #[arg(long)]
+    l1_head: Option<B256>,
 }
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sp1_sdk::{
@@ -245,6 +252,7 @@ fn aggregate_execution_stats(
 async fn main() -> Result<()> {
     let args = CostEstimatorArgs::parse();
     let no_safe_head_split = args.no_safe_head_split;
+    let l1_head = args.l1_head;
     let args = args.host;
 
     dotenv::from_path(&args.env_file).ok();
@@ -298,7 +306,7 @@ async fn main() -> Result<()> {
 
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            host.fetch(range.start, range.end, None, args.safe_db_fallback)
+            host.fetch(range.start, range.end, l1_head, args.safe_db_fallback)
                 .await
                 .expect("Failed to get host CLI args")
         })

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -275,11 +275,14 @@ async fn main() -> Result<()> {
         .await?
     };
 
-    // Check if the safeDB is activated on the L2 node. If it is, we use the safeHead based range
-    // splitting algorithm. Otherwise, we use the simple range splitting algorithm.
-    let safe_db_activated = data_fetcher.is_safe_db_activated().await?;
-
-    let split_ranges = if safe_db_activated && !no_safe_head_split {
+    // Pick the splitter. With --no-safe-head-split the caller wants the basic fixed-size splitter
+    // regardless, so skip the is_safe_db_activated() probe entirely: that probe queries the op-node
+    // safeDB (optimism_safeHeadAtL1Block), which may be disabled or unreachable, and there is no
+    // reason to touch it on a path that will not use safeHead-aligned splitting. Otherwise probe,
+    // and use the basic splitter when the safeDB is not active.
+    let split_ranges = if no_safe_head_split {
+        split_range_basic(l2_start_block, l2_end_block, args.effective_batch_size())
+    } else if data_fetcher.is_safe_db_activated().await? {
         split_range_based_on_safe_heads(
             &data_fetcher,
             l2_start_block,


### PR DESCRIPTION
## Background

We are migrating our op-node's execution layer to reth. A reth-backed op-node EL-syncs on restart, which wipes its safeDB and refills it only forward from the restart point, so the safeDB is frequently empty or behind, and anything that depends on it for a historical range fails on a routine restart.

The cost-estimator depended on the safeDB in two places: range splitting (`split_range_based_on_safe_heads`) and the L1 head (`host.fetch`). The fault-proof proposer never touches the safeDB: it splits by a fixed segment count and anchors each range to the L1 head committed on-chain. The two changes below let a caller run the estimator the same way, so it keeps working regardless of safeDB state.

## --no-safe-head-split should not probe the safeDB

`main` calls `is_safe_db_activated()` unconditionally, before checking `--no-safe-head-split`. That probe queries `optimism_safeHeadAtL1Block` at the finalized L1 block and returns an error for any response other than a clean result or a recognized "disabled" signal. So `--no-safe-head-split`, which means "use the basic splitter, don't do safeHead splitting at all", still hit the safeDB and could fail when it is unavailable (e.g. right after an EL-sync, where the finalized block sits below the refilled range and returns "not found").

The first commit reorders the selection so the probe runs only on the path that uses it: `--no-safe-head-split` goes straight to `split_range_basic` without touching the safeDB. Behavior is unchanged when the flag is not set.

## Optional --l1-head

`host.fetch` already accepts an optional L1 head; the second commit exposes it as `--l1-head`. When set, the L1 head is used directly and the safeDB lookup (the binary search plus the `--safe-db-fallback` timestamp estimation) is skipped. This matches the fault-proof proposer, which derives each range from the L1 head committed on-chain. The flag lives on `CostEstimatorArgs` (like `--no-safe-head-split`), so the shared-args binaries (`multi`, `gen-sp1-test-artifacts`) don't advertise a flag they would ignore.

`--l1-head` controls only the fetch L1 head and `--no-safe-head-split` only the splitter, so they are orthogonal; pass both to run with no safeDB dependency at all.

## Testing

`cargo check -p op-succinct-scripts --bin cost-estimator` passes. Motivating case: on a node whose safeDB had just been wiped by an op-node EL-sync restart, a cost-estimator run over a range below the refill floor failed at the safeDB; with `--no-safe-head-split --l1-head <hash>` it no longer queries the safeDB.