### PR TITLE
backport(altda): prefetch payload witnesses (#946)

### DIFF
--- a/utils/altda/host/src/cfg.rs
+++ b/utils/altda/host/src/cfg.rs
@@ -106,7 +106,10 @@ impl AltDAChainHost {
         } else {
             let providers = self.create_providers().await?;
             let backend =
-                OnlineHostBackend::new(self.clone(), kv_store.clone(), providers, AltDAHintHandler);
+                OnlineHostBackend::new(self.clone(), kv_store.clone(), providers, AltDAHintHandler)
+                    .with_high_level_hint(AltDAExtendedHintType::Standard(
+                        HintType::L2PayloadWitness,
+                    ));
 
             task::spawn(async {
                 PreimageServer::new(


### PR DESCRIPTION
## What
- Register the payload-witness hint with the AltDA online host backend on v3.x.

## Why
- Without registration, the host falls back to fine-grained proof requests instead of prefetching the execution witness.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p op-succinct-altda-host-utils`
- `cargo test -p op-succinct-altda-host-utils`
- `cargo check -p op-succinct-scripts --bin cost-estimator --no-default-features --features altda`
- `cargo check -p op-succinct-validity --bin validity --no-default-features --features altda`
- `cargo check -p op-succinct-fp --bin proposer --no-default-features --features altda`
- Confirmed the AltDA range ELF hash is unchanged.