### PR TITLE
ci: add cycle-count test timeouts

### DIFF
--- a/.github/workflows/cycle-count-diff-eigenda.yml
+++ b/.github/workflows/cycle-count-diff-eigenda.yml
@@ -86,6 +86,7 @@ jobs:
           l1_rpc: ${{ secrets.L1_RPC }}
 
       - name: Run Test On New Branch
+        timeout-minutes: 30
         run: |
           RUST_LOG=info NEW_BRANCH=true cargo test -p op-succinct-prove --features eigenda test_cycle_count_diff --release -- --exact --nocapture
         working-directory: ./new_code
@@ -103,6 +104,7 @@ jobs:
           cp "$STATS_FILE" ${{ github.workspace }}/old_code/scripts/prove/new_cycle_stats.json
 
       - name: Run Test On Old Branch
+        timeout-minutes: 30
         run: |
           RUST_LOG=info NEW_BRANCH=false cargo test -p op-succinct-prove --features eigenda test_cycle_count_diff --release -- --exact --nocapture
         working-directory: ./old_code

--- a/.github/workflows/cycle-count-diff.yml
+++ b/.github/workflows/cycle-count-diff.yml
@@ -57,6 +57,7 @@ jobs:
           submodules: recursive
 
       - name: Run Test On New Branch
+        timeout-minutes: 30
         run: |
           RUST_LOG=info NEW_BRANCH=true cargo test test_cycle_count_diff --release -- --exact --nocapture
         working-directory: ./new_code
@@ -72,6 +73,7 @@ jobs:
           cp "$STATS_FILE" ${{ github.workspace }}/old_code/scripts/prove/new_cycle_stats.json
 
       - name: Run Test On Old Branch
+        timeout-minutes: 30
         run: |
           RUST_LOG=info NEW_BRANCH=false cargo test test_cycle_count_diff --release -- --exact --nocapture
         working-directory: ./old_code


### PR DESCRIPTION
## What
- Add 30 minute timeouts to the new-branch and old-branch test steps in the default and EigenDA cycle-count diff workflows.

## Why
- These jobs can hang inside the baseline measurement step and otherwise stay in progress until the GitHub Actions default timeout.

## Validation
- git diff --check
- actionlint not run locally; not installed