### PR TITLE
fix(altda): prefetch payload witnesses

### DIFF
--- a/utils/altda/host/src/cfg.rs
+++ b/utils/altda/host/src/cfg.rs
@@ -106,7 +106,10 @@ impl AltDAChainHost {
         } else {
             let providers = self.create_providers().await?;
             let backend =
-                OnlineHostBackend::new(self.clone(), kv_store.clone(), providers, AltDAHintHandler);
+                OnlineHostBackend::new(self.clone(), kv_store.clone(), providers, AltDAHintHandler)
+                    .with_high_level_hint(AltDAExtendedHintType::Standard(
+                        HintType::L2PayloadWitness,
+                    ));
 
             task::spawn(async {
                 PreimageServer::new(


### PR DESCRIPTION
## What
- Register the payload-witness hint with the AltDA online host backend.

## Why
- Without registration, the host falls back to fine-grained proof requests instead of prefetching the execution witness.

## Validation
- `PATH="$HOME/.sp1/bin:$PATH" cargo fmt --all -- --check`
- `PATH="$HOME/.sp1/bin:$PATH" cargo check -p op-succinct-altda-host-utils`
- `PATH="$HOME/.sp1/bin:$PATH" cargo test -p op-succinct-altda-host-utils`
- `PATH="$HOME/.sp1/bin:$PATH" cargo check -p op-succinct-scripts --bin cost-estimator --no-default-features --features altda`
- `PATH="$HOME/.sp1/bin:$PATH" cargo check -p op-succinct-validity --bin validity --no-default-features --features altda`
- `PATH="$HOME/.sp1/bin:$PATH" cargo check -p op-succinct-fp --bin proposer --no-default-features --features altda`
- Confirmed the AltDA range ELF hash is unchanged.