### PR TITLE
feat: add private stdin flag

### DIFF
--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -109,7 +109,7 @@ Depending on the one you choose, you must provide the corresponding environment 
 | `AGG_CYCLE_LIMIT` | The cycle limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `AGG_GAS_LIMIT` | The gas limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `WHITELIST` | The list of prover addresses that are allowed to bid on proof requests. | `` |
-| `PRIVATE_STDIN` | Gated SPN feature. Keeps program inputs private from bidders; [contact Succinct](https://partner.succinct.xyz/) to enable it for your requester account. | `false` |
+| `PRIVATE_STDIN` | Gated Succinct Prover Network feature. Keeps program inputs private from bidders; [contact us](https://partner.succinct.xyz/) to enable it for your requester account. | `false` |
 | `BACKUP_PATH` | Path to backup file for persisting proposer state across restarts. Enables faster recovery by restoring cached state instead of re-syncing from the factory. | (disabled) |
 | `TX_CONFIRMATION_TIMEOUT` | Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Setting this too low risks timeout-triggered retries that can produce duplicate sibling games. | `60` |
 

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -109,6 +109,7 @@ Depending on the one you choose, you must provide the corresponding environment 
 | `AGG_CYCLE_LIMIT` | The cycle limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `AGG_GAS_LIMIT` | The gas limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `WHITELIST` | The list of prover addresses that are allowed to bid on proof requests. | `` |
+| `PRIVATE_STDIN` | Whether proof requests should upload stdin through the private artifact path. | `false` |
 | `BACKUP_PATH` | Path to backup file for persisting proposer state across restarts. Enables faster recovery by restoring cached state instead of re-syncing from the factory. | (disabled) |
 | `TX_CONFIRMATION_TIMEOUT` | Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Setting this too low risks timeout-triggered retries that can produce duplicate sibling games. | `60` |
 
@@ -132,6 +133,7 @@ MOCK_MODE=false                  # Whether to use mock mode
 FAST_FINALITY_MODE=false         # Whether to use fast finality mode
 RANGE_PROOF_STRATEGY=reserved    # Set to hosted to use hosted proof strategy
 AGG_PROOF_STRATEGY=reserved      # Set to hosted to use hosted proof strategy
+PRIVATE_STDIN=false              # Upload stdin through the private artifact path
 PROPOSAL_INTERVAL_IN_BLOCKS=1800 # Number of L2 blocks between proposals
 FETCH_INTERVAL=30                # Polling interval in seconds
 PROPOSER_METRICS_PORT=9000       # The port to expose metrics on

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -109,7 +109,7 @@ Depending on the one you choose, you must provide the corresponding environment 
 | `AGG_CYCLE_LIMIT` | The cycle limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `AGG_GAS_LIMIT` | The gas limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `WHITELIST` | The list of prover addresses that are allowed to bid on proof requests. | `` |
-| `PRIVATE_STDIN` | Whether proof requests should upload stdin through the private artifact path. | `false` |
+| `PRIVATE_STDIN` | Gated SPN feature. Keeps program inputs private from bidders; [contact Succinct](https://partner.succinct.xyz/) to enable it for your requester account. | `false` |
 | `BACKUP_PATH` | Path to backup file for persisting proposer state across restarts. Enables faster recovery by restoring cached state instead of re-syncing from the factory. | (disabled) |
 | `TX_CONFIRMATION_TIMEOUT` | Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Setting this too low risks timeout-triggered retries that can produce duplicate sibling games. | `60` |
 
@@ -133,7 +133,7 @@ MOCK_MODE=false                  # Whether to use mock mode
 FAST_FINALITY_MODE=false         # Whether to use fast finality mode
 RANGE_PROOF_STRATEGY=reserved    # Set to hosted to use hosted proof strategy
 AGG_PROOF_STRATEGY=reserved      # Set to hosted to use hosted proof strategy
-PRIVATE_STDIN=false              # Upload stdin through the private artifact path
+PRIVATE_STDIN=false              # Use private stdin for network proof requests
 PROPOSAL_INTERVAL_IN_BLOCKS=1800 # Number of L2 blocks between proposals
 FETCH_INTERVAL=30                # Polling interval in seconds
 PROPOSER_METRICS_PORT=9000       # The port to expose metrics on

--- a/book/validity/proposer.md
+++ b/book/validity/proposer.md
@@ -73,7 +73,7 @@ Before starting the proposer, ensure you have deployed the relevant contracts an
 | `AGG_CYCLE_LIMIT` | Default: `1,000,000,000,000`. The cycle limit to use for aggregation proofs. |
 | `AGG_GAS_LIMIT` | Default: `1,000,000,000,000`. The gas limit to use for aggregation proofs. |
 | `WHITELIST` | Default: ``. The list of prover addresses that are allowed to bid on proof requests. |
-| `PRIVATE_STDIN` | Default: `false`. Whether proof requests should upload stdin through the private artifact path. |
+| `PRIVATE_STDIN` | Default: `false`. Gated SPN feature. Keeps program inputs private from bidders; [contact Succinct](https://partner.succinct.xyz/) to enable it for your requester account. |
 | `MIN_AUCTION_PERIOD` | Default: `1`. The minimum auction period (in seconds). |
 | `AUCTION_TIMEOUT` | Default: `60` (1 minute). How long to wait before canceling a proof request that hasn't been assigned (in seconds). |
 | `TX_CONFIRMATION_TIMEOUT` | Default: `60`. Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Raise on congested L1s to avoid timeout-triggered retries. |

--- a/book/validity/proposer.md
+++ b/book/validity/proposer.md
@@ -73,6 +73,7 @@ Before starting the proposer, ensure you have deployed the relevant contracts an
 | `AGG_CYCLE_LIMIT` | Default: `1,000,000,000,000`. The cycle limit to use for aggregation proofs. |
 | `AGG_GAS_LIMIT` | Default: `1,000,000,000,000`. The gas limit to use for aggregation proofs. |
 | `WHITELIST` | Default: ``. The list of prover addresses that are allowed to bid on proof requests. |
+| `PRIVATE_STDIN` | Default: `false`. Whether proof requests should upload stdin through the private artifact path. |
 | `MIN_AUCTION_PERIOD` | Default: `1`. The minimum auction period (in seconds). |
 | `AUCTION_TIMEOUT` | Default: `60` (1 minute). How long to wait before canceling a proof request that hasn't been assigned (in seconds). |
 | `TX_CONFIRMATION_TIMEOUT` | Default: `60`. Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Raise on congested L1s to avoid timeout-triggered retries. |

--- a/book/validity/proposer.md
+++ b/book/validity/proposer.md
@@ -73,7 +73,7 @@ Before starting the proposer, ensure you have deployed the relevant contracts an
 | `AGG_CYCLE_LIMIT` | Default: `1,000,000,000,000`. The cycle limit to use for aggregation proofs. |
 | `AGG_GAS_LIMIT` | Default: `1,000,000,000,000`. The gas limit to use for aggregation proofs. |
 | `WHITELIST` | Default: ``. The list of prover addresses that are allowed to bid on proof requests. |
-| `PRIVATE_STDIN` | Default: `false`. Gated SPN feature. Keeps program inputs private from bidders; [contact Succinct](https://partner.succinct.xyz/) to enable it for your requester account. |
+| `PRIVATE_STDIN` | Default: `false`. Gated Succinct Prover Network feature. Keeps program inputs private from bidders; [contact us](https://partner.succinct.xyz/) to enable it for your requester account. |
 | `MIN_AUCTION_PERIOD` | Default: `1`. The minimum auction period (in seconds). |
 | `AUCTION_TIMEOUT` | Default: `60` (1 minute). How long to wait before canceling a proof request that hasn't been assigned (in seconds). |
 | `TX_CONFIRMATION_TIMEOUT` | Default: `60`. Maximum time (in seconds) to wait for an L1 transaction to reach the required number of confirmations. Raise on congested L1s to avoid timeout-triggered retries. |

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -247,7 +247,7 @@ pub struct ProofProviderConfig {
     /// The list of prover addresses that are allowed to bid on proof requests.
     pub whitelist: Option<Vec<Address>>,
 
-    /// Whether proof requests should upload stdin through the private artifact path.
+    /// Whether SP1 network proof requests should use private stdin.
     pub private_stdin: bool,
 }
 

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -193,6 +193,7 @@ impl ProposerConfig {
             max_price_per_pgu = self.proof_provider.max_price_per_pgu,
             min_auction_period = self.proof_provider.min_auction_period,
             whitelist = ?self.proof_provider.whitelist,
+            private_stdin = self.proof_provider.private_stdin,
             backup_path = ?self.backup_path,
             sync_l1_confirmations = self.sync_l1_confirmations,
             tx_confirmation_timeout = self.tx_confirmation_timeout,
@@ -245,6 +246,9 @@ pub struct ProofProviderConfig {
 
     /// The list of prover addresses that are allowed to bid on proof requests.
     pub whitelist: Option<Vec<Address>>,
+
+    /// Whether proof requests should upload stdin through the private artifact path.
+    pub private_stdin: bool,
 }
 
 impl ProofProviderConfig {
@@ -291,6 +295,7 @@ impl ProofProviderConfig {
                 .unwrap_or("1".to_string())
                 .parse()?,
             whitelist: parse_whitelist(&env::var("WHITELIST").unwrap_or("".to_string()))?,
+            private_stdin: env::var("PRIVATE_STDIN").unwrap_or("false".to_string()).parse()?,
         })
     }
 }

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -361,6 +361,10 @@ where
             !(is_cluster && config.mock_mode),
             "mock and cluster modes are mutually exclusive — set only one of SP1_PROVER=cluster or mock_mode=true"
         );
+        anyhow::ensure!(
+            !config.proof_provider.private_stdin || (!config.mock_mode && !is_cluster),
+            "PRIVATE_STDIN only applies to SP1 network proof requests; disable mock mode and SP1_PROVER=cluster"
+        );
 
         let (range_pk, range_vk, agg_pk, agg_vk, network_prover, network_mode) = if is_cluster {
             let (range_pk, range_vk, agg_pk, agg_vk) = cluster_setup_keys().await?;

--- a/fault-proof/src/prover.rs
+++ b/fault-proof/src/prover.rs
@@ -159,6 +159,7 @@ impl NetworkProofProvider {
             .max_price_per_pgu(self.config.max_price_per_pgu)
             .cycle_limit(self.config.range_cycle_limit)
             .gas_limit(self.config.range_gas_limit)
+            .private_stdin(self.config.private_stdin)
             .whitelist(self.config.whitelist.clone())
             .request()
             .await?;
@@ -179,6 +180,7 @@ impl NetworkProofProvider {
             .max_price_per_pgu(self.config.max_price_per_pgu)
             .cycle_limit(self.config.agg_cycle_limit)
             .gas_limit(self.config.agg_gas_limit)
+            .private_stdin(self.config.private_stdin)
             .whitelist(self.config.whitelist.clone())
             .request()
             .await?;

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -85,6 +85,7 @@ pub async fn new_proposer_with_confirmations(
             max_price_per_pgu: 300_000_000, // 0.3 PROVE per billion PGU
             min_auction_period: 1,
             whitelist: None,
+            private_stdin: false,
         },
         sync_l1_confirmations,
     };

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -97,6 +97,7 @@ async fn main() -> Result<()> {
         agg_cycle_limit: env_config.agg_cycle_limit,
         agg_gas_limit: env_config.agg_gas_limit,
         whitelist: env_config.whitelist,
+        private_stdin: env_config.private_stdin,
         min_auction_period: env_config.min_auction_period,
         auction_timeout: env_config.auction_timeout,
         tx_confirmation_timeout: env_config.tx_confirmation_timeout,

--- a/validity/src/config.rs
+++ b/validity/src/config.rs
@@ -95,6 +95,9 @@ pub struct RequesterConfig {
     /// The list of prover addresses that are allowed to bid on proof requests.
     pub whitelist: Option<Vec<Address>>,
 
+    /// Whether proof requests should upload stdin through the private artifact path.
+    pub private_stdin: bool,
+
     /// The minimum auction period (in seconds).
     pub min_auction_period: u64,
 
@@ -138,6 +141,7 @@ impl RequesterConfig {
             agg_cycle_limit = self.agg_cycle_limit,
             agg_gas_limit = self.agg_gas_limit,
             whitelist = ?self.whitelist,
+            private_stdin = self.private_stdin,
             min_auction_period = self.min_auction_period,
             auction_timeout = self.auction_timeout,
             tx_confirmation_timeout = self.tx_confirmation_timeout,

--- a/validity/src/config.rs
+++ b/validity/src/config.rs
@@ -95,7 +95,7 @@ pub struct RequesterConfig {
     /// The list of prover addresses that are allowed to bid on proof requests.
     pub whitelist: Option<Vec<Address>>,
 
-    /// Whether proof requests should upload stdin through the private artifact path.
+    /// Whether SP1 network proof requests should use private stdin.
     pub private_stdin: bool,
 
     /// The minimum auction period (in seconds).

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -36,6 +36,7 @@ pub struct EnvironmentConfig {
     pub agg_cycle_limit: u64,
     pub agg_gas_limit: u64,
     pub whitelist: Option<Vec<Address>>,
+    pub private_stdin: bool,
     pub min_auction_period: u64,
     pub auction_timeout: u64,
     pub tx_confirmation_timeout: u64,
@@ -139,6 +140,7 @@ pub async fn read_proposer_env() -> Result<EnvironmentConfig> {
         agg_cycle_limit: get_env_var("AGG_CYCLE_LIMIT", Some(1_000_000_000_000))?, // 1 trillion
         agg_gas_limit: get_env_var("AGG_GAS_LIMIT", Some(1_000_000_000_000))?,   // 1 trillion
         whitelist: parse_whitelist(&get_env_var("WHITELIST", Some("".to_string()))?)?,
+        private_stdin: get_env_var("PRIVATE_STDIN", Some(false))?,
         min_auction_period: get_env_var("MIN_AUCTION_PERIOD", Some(1))?,
         auction_timeout: get_env_var("AUCTION_TIMEOUT", Some(60))?, // 1 minute
         tx_confirmation_timeout: get_env_var("TX_CONFIRMATION_TIMEOUT", Some(60))?,

--- a/validity/src/proof_requester.rs
+++ b/validity/src/proof_requester.rs
@@ -50,6 +50,7 @@ pub struct OPSuccinctProofRequester<H: OPSuccinctHost> {
     pub agg_cycle_limit: u64,
     pub agg_gas_limit: u64,
     pub whitelist: Option<Vec<Address>>,
+    pub private_stdin: bool,
     pub min_auction_period: u64,
     pub auction_timeout: u64,
 }
@@ -77,6 +78,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
         agg_cycle_limit: u64,
         agg_gas_limit: u64,
         whitelist: Option<Vec<Address>>,
+        private_stdin: bool,
         min_auction_period: u64,
         auction_timeout: u64,
     ) -> Result<Self> {
@@ -109,6 +111,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             agg_cycle_limit,
             agg_gas_limit,
             whitelist,
+            private_stdin,
             min_auction_period,
             auction_timeout,
         })
@@ -270,6 +273,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             .max_price_per_pgu(self.max_price_per_pgu)
             .cycle_limit(self.range_cycle_limit)
             .gas_limit(self.range_gas_limit)
+            .private_stdin(self.private_stdin)
             .whitelist(self.whitelist.clone())
             .request()
             .await
@@ -300,6 +304,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             .max_price_per_pgu(self.max_price_per_pgu)
             .cycle_limit(self.agg_cycle_limit)
             .gas_limit(self.agg_gas_limit)
+            .private_stdin(self.private_stdin)
             .whitelist(self.whitelist.clone())
             .request()
             .await

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -97,6 +97,12 @@ where
         loop_interval: u64,
         host: Arc<H>,
     ) -> Result<Self> {
+        let is_cluster = is_cluster_mode();
+        anyhow::ensure!(
+            !requester_config.private_stdin || (!requester_config.mock && !is_cluster),
+            "PRIVATE_STDIN only applies to SP1 network proof requests; disable mock mode and SP1_PROVER=cluster"
+        );
+
         // This check prevents users from running multiple proposers for the same chain at the same
         // time.
         let is_locked = db_client
@@ -116,8 +122,6 @@ where
         db_client
             .add_chain_lock(requester_config.l1_chain_id, requester_config.l2_chain_id)
             .await?;
-
-        let is_cluster = is_cluster_mode();
 
         let cluster_config =
             if is_cluster { Some(Arc::new(ClusterProofConfig::from_env().await?)) } else { None };
@@ -190,6 +194,7 @@ where
             requester_config.agg_cycle_limit,
             requester_config.agg_gas_limit,
             requester_config.whitelist.clone(),
+            requester_config.private_stdin,
             requester_config.min_auction_period,
             requester_config.auction_timeout,
         )?);


### PR DESCRIPTION
Adds PRIVATE_STDIN for validity and fault-proof network proof requests.

Checks:
- cargo check -p op-succinct-validity -p op-succinct-fp