### PR TITLE
fix(bindings): preserve generated bytecode

### DIFF
--- a/bindings/build.rs
+++ b/bindings/build.rs
@@ -27,6 +27,14 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Generate full artifacts because the bindings expose contract bytecode.
+    let status =
+        Command::new("forge").arg("build").current_dir(&contracts_package_path).status()?;
+
+    if !status.success() {
+        anyhow::bail!("Forge build failed with exit code: {}", status);
+    }
+
     // Use 'forge bind' to generate bindings for only the contracts we need for E2E tests
     let mut forge_command = Command::new("forge");
     forge_command.args([
@@ -35,6 +43,7 @@ fn main() -> anyhow::Result<()> {
         bindings_codegen_path.as_str(),
         "--module",
         "--overwrite",
+        "--skip-build",
         "--skip-extra-derives",
     ]);
 


### PR DESCRIPTION
## What
- Build full contract artifacts before generating Rust bindings.
- Reuse those artifacts when running `forge bind`.

## Why
- Recent Foundry versions use ABI-only artifacts for implicit binding builds, omitting bytecode consumed by fault-proof tests.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p op-succinct-fp --tests`
- `cargo check --all-targets --all-features --tests`