### PR TITLE
backport(ci): remove redundant Rust installs (#921)

### DIFF
--- a/fault-proof/Dockerfile.challenger
+++ b/fault-proof/Dockerfile.challenger
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \

--- a/fault-proof/Dockerfile.proposer
+++ b/fault-proof/Dockerfile.proposer
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -55,7 +54,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
     
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.altda
+++ b/fault-proof/Dockerfile.proposer.altda
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -55,7 +54,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.celestia
+++ b/fault-proof/Dockerfile.proposer.celestia
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -55,7 +54,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
     
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.eigenda
+++ b/fault-proof/Dockerfile.proposer.eigenda
@@ -25,7 +25,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
@@ -58,7 +57,6 @@ RUN apt-get update && apt-get install -y \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
     
 # Copy the built proposer binary
 COPY --from=builder /usr/src/app/target/release/proposer /usr/local/bin/


### PR DESCRIPTION
## What
- Remove redundant Rust toolchain reinstalls from fault-proof images.

## Why
- Avoid rustup filesystem failures in the v3.x image workflow.

## Validation
- `git diff --check`
- Confirmed logical patch equivalence with #921.
- Docker build checks: Not run locally (Docker daemon unavailable); CI will run them.