### PR TITLE
backport(validity): recover from noncanonical range proofs (#951)

### DIFF
--- a/validity/migrations/05_add_request_invalidation.sql
+++ b/validity/migrations/05_add_request_invalidation.sql
@@ -1,0 +1,4 @@
+-- Records the L1 identity used by range proofs and logical invalidation after an L1 reorg.
+ALTER TABLE requests
+ADD COLUMN l1_head_block_hash BYTEA,
+ADD COLUMN invalidated_at TIMESTAMP;

--- a/validity/src/db/client.rs
+++ b/validity/src/db/client.rs
@@ -9,7 +9,10 @@ use sqlx::{
 use std::time::Duration;
 use tracing::info;
 
-use crate::{CommitmentConfig, DriverDBClient, OPSuccinctRequest, RequestStatus, RequestType};
+use crate::{
+    CommitmentConfig, CompletedRangeMetadata, DriverDBClient, MissingRangeMetadata,
+    OPSuccinctRequest, RequestStatus, RequestType,
+};
 
 impl DriverDBClient {
     pub async fn new(database_url: &str) -> Result<Self> {
@@ -184,18 +187,18 @@ impl DriverDBClient {
         l2_chain_id: i64,
     ) -> Result<Option<i64>, Error> {
         let status_values: Vec<i16> = statuses.iter().map(|s| *s as i16).collect();
-        let result = sqlx::query!(
-            "SELECT end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = ANY($3) AND req_type = $4 AND l1_chain_id = $5 AND l2_chain_id = $6 ORDER BY end_block DESC LIMIT 1",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            &status_values[..],
-            RequestType::Range as i16,
-            l1_chain_id,
-            l2_chain_id,
+        let result = sqlx::query_scalar::<_, i64>(
+            "SELECT end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = ANY($3) AND req_type = $4 AND invalidated_at IS NULL AND l1_chain_id = $5 AND l2_chain_id = $6 ORDER BY end_block DESC LIMIT 1",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&status_values[..])
+        .bind(RequestType::Range as i16)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_optional(&self.pool)
         .await?;
-        Ok(result.map(|r| r.end_block))
+        Ok(result)
     }
 
     /// Fetch all range requests that have one of the given statuses and start block >=
@@ -209,20 +212,20 @@ impl DriverDBClient {
         l2_chain_id: i64,
     ) -> Result<Vec<(i64, i64)>, Error> {
         let status_values: Vec<i16> = statuses.iter().map(|s| *s as i16).collect();
-        let ranges = sqlx::query!(
-            "SELECT start_block, end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = ANY($3) AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            &status_values[..],
-            RequestType::Range as i16,
-            latest_contract_l2_block,
-            l1_chain_id,
-            l2_chain_id,
+        let ranges = sqlx::query_as::<_, (i64, i64)>(
+            "SELECT start_block, end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = ANY($3) AND req_type = $4 AND invalidated_at IS NULL AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&status_values[..])
+        .bind(RequestType::Range as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(ranges.into_iter().map(|r| (r.start_block, r.end_block)).collect())
+        Ok(ranges)
     }
 
     /// Fetch the number of requests with a specific status.
@@ -277,18 +280,17 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Vec<OPSuccinctRequest>, Error> {
-        let requests = sqlx::query_as!(
-            OPSuccinctRequest,
-            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND start_block >= $5 AND end_block <= $6 AND l1_chain_id = $7 AND l2_chain_id = $8 ORDER BY start_block ASC",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            RequestStatus::Complete as i16,
-            RequestType::Range as i16,
-            start_block,
-            end_block,
-            l1_chain_id,
-            l2_chain_id,
+        let requests = sqlx::query_as::<_, OPSuccinctRequest>(
+            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND invalidated_at IS NULL AND start_block >= $5 AND end_block <= $6 AND l1_chain_id = $7 AND l2_chain_id = $8 ORDER BY start_block ASC",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(RequestStatus::Complete as i16)
+        .bind(RequestType::Range as i16)
+        .bind(start_block)
+        .bind(end_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_all(&self.pool)
         .await?;
         Ok(requests)
@@ -312,25 +314,25 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Option<i64>, Error> {
-        let result = sqlx::query!(
-            "SELECT MAX(l1_head_block_number) AS max_l1_head FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND start_block >= $5 AND end_block <= $6 AND l1_chain_id = $7 AND l2_chain_id = $8",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            RequestStatus::Complete as i16,
-            RequestType::Range as i16,
-            start_block,
-            end_block,
-            l1_chain_id,
-            l2_chain_id,
+        let result = sqlx::query_scalar::<_, Option<i64>>(
+            "SELECT MAX(l1_head_block_number) FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND invalidated_at IS NULL AND start_block >= $5 AND end_block <= $6 AND l1_chain_id = $7 AND l2_chain_id = $8",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(RequestStatus::Complete as i16)
+        .bind(RequestType::Range as i16)
+        .bind(start_block)
+        .bind(end_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_one(&self.pool)
         .await?;
-        Ok(result.max_l1_head)
+        Ok(result)
     }
 
     /// Fetch the checkpointed block hash and number for an aggregation request with the same start
     /// block, end block, and commitment config.
-    pub async fn fetch_failed_agg_request_with_checkpointed_block_hash(
+    pub async fn fetch_reusable_agg_checkpoint(
         &self,
         start_block: i64,
         end_block: i64,
@@ -338,24 +340,23 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Option<(Vec<u8>, i64)>, Error> {
-        let result = sqlx::query!(
-            "SELECT checkpointed_l1_block_hash, checkpointed_l1_block_number FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND req_type = $4 AND start_block = $5 AND end_block = $6 AND status = $7 AND checkpointed_l1_block_hash IS NOT NULL AND checkpointed_l1_block_number IS NOT NULL AND l1_chain_id = $8 AND l2_chain_id = $9 LIMIT 1",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            &commitment.agg_vkey_hash[..],
-            RequestType::Aggregation as i16,
-            start_block,
-            end_block,
-            RequestStatus::Failed as i16,
-            l1_chain_id,
-            l2_chain_id,
+        let reusable_statuses = [RequestStatus::Failed as i16, RequestStatus::Invalidated as i16];
+        let result = sqlx::query_as::<_, (Vec<u8>, i64)>(
+            "SELECT checkpointed_l1_block_hash, checkpointed_l1_block_number FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND req_type = $4 AND start_block = $5 AND end_block = $6 AND status = ANY($7) AND checkpointed_l1_block_hash IS NOT NULL AND checkpointed_l1_block_number IS NOT NULL AND l1_chain_id = $8 AND l2_chain_id = $9 LIMIT 1",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&commitment.agg_vkey_hash[..])
+        .bind(RequestType::Aggregation as i16)
+        .bind(start_block)
+        .bind(end_block)
+        .bind(&reusable_statuses[..])
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(result.map(|r| {
-            (r.checkpointed_l1_block_hash.unwrap(), r.checkpointed_l1_block_number.unwrap())
-        }))
+        Ok(result)
     }
     /// Fetch the count of active (non-failed, non-cancelled) Aggregation proofs with the same start
     /// block, range vkey commitment, and aggregation vkey.
@@ -375,20 +376,20 @@ impl DriverDBClient {
         ];
         // Note: Relayed is not included in the status list in case the user re-starts the proposer
         // with the same DB and a different contract at the same starting block.
-        let result = sqlx::query!(
-            "SELECT COUNT(*) as count FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND status = ANY($4) AND req_type = $5 AND start_block = $6 AND l1_chain_id = $7 AND l2_chain_id = $8",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            &commitment.agg_vkey_hash[..],
-            &status_values[..],
-            RequestType::Aggregation as i16,
-            start_block,
-            l1_chain_id,
-            l2_chain_id,
+        let result = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND status = ANY($4) AND invalidated_at IS NULL AND req_type = $5 AND start_block = $6 AND l1_chain_id = $7 AND l2_chain_id = $8",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&commitment.agg_vkey_hash[..])
+        .bind(&status_values[..])
+        .bind(RequestType::Aggregation as i16)
+        .bind(start_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_one(&self.pool)
         .await?;
-        Ok(result.count.unwrap_or(0))
+        Ok(result)
     }
 
     /// Fetch the sorted list of Aggregation proofs with status Unrequested that have a start_block
@@ -406,18 +407,17 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Option<OPSuccinctRequest>, Error> {
-        let request = sqlx::query_as!(
-            OPSuccinctRequest,
-            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND status = $4 AND req_type = $5 AND start_block >= $6 AND l1_chain_id = $7 AND l2_chain_id = $8 ORDER BY start_block ASC LIMIT 1",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            &commitment.agg_vkey_hash[..],
-            RequestStatus::Unrequested as i16,
-            RequestType::Aggregation as i16,
-            latest_contract_l2_block,
-            l1_chain_id,
-            l2_chain_id,
+        let request = sqlx::query_as::<_, OPSuccinctRequest>(
+            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND status = $4 AND invalidated_at IS NULL AND req_type = $5 AND start_block >= $6 AND l1_chain_id = $7 AND l2_chain_id = $8 ORDER BY start_block ASC LIMIT 1",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&commitment.agg_vkey_hash[..])
+        .bind(RequestStatus::Unrequested as i16)
+        .bind(RequestType::Aggregation as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -433,17 +433,16 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Option<OPSuccinctRequest>, Error> {
-        let request = sqlx::query_as!(
-            OPSuccinctRequest,
-            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC LIMIT 1",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            RequestStatus::Unrequested as i16,
-            RequestType::Range as i16,
-            latest_contract_l2_block,
-            l1_chain_id,
-            l2_chain_id,
+        let request = sqlx::query_as::<_, OPSuccinctRequest>(
+            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND invalidated_at IS NULL AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC LIMIT 1",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(RequestStatus::Unrequested as i16)
+        .bind(RequestType::Range as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_optional(&self.pool)
         .await?;
         Ok(request)
@@ -458,37 +457,169 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Vec<(i64, i64)>, Error> {
-        let blocks = sqlx::query!(
-            "SELECT start_block, end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            RequestStatus::Complete as i16,
-            RequestType::Range as i16,
-            latest_contract_l2_block,
-            l1_chain_id,
-            l2_chain_id,
+        let blocks = sqlx::query_as::<_, (i64, i64)>(
+            "SELECT start_block, end_block FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND invalidated_at IS NULL AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(RequestStatus::Complete as i16)
+        .bind(RequestType::Range as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(blocks.iter().map(|block| (block.start_block, block.end_block)).collect())
+        Ok(blocks)
     }
 
-    /// Update the l1_head_block_number for a request.
-    pub async fn update_l1_head_block_number(
+    /// Fetch canonicality metadata for active completed range proofs.
+    pub async fn fetch_completed_range_metadata(
+        &self,
+        commitment: &CommitmentConfig,
+        latest_contract_l2_block: i64,
+        l1_chain_id: i64,
+        l2_chain_id: i64,
+    ) -> Result<Vec<CompletedRangeMetadata>, Error> {
+        sqlx::query_as::<_, CompletedRangeMetadata>(
+            "SELECT id, start_block, end_block, l1_head_block_number, l1_head_block_hash FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND invalidated_at IS NULL AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 ORDER BY start_block ASC",
+        )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(RequestStatus::Complete as i16)
+        .bind(RequestType::Range as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Fetch a bounded batch of completed range proofs missing canonicality metadata.
+    pub async fn fetch_missing_range_metadata(
+        &self,
+        commitment: &CommitmentConfig,
+        latest_contract_l2_block: i64,
+        l1_chain_id: i64,
+        l2_chain_id: i64,
+        limit: i64,
+    ) -> Result<Vec<MissingRangeMetadata>, Error> {
+        sqlx::query_as::<_, MissingRangeMetadata>(
+            "SELECT id, start_block, end_block, l1_head_block_number, proof FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND status = $3 AND invalidated_at IS NULL AND req_type = $4 AND start_block >= $5 AND l1_chain_id = $6 AND l2_chain_id = $7 AND (l1_head_block_number IS NULL OR l1_head_block_hash IS NULL) ORDER BY start_block ASC LIMIT $8",
+        )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(RequestStatus::Complete as i16)
+        .bind(RequestType::Range as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Record the L1 block identity used by a range proof.
+    pub async fn update_l1_head(
         &self,
         id: i64,
         l1_head_block_number: i64,
+        l1_head_block_hash: B256,
     ) -> Result<PgQueryResult, Error> {
-        sqlx::query!(
-            r#"
-            UPDATE requests SET l1_head_block_number = $1 WHERE id = $2
-            "#,
-            l1_head_block_number,
-            id,
+        sqlx::query(
+            "UPDATE requests SET l1_head_block_number = $1, l1_head_block_hash = $2, updated_at = NOW() WHERE id = $3",
         )
+        .bind(l1_head_block_number)
+        .bind(l1_head_block_hash.as_slice())
+        .bind(id)
         .execute(&self.pool)
         .await
+    }
+
+    /// Return whether a request has been logically invalidated.
+    pub async fn is_request_invalidated(&self, id: i64) -> Result<bool, Error> {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT invalidated_at IS NOT NULL FROM requests WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    /// Begin witness generation only for a still-valid queued request.
+    pub async fn try_start_witness_generation(&self, id: i64) -> Result<bool, Error> {
+        let result = sqlx::query(
+            "UPDATE requests SET status = $1, updated_at = NOW() WHERE id = $2 AND status = $3 AND invalidated_at IS NULL",
+        )
+        .bind(RequestStatus::WitnessGeneration as i16)
+        .bind(id)
+        .bind(RequestStatus::Unrequested as i16)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Move an invalidated physical request to its terminal status.
+    pub async fn finish_invalidated_request(&self, id: i64) -> Result<bool, Error> {
+        let result = sqlx::query(
+            "UPDATE requests SET status = $1, updated_at = NOW() WHERE id = $2 AND invalidated_at IS NOT NULL AND status != $1",
+        )
+        .bind(RequestStatus::Invalidated as i16)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Invalidate stale completed ranges and every pre-relay aggregation containing them.
+    pub async fn invalidate_noncanonical_ranges(
+        &self,
+        stale_range_ids: &[i64],
+        commitment: &CommitmentConfig,
+        l1_chain_id: i64,
+        l2_chain_id: i64,
+    ) -> Result<(u64, u64), Error> {
+        if stale_range_ids.is_empty() {
+            return Ok((0, 0));
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let range_result = sqlx::query(
+            "UPDATE requests SET status = $1, invalidated_at = NOW(), updated_at = NOW() WHERE id = ANY($2) AND req_type = $3 AND status = $4 AND invalidated_at IS NULL",
+        )
+        .bind(RequestStatus::Invalidated as i16)
+        .bind(stale_range_ids)
+        .bind(RequestType::Range as i16)
+        .bind(RequestStatus::Complete as i16)
+        .execute(&mut *tx)
+        .await?;
+
+        let active_statuses = [
+            RequestStatus::Unrequested as i16,
+            RequestStatus::WitnessGeneration as i16,
+            RequestStatus::Execution as i16,
+            RequestStatus::Prove as i16,
+            RequestStatus::Complete as i16,
+        ];
+        let terminal_statuses = [RequestStatus::Unrequested as i16, RequestStatus::Complete as i16];
+        let agg_result = sqlx::query(
+            "UPDATE requests AS agg SET status = CASE WHEN agg.status = ANY($1) THEN $2 ELSE agg.status END, invalidated_at = NOW(), updated_at = NOW() WHERE agg.req_type = $3 AND agg.status = ANY($4) AND agg.invalidated_at IS NULL AND agg.range_vkey_commitment = $5 AND agg.rollup_config_hash = $6 AND agg.aggregation_vkey_hash = $7 AND agg.l1_chain_id = $8 AND agg.l2_chain_id = $9 AND EXISTS (SELECT 1 FROM requests AS stale WHERE stale.id = ANY($10) AND agg.start_block <= stale.start_block AND stale.end_block <= agg.end_block)",
+        )
+        .bind(&terminal_statuses[..])
+        .bind(RequestStatus::Invalidated as i16)
+        .bind(RequestType::Aggregation as i16)
+        .bind(&active_statuses[..])
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&commitment.agg_vkey_hash[..])
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
+        .bind(stale_range_ids)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok((range_result.rows_affected(), agg_result.rows_affected()))
     }
 
     /// Update the prove_duration based on the current time and the proof_request_time.
@@ -504,21 +635,18 @@ impl DriverDBClient {
     }
 
     /// Add a completed proof to the database.
-    pub async fn update_proof_to_complete(
-        &self,
-        id: i64,
-        proof: &[u8],
-    ) -> Result<PgQueryResult, Error> {
-        sqlx::query!(
-            r#"
-            UPDATE requests SET proof = $1, status = $2, updated_at = NOW() WHERE id = $3
-            "#,
-            proof,
-            RequestStatus::Complete as i16,
-            id,
+    pub async fn update_proof_to_complete(&self, id: i64, proof: &[u8]) -> Result<bool, Error> {
+        let completable_statuses = [RequestStatus::Execution as i16, RequestStatus::Prove as i16];
+        let result = sqlx::query(
+            "UPDATE requests SET proof = $1, status = $2, updated_at = NOW() WHERE id = $3 AND status = ANY($4) AND invalidated_at IS NULL",
         )
+        .bind(proof)
+        .bind(RequestStatus::Complete as i16)
+        .bind(id)
+        .bind(&completable_statuses[..])
         .execute(&self.pool)
-        .await
+        .await?;
+        Ok(result.rows_affected() == 1)
     }
 
     /// Update the witness generation duration of a request in the database.
@@ -611,18 +739,18 @@ impl DriverDBClient {
         id: i64,
         relay_tx_hash: B256,
         contract_address: Address,
-    ) -> Result<PgQueryResult, Error> {
-        sqlx::query!(
-            r#"
-            UPDATE requests SET status = $1, relay_tx_hash = $2, contract_address = $3, updated_at = NOW() WHERE id = $4
-            "#,
-            RequestStatus::Relayed as i16,
-            relay_tx_hash.to_vec(),
-            contract_address.to_vec(),
-            id,
+    ) -> Result<bool, Error> {
+        let result = sqlx::query(
+            "UPDATE requests SET status = $1, relay_tx_hash = $2, contract_address = $3, updated_at = NOW() WHERE id = $4 AND status = $5 AND invalidated_at IS NULL",
         )
+        .bind(RequestStatus::Relayed as i16)
+        .bind(relay_tx_hash.as_slice())
+        .bind(contract_address.as_slice())
+        .bind(id)
+        .bind(RequestStatus::Complete as i16)
         .execute(&self.pool)
-        .await
+        .await?;
+        Ok(result.rows_affected() == 1)
     }
 
     /// Fetch a single completed aggregation proof after the given start block.
@@ -633,18 +761,17 @@ impl DriverDBClient {
         l1_chain_id: i64,
         l2_chain_id: i64,
     ) -> Result<Option<OPSuccinctRequest>, Error> {
-        let request = sqlx::query_as!(
-            OPSuccinctRequest,
-            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND status = $4 AND req_type = $5 AND start_block = $6 AND l1_chain_id = $7 AND l2_chain_id = $8 ORDER BY start_block ASC LIMIT 1",
-            &commitment.range_vkey_commitment[..],
-            &commitment.rollup_config_hash[..],
-            &commitment.agg_vkey_hash[..],
-            RequestStatus::Complete as i16,
-            RequestType::Aggregation as i16,
-            latest_contract_l2_block,
-            l1_chain_id,
-            l2_chain_id,
+        let request = sqlx::query_as::<_, OPSuccinctRequest>(
+            "SELECT * FROM requests WHERE range_vkey_commitment = $1 AND rollup_config_hash = $2 AND aggregation_vkey_hash = $3 AND status = $4 AND invalidated_at IS NULL AND req_type = $5 AND start_block = $6 AND l1_chain_id = $7 AND l2_chain_id = $8 ORDER BY start_block ASC LIMIT 1",
         )
+        .bind(&commitment.range_vkey_commitment[..])
+        .bind(&commitment.rollup_config_hash[..])
+        .bind(&commitment.agg_vkey_hash[..])
+        .bind(RequestStatus::Complete as i16)
+        .bind(RequestType::Aggregation as i16)
+        .bind(latest_contract_l2_block)
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .fetch_optional(&self.pool)
         .await?;
         Ok(request)
@@ -698,14 +825,12 @@ impl DriverDBClient {
         l2_chain_id: i64,
     ) -> Result<PgQueryResult, Error> {
         let status_values: Vec<i16> = statuses.iter().map(|s| *s as i16).collect();
-        sqlx::query!(
-            r#"
-            DELETE FROM requests WHERE status = ANY($1) AND l1_chain_id = $2 AND l2_chain_id = $3
-            "#,
-            &status_values[..],
-            l1_chain_id,
-            l2_chain_id,
+        sqlx::query(
+            "DELETE FROM requests WHERE status = ANY($1) AND invalidated_at IS NULL AND l1_chain_id = $2 AND l2_chain_id = $3",
         )
+        .bind(&status_values[..])
+        .bind(l1_chain_id)
+        .bind(l2_chain_id)
         .execute(&self.pool)
         .await
     }
@@ -1509,5 +1634,172 @@ mod tests {
         let result =
             c.fetch_completed_agg_proof_after_block(100, &diff_comm, L1ID, L2ID).await.unwrap();
         assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn invalidation_cascades_to_every_containing_aggregation() {
+        let db = TestDb::new().await;
+        let c = db.client();
+        let cases =
+            [(0, vec![0]), (1_000, vec![1_100]), (2_000, vec![2_200]), (3_000, vec![3_000, 3_200])];
+
+        for (offset, _) in &cases {
+            insert_requests(
+                c,
+                &[
+                    completed_range(*offset, offset + 100),
+                    completed_range(offset + 100, offset + 200),
+                    completed_range(offset + 200, offset + 300),
+                    agg_request(*offset, offset + 100, RequestStatus::Complete),
+                    agg_request(offset + 100, offset + 200, RequestStatus::Complete),
+                    agg_request(offset + 200, offset + 300, RequestStatus::Complete),
+                    agg_request(*offset, offset + 300, RequestStatus::Complete),
+                ],
+            )
+            .await;
+        }
+
+        let ranges =
+            c.fetch_completed_range_metadata(&default_commitment(), 0, L1ID, L2ID).await.unwrap();
+        for (_, stale_starts) in &cases {
+            let stale_ids = ranges
+                .iter()
+                .filter(|range| stale_starts.contains(&range.start_block))
+                .map(|range| range.id)
+                .collect::<Vec<_>>();
+            c.invalidate_noncanonical_ranges(&stale_ids, &default_commitment(), L1ID, L2ID)
+                .await
+                .unwrap();
+
+            for range in ranges.iter().filter(|range| stale_ids.contains(&range.id)) {
+                let (status, invalidated): (i16, bool) = sqlx::query_as(
+                    "SELECT status, invalidated_at IS NOT NULL FROM requests WHERE id = $1",
+                )
+                .bind(range.id)
+                .fetch_one(&c.pool)
+                .await
+                .unwrap();
+                assert_eq!(RequestStatus::from(status), RequestStatus::Invalidated);
+                assert!(invalidated);
+            }
+
+            let offset = stale_starts[0] / 1_000 * 1_000;
+            let aggregations: Vec<(i64, i64, i16, bool)> = sqlx::query_as(
+                "SELECT start_block, end_block, status, invalidated_at IS NOT NULL FROM requests WHERE req_type = $1 AND start_block >= $2 AND start_block < $3 ORDER BY start_block, end_block",
+            )
+            .bind(RequestType::Aggregation as i16)
+            .bind(offset)
+            .bind(offset + 1_000)
+            .fetch_all(&c.pool)
+            .await
+            .unwrap();
+            for (start_block, end_block, status, invalidated) in aggregations {
+                let expected = stale_starts.iter().any(|stale_start| {
+                    start_block <= *stale_start && stale_start + 100 <= end_block
+                });
+                assert_eq!(invalidated, expected, "aggregation ({start_block}, {end_block}]");
+                assert_eq!(
+                    RequestStatus::from(status),
+                    if expected { RequestStatus::Invalidated } else { RequestStatus::Complete }
+                );
+            }
+        }
+
+        let repeated_ids = ranges
+            .iter()
+            .filter(|range| [3_000, 3_200].contains(&range.start_block))
+            .map(|range| range.id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            c.invalidate_noncanonical_ranges(&repeated_ids, &default_commitment(), L1ID, L2ID,)
+                .await
+                .unwrap(),
+            (0, 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidation_preserves_in_flight_status_until_terminal() {
+        let db = TestDb::new().await;
+        let c = db.client();
+        insert_requests(
+            c,
+            &[
+                completed_range(0, 100),
+                agg_request(0, 101, RequestStatus::Unrequested),
+                agg_request(0, 102, RequestStatus::WitnessGeneration),
+                agg_request(0, 103, RequestStatus::Execution),
+                agg_request(0, 104, RequestStatus::Prove),
+                agg_request(0, 105, RequestStatus::Complete),
+                agg_request(0, 106, RequestStatus::Relayed),
+            ],
+        )
+        .await;
+        let stale_id =
+            c.fetch_completed_range_metadata(&default_commitment(), 0, L1ID, L2ID).await.unwrap()
+                [0]
+            .id;
+
+        assert_eq!(
+            c.invalidate_noncanonical_ranges(&[stale_id], &default_commitment(), L1ID, L2ID,)
+                .await
+                .unwrap(),
+            (1, 5)
+        );
+
+        let aggregations: Vec<(i64, i16, bool)> = sqlx::query_as(
+            "SELECT end_block, status, invalidated_at IS NOT NULL FROM requests WHERE req_type = $1 ORDER BY end_block",
+        )
+        .bind(RequestType::Aggregation as i16)
+        .fetch_all(&c.pool)
+        .await
+        .unwrap();
+        let expected = [
+            (101, RequestStatus::Invalidated, true),
+            (102, RequestStatus::WitnessGeneration, true),
+            (103, RequestStatus::Execution, true),
+            (104, RequestStatus::Prove, true),
+            (105, RequestStatus::Invalidated, true),
+            (106, RequestStatus::Relayed, false),
+        ];
+        for ((end, status, invalidated), expected) in aggregations.into_iter().zip(expected) {
+            assert_eq!((end, RequestStatus::from(status), invalidated), expected);
+        }
+
+        assert_eq!(
+            c.fetch_active_agg_proofs_count(0, &default_commitment(), L1ID, L2ID).await.unwrap(),
+            0
+        );
+        assert_eq!(count(c, RequestStatus::Prove).await, 1);
+        assert!(c
+            .fetch_unrequested_agg_proof(0, &default_commitment(), L1ID, L2ID)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(c
+            .fetch_completed_agg_proof_after_block(0, &default_commitment(), L1ID, L2ID)
+            .await
+            .unwrap()
+            .is_none());
+
+        let queued_id: i64 = sqlx::query_scalar("SELECT id FROM requests WHERE end_block = 101")
+            .fetch_one(&c.pool)
+            .await
+            .unwrap();
+        assert!(!c.try_start_witness_generation(queued_id).await.unwrap());
+
+        let witness_id: i64 = sqlx::query_scalar("SELECT id FROM requests WHERE end_block = 102")
+            .fetch_one(&c.pool)
+            .await
+            .unwrap();
+        c.update_request_to_prove(witness_id, B256::repeat_byte(1)).await.unwrap();
+        assert!(c.is_request_invalidated(witness_id).await.unwrap());
+
+        let prove_id: i64 = sqlx::query_scalar("SELECT id FROM requests WHERE end_block = 104")
+            .fetch_one(&c.pool)
+            .await
+            .unwrap();
+        assert!(!c.update_proof_to_complete(prove_id, &[1, 2, 3]).await.unwrap());
+        assert!(c.finish_invalidated_request(prove_id).await.unwrap());
     }
 }

--- a/validity/src/db/types.rs
+++ b/validity/src/db/types.rs
@@ -19,6 +19,7 @@ pub enum RequestStatus {
     Relayed = 5,
     Failed = 6,
     Cancelled = 7,
+    Invalidated = 8,
 }
 
 impl From<i16> for RequestStatus {
@@ -32,9 +33,30 @@ impl From<i16> for RequestStatus {
             5 => RequestStatus::Relayed,
             6 => RequestStatus::Failed,
             7 => RequestStatus::Cancelled,
+            8 => RequestStatus::Invalidated,
             _ => panic!("Invalid request status: {value}"),
         }
     }
+}
+
+/// Canonicality metadata for a completed range proof.
+#[derive(FromRow)]
+pub struct CompletedRangeMetadata {
+    pub id: i64,
+    pub start_block: i64,
+    pub end_block: i64,
+    pub l1_head_block_number: Option<i64>,
+    pub l1_head_block_hash: Option<Vec<u8>>,
+}
+
+/// A completed range proof that still needs canonicality metadata recovered.
+#[derive(FromRow)]
+pub struct MissingRangeMetadata {
+    pub id: i64,
+    pub start_block: i64,
+    pub end_block: i64,
+    pub l1_head_block_number: Option<i64>,
+    pub proof: Option<Vec<u8>>,
 }
 
 #[derive(sqlx::Type, Debug, Copy, Clone, PartialEq, Eq, Default)]

--- a/validity/src/proof_requester.rs
+++ b/validity/src/proof_requester.rs
@@ -173,9 +173,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
 
         if let Some(l1_head) = self.host.get_l1_head_hash(&host_args) {
             let l1_head_block_number = self.fetcher.get_l1_header(l1_head.into()).await?.number;
-            self.db_client
-                .update_l1_head_block_number(request.id, l1_head_block_number as i64)
-                .await?;
+            self.db_client.update_l1_head(request.id, l1_head_block_number as i64, l1_head).await?;
         }
 
         let witness = self.host.run(&host_args).await?;
@@ -451,6 +449,12 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
         request: OPSuccinctRequest,
         execution_status: i32,
     ) -> Result<()> {
+        if self.db_client.is_request_invalidated(request.id).await? {
+            self.db_client.finish_invalidated_request(request.id).await?;
+            info!(request_id = request.id, "Discarded invalidated proof request");
+            return Ok(());
+        }
+
         warn!(
             id = request.id,
             start_block = request.start_block,
@@ -551,13 +555,28 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
         Ok(stdin)
     }
 
+    /// Store a proof unless the request was invalidated while work was in flight.
+    async fn store_completed_proof(&self, request_id: i64, proof: &[u8]) -> Result<()> {
+        if self.db_client.update_proof_to_complete(request_id, proof).await? {
+            return Ok(());
+        }
+        if self.db_client.finish_invalidated_request(request_id).await? {
+            info!(request_id, "Discarded proof completed after invalidation");
+            return Ok(());
+        }
+        anyhow::bail!("Request {request_id} could not transition to Complete")
+    }
+
     /// Makes a proof request by updating statuses, generating witnesses, and then either requesting
     /// or mocking the proof depending on configuration.
     ///
     /// Note: Any error from this function will cause the proof to be retried.
     #[tracing::instrument(name = "proof_requester.make_proof_request", skip(self, request))]
     pub async fn make_proof_request(&self, request: OPSuccinctRequest) -> Result<()> {
-        self.db_client.update_request_status(request.id, RequestStatus::WitnessGeneration).await?;
+        if !self.db_client.try_start_witness_generation(request.id).await? {
+            info!(request_id = request.id, "Skipped request that is no longer queued");
+            return Ok(());
+        }
 
         info!(
             request_id = request.id,
@@ -589,6 +608,12 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             "Completed witness generation"
         );
 
+        if self.db_client.is_request_invalidated(request.id).await? {
+            self.db_client.finish_invalidated_request(request.id).await?;
+            info!(request_id = request.id, "Discarded invalidated witness");
+            return Ok(());
+        }
+
         if self.mock {
             self.db_client.update_request_status(request.id, RequestStatus::Execution).await?;
         }
@@ -598,7 +623,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
                 if self.mock {
                     let proof = self.generate_mock_range_proof(&request, stdin).await?;
                     let proof_bytes = bincode::serialize(&proof)?;
-                    self.db_client.update_proof_to_complete(request.id, &proof_bytes).await?;
+                    self.store_completed_proof(request.id, &proof_bytes).await?;
                 } else if self.cluster {
                     let cluster_config = self
                         .cluster_config
@@ -637,7 +662,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             RequestType::Aggregation => {
                 if self.mock {
                     let proof = self.generate_mock_agg_proof(&request, stdin).await?;
-                    self.db_client.update_proof_to_complete(request.id, &proof.bytes()).await?;
+                    self.store_completed_proof(request.id, &proof.bytes()).await?;
                 } else if self.cluster {
                     let cluster_config = self
                         .cluster_config

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -6,7 +6,10 @@ use alloy_provider::{network::ReceiptResponse, Provider};
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use futures_util::{stream, StreamExt, TryStreamExt};
-use op_succinct_client_utils::{boot::hash_rollup_config, types::u32_to_u8};
+use op_succinct_client_utils::{
+    boot::{hash_rollup_config, BootInfoStruct},
+    types::u32_to_u8,
+};
 use op_succinct_elfs::AGGREGATION_ELF;
 use op_succinct_host_utils::{
     fetcher::OPSuccinctDataFetcher,
@@ -42,6 +45,9 @@ use crate::{
 /// Number of consecutive poll failures before a cluster proof is marked as permanently failed.
 const MAX_CONSECUTIVE_POLL_FAILURES: u32 = 3;
 
+/// Maximum number of legacy completed ranges hydrated in one proposer loop.
+const RANGE_METADATA_HYDRATION_LIMIT: i64 = 100;
+
 /// Select the L1 block number to checkpoint for an aggregation proof.
 ///
 /// The aggregation guest walks L1 headers back from the checkpointed head *by hash* and requires
@@ -59,6 +65,34 @@ const MAX_CONSECUTIVE_POLL_FAILURES: u32 = 3;
 /// `None` (no completed range proof has a recorded `l1_head_block_number`) falls back to `safe`.
 fn select_checkpoint_block_number(safe_block_number: u64, batch_max_l1_head: Option<u64>) -> u64 {
     batch_max_l1_head.map_or(safe_block_number, |max| max.max(safe_block_number))
+}
+
+/// Return the end of the completed range chain beginning at `expected_start`.
+fn highest_contiguous_end(
+    expected_start: i64,
+    completed_ranges: &[(i64, i64)],
+) -> Result<Option<i64>> {
+    let mut current_end = expected_start;
+    let mut found = false;
+
+    for &(start, end) in completed_ranges {
+        if start > current_end {
+            break;
+        }
+        if start < current_end {
+            return Err(anyhow!(
+                "Completed range ({start}, {end}] overlaps the contiguous chain ending at {current_end}"
+            ));
+        }
+        if end <= start {
+            return Err(anyhow!("Completed range ({start}, {end}] is empty or reversed"));
+        }
+
+        current_end = end;
+        found = true;
+    }
+
+    Ok(found.then_some(current_end))
 }
 
 /// Configuration for the driver.
@@ -363,6 +397,162 @@ where
         Ok(())
     }
 
+    /// Verify that active completed range proofs still reference canonical L1 blocks.
+    async fn reconcile_completed_range_canonicality(&self) -> Result<bool> {
+        let latest_proposed_block = get_latest_proposed_block_number(
+            self.contract_config.l2oo_address,
+            self.driver_config.fetcher.as_ref(),
+        )
+        .await? as i64;
+        let db = &self.driver_config.driver_db_client;
+        let commitments = &self.program_config.commitments;
+        let l1_chain_id = self.requester_config.l1_chain_id;
+        let l2_chain_id = self.requester_config.l2_chain_id;
+
+        let missing = db
+            .fetch_missing_range_metadata(
+                commitments,
+                latest_proposed_block,
+                l1_chain_id,
+                l2_chain_id,
+                RANGE_METADATA_HYDRATION_LIMIT + 1,
+            )
+            .await?;
+        let more_metadata_remains = missing.len() > RANGE_METADATA_HYDRATION_LIMIT as usize;
+
+        for range in missing.iter().take(RANGE_METADATA_HYDRATION_LIMIT as usize) {
+            let proof_bytes = range.proof.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "Completed range ({}, {}] has no proof bytes",
+                    range.start_block,
+                    range.end_block
+                )
+            })?;
+            let mut proof: SP1ProofWithPublicValues = bincode::deserialize(proof_bytes)
+                .with_context(|| {
+                    format!(
+                        "Failed to deserialize completed range ({}, {}]",
+                        range.start_block, range.end_block
+                    )
+                })?;
+            let boot_info: BootInfoStruct = proof.public_values.read();
+            let expected_end_block =
+                u64::try_from(range.end_block).context("Completed range end block is negative")?;
+            anyhow::ensure!(
+                boot_info.l2BlockNumber == expected_end_block,
+                "Completed range ({}, {}] reports L2 block {}",
+                range.start_block,
+                range.end_block,
+                boot_info.l2BlockNumber
+            );
+            anyhow::ensure!(
+                boot_info.rollupConfigHash == commitments.rollup_config_hash,
+                "Completed range ({}, {}] has a different rollup config hash",
+                range.start_block,
+                range.end_block
+            );
+
+            let l1_head_number = if let Some(number) = range.l1_head_block_number {
+                u64::try_from(number).context("Completed range L1 head number is negative")?
+            } else {
+                self.driver_config.fetcher.get_l1_header(boot_info.l1Head.into()).await?.number
+            };
+            db.update_l1_head(
+                range.id,
+                i64::try_from(l1_head_number).context("Completed range L1 head is too large")?,
+                boot_info.l1Head,
+            )
+            .await?;
+        }
+
+        if more_metadata_remains {
+            info!(
+                hydrated = RANGE_METADATA_HYDRATION_LIMIT,
+                "Deferring proof scheduling while legacy range metadata is hydrated"
+            );
+            return Ok(false);
+        }
+
+        let completed_ranges = db
+            .fetch_completed_range_metadata(
+                commitments,
+                latest_proposed_block,
+                l1_chain_id,
+                l2_chain_id,
+            )
+            .await?;
+        let mut canonical_hashes = HashMap::new();
+
+        for range in &completed_ranges {
+            let l1_head_number = range.l1_head_block_number.ok_or_else(|| {
+                anyhow!(
+                    "Completed range ({}, {}] has no L1 head number",
+                    range.start_block,
+                    range.end_block
+                )
+            })?;
+            let l1_head_number = u64::try_from(l1_head_number)
+                .context("Completed range L1 head number is negative")?;
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                canonical_hashes.entry(l1_head_number)
+            {
+                let header =
+                    self.driver_config.fetcher.get_l1_header(l1_head_number.into()).await?;
+                entry.insert(header.hash_slow());
+            }
+        }
+
+        let mut stale_range_ids = Vec::new();
+        for range in &completed_ranges {
+            let l1_head_number = u64::try_from(range.l1_head_block_number.ok_or_else(|| {
+                anyhow!(
+                    "Completed range ({}, {}] has no L1 head number",
+                    range.start_block,
+                    range.end_block
+                )
+            })?)
+            .context("Completed range L1 head number is negative")?;
+            let stored_hash_bytes = range.l1_head_block_hash.as_deref().ok_or_else(|| {
+                anyhow!(
+                    "Completed range ({}, {}] has no L1 head hash",
+                    range.start_block,
+                    range.end_block
+                )
+            })?;
+            let stored_hash = B256::try_from(stored_hash_bytes).map_err(|_| {
+                anyhow!(
+                    "Completed range ({}, {}] has an invalid L1 head hash",
+                    range.start_block,
+                    range.end_block
+                )
+            })?;
+            let canonical_hash = canonical_hashes.get(&l1_head_number).ok_or_else(|| {
+                anyhow!("Canonical L1 hash was not fetched for block {l1_head_number}")
+            })?;
+            if canonical_hash != &stored_hash {
+                stale_range_ids.push(range.id);
+                warn!(
+                    request_id = range.id,
+                    start_block = range.start_block,
+                    end_block = range.end_block,
+                    l1_head_number,
+                    ?stored_hash,
+                    ?canonical_hash,
+                    "Completed range proof references a noncanonical L1 block"
+                );
+            }
+        }
+
+        let (range_count, aggregation_count) = db
+            .invalidate_noncanonical_ranges(&stale_range_ids, commitments, l1_chain_id, l2_chain_id)
+            .await?;
+        if range_count > 0 {
+            warn!(range_count, aggregation_count, "Invalidated noncanonical proof requests");
+        }
+
+        Ok(true)
+    }
+
     /// Handle all proof requests in the Prove state.
     ///
     /// No-op in mock mode (proofs are generated synchronously).
@@ -430,6 +620,34 @@ where
             // Check if current time exceeds deadline. If so, the proof has timed out.
             let current_time =
                 std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_secs();
+
+            if self.driver_config.driver_db_client.is_request_invalidated(request.id).await? {
+                if network_prover.network_mode() == NetworkMode::Mainnet &&
+                    request_details.as_ref().is_some_and(|details| {
+                        details.fulfillment_status == FulfillmentStatus::Requested as i32
+                    })
+                {
+                    self.network_call_with_timeout(
+                        network_prover.cancel_request(proof_request_id),
+                        "cancelling invalidated proof request",
+                        &request,
+                    )
+                    .await?;
+                    self.driver_config
+                        .driver_db_client
+                        .finish_invalidated_request(request.id)
+                        .await?;
+                } else if status.fulfillment_status() == FulfillmentStatus::Fulfilled as i32 ||
+                    status.fulfillment_status() == FulfillmentStatus::Unfulfillable as i32 ||
+                    current_time > status.deadline()
+                {
+                    self.driver_config
+                        .driver_db_client
+                        .finish_invalidated_request(request.id)
+                        .await?;
+                }
+                return Ok(());
+            }
 
             // Cancel the request in the network if the auction timeout is exceeded.
             if let Some(request_details) = request_details {
@@ -519,10 +737,12 @@ where
                 };
 
                 // Add the completed proof to the database.
-                self.driver_config
+                let stored = self
+                    .driver_config
                     .driver_db_client
                     .update_proof_to_complete(request.id, &proof_bytes)
                     .await?;
+                anyhow::ensure!(stored, "Request {} could not transition to Complete", request.id);
                 // Update the prove_duration based on the current time and the proof_request_time.
                 self.driver_config.driver_db_client.update_prove_duration(request.id).await?;
 
@@ -661,6 +881,8 @@ where
             .cluster_config
             .as_ref()
             .context("cluster_config required for cluster proof polling")?;
+        let invalidated =
+            self.driver_config.driver_db_client.is_request_invalidated(request.id).await?;
 
         // 1. Wall-clock timeout check — runs before handle lookup/reconstruction so we skip
         //    unnecessary deserialization and lock acquisition for already-timed-out proofs.
@@ -677,7 +899,15 @@ where
                     "Cluster proof exceeded wall-clock timeout"
                 );
 
-                self.fail_cluster_request(&request).await?;
+                if invalidated {
+                    self.proof_requester.cluster_handles.lock().await.remove(&request.id);
+                    self.driver_config
+                        .driver_db_client
+                        .finish_invalidated_request(request.id)
+                        .await?;
+                } else {
+                    self.fail_cluster_request(&request).await?;
+                }
                 ValidityGauge::ProofRequestTimeoutErrorCount.increment(1.0);
 
                 return Ok(());
@@ -746,6 +976,15 @@ where
         // 3. Poll the cluster for proof status.
         match cluster_poll_proof(cluster_config, proof_request).await {
             Ok(Some(results)) => {
+                if invalidated {
+                    self.proof_requester.cluster_handles.lock().await.remove(&request.id);
+                    self.driver_config
+                        .driver_db_client
+                        .finish_invalidated_request(request.id)
+                        .await?;
+                    return Ok(());
+                }
+
                 // Proof complete — convert and store.
                 let proof = SP1ProofWithPublicValues::from(results.proof);
 
@@ -755,10 +994,12 @@ where
                     SP1Proof::Core(_) => return Err(anyhow!("Core proofs are not supported.")),
                 };
 
-                self.driver_config
+                let stored = self
+                    .driver_config
                     .driver_db_client
                     .update_proof_to_complete(request.id, &proof_bytes)
                     .await?;
+                anyhow::ensure!(stored, "Request {} could not transition to Complete", request.id);
                 self.driver_config.driver_db_client.update_prove_duration(request.id).await?;
 
                 let prove_duration_s = request
@@ -825,7 +1066,15 @@ where
                         "Cluster proof poll failed permanently"
                     );
 
-                    self.fail_cluster_request(&request).await?;
+                    if invalidated {
+                        self.proof_requester.cluster_handles.lock().await.remove(&request.id);
+                        self.driver_config
+                            .driver_db_client
+                            .finish_invalidated_request(request.id)
+                            .await?;
+                    } else {
+                        self.fail_cluster_request(&request).await?;
+                    }
                 } else {
                     warn!(
                         request_id = request.id,
@@ -890,12 +1139,10 @@ where
             .await?;
 
         // Get the highest block number of the completed range proofs.
-        let highest_proven_contiguous_block_number = match self
-            .get_highest_proven_contiguous_block(completed_range_proofs)?
-        {
-            Some(block) => block,
-            None => return Ok(()), /* No completed range proofs contiguous to the latest proposed
-                                    * block number, so no need to create an aggregation proof. */
+        let Some(highest_proven_contiguous_block_number) =
+            highest_contiguous_end(latest_proposed_block_number, &completed_range_proofs)?
+        else {
+            return Ok(());
         };
 
         // Get the submission interval from the contract.
@@ -920,7 +1167,7 @@ where
             let existing_request = self
                 .driver_config
                 .driver_db_client
-                .fetch_failed_agg_request_with_checkpointed_block_hash(
+                .fetch_reusable_agg_checkpoint(
                     latest_proposed_block_number,
                     highest_proven_contiguous_block_number,
                     &self.program_config.commitments,
@@ -1361,7 +1608,8 @@ where
         info!("Relayed aggregation proof. Transaction hash: {:?}", transaction_hash);
 
         // Update the request to status RELAYED.
-        self.driver_config
+        let recorded = self
+            .driver_config
             .driver_db_client
             .update_request_to_relayed(
                 completed_agg_proof.id,
@@ -1369,6 +1617,11 @@ where
                 self.contract_config.l2oo_address,
             )
             .await?;
+        anyhow::ensure!(
+            recorded,
+            "Aggregation request {} changed before relay persistence",
+            completed_agg_proof.id
+        );
 
         Ok(())
     }
@@ -1547,15 +1800,22 @@ where
         // tasks map, set it to status FAILED.
         for request in requests {
             if !self.tasks.lock().await.contains_key(&request.id) {
-                tracing::warn!(
-                    request_id = request.id,
-                    request_type = ?request.req_type,
-                    "Task is in the database in status Execution or WitnessGeneration but not in the tasks map, setting to status FAILED."
-                );
-                self.driver_config
-                    .driver_db_client
-                    .update_request_status(request.id, RequestStatus::Failed)
-                    .await?;
+                if self.driver_config.driver_db_client.is_request_invalidated(request.id).await? {
+                    self.driver_config
+                        .driver_db_client
+                        .finish_invalidated_request(request.id)
+                        .await?;
+                } else {
+                    tracing::warn!(
+                        request_id = request.id,
+                        request_type = ?request.req_type,
+                        "Task is in the database in status Execution or WitnessGeneration but not in the tasks map, setting to status FAILED."
+                    );
+                    self.driver_config
+                        .driver_db_client
+                        .update_request_status(request.id, RequestStatus::Failed)
+                        .await?;
+                }
             }
         }
 
@@ -1710,9 +1970,9 @@ where
             .await?;
 
         // Get the highest proven contiguous block.
-        let highest_block_number = self
-            .get_highest_proven_contiguous_block(completed_range_proofs)?
-            .map_or(latest_proposed_block_number, |block| block as u64);
+        let highest_block_number =
+            highest_contiguous_end(latest_proposed_block_number as i64, &completed_range_proofs)?
+                .map_or(latest_proposed_block_number, |block| block as u64);
 
         // Fetch request counts for different statuses
         let commitments = &self.program_config.commitments;
@@ -1855,18 +2115,22 @@ where
         // Get all proof statuses of all requests in the proving state.
         self.handle_proving_requests().await?;
 
-        // Add new range requests to the database.
-        self.add_new_ranges().await?;
+        let canonicality_ready = self.reconcile_completed_range_canonicality().await?;
 
-        // Create aggregation proofs based on the completed range proofs. Checkpoints the block hash
-        // associated with the aggregation proof in advance.
-        self.create_aggregation_proofs().await?;
+        if canonicality_ready {
+            // Add new range requests to the database.
+            self.add_new_ranges().await?;
 
-        // Request all unrequested proofs from the prover network.
-        self.request_queued_proofs().await?;
+            // Create aggregation proofs based on the completed range proofs. Checkpoints the block
+            // hash associated with the aggregation proof in advance.
+            self.create_aggregation_proofs().await?;
 
-        // Submit any aggregation proofs that are complete.
-        self.submit_agg_proofs().await?;
+            // Request all unrequested proofs from the prover network.
+            self.request_queued_proofs().await?;
+
+            // Submit any aggregation proofs that are complete.
+            self.submit_agg_proofs().await?;
+        }
 
         // Update the chain lock.
         self.proof_requester
@@ -1875,28 +2139,6 @@ where
             .await?;
 
         Ok(())
-    }
-
-    /// Get the highest block number at the end of the largest contiguous range of completed range
-    /// proofs. Returns None if there are no completed range proofs.
-    fn get_highest_proven_contiguous_block(
-        &self,
-        completed_range_proofs: Vec<(i64, i64)>,
-    ) -> Result<Option<i64>> {
-        if completed_range_proofs.is_empty() {
-            return Ok(None);
-        }
-
-        let mut current_end = completed_range_proofs[0].1;
-
-        for proof in completed_range_proofs.iter().skip(1) {
-            if proof.0 != current_end {
-                break;
-            }
-            current_end = proof.1;
-        }
-
-        Ok(Some(current_end))
     }
 
     /// Wrap a network prover call with timeout, logging, and metrics.
@@ -1959,7 +2201,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::select_checkpoint_block_number;
+    use super::{highest_contiguous_end, select_checkpoint_block_number};
 
     #[test]
     fn checkpoint_falls_back_to_safe_when_no_batch_max() {
@@ -1975,5 +2217,26 @@ mod tests {
     #[test]
     fn checkpoint_floors_at_batch_max_when_above_safe() {
         assert_eq!(select_checkpoint_block_number(100, Some(150)), 150);
+    }
+
+    #[test]
+    fn contiguous_ranges_must_begin_at_expected_start() {
+        assert_eq!(highest_contiguous_end(100, &[(200, 300), (300, 400)]).unwrap(), None);
+        assert_eq!(
+            highest_contiguous_end(100, &[(100, 200), (200, 300), (400, 500)]).unwrap(),
+            Some(300)
+        );
+    }
+
+    #[test]
+    fn contiguous_ranges_reject_overlap() {
+        let error = highest_contiguous_end(100, &[(100, 200), (150, 250)]).unwrap_err();
+        assert!(error.to_string().contains("overlaps"));
+    }
+
+    #[test]
+    fn contiguous_ranges_reject_empty_range() {
+        let error = highest_contiguous_end(100, &[(100, 100)]).unwrap_err();
+        assert!(error.to_string().contains("empty or reversed"));
     }
 }


### PR DESCRIPTION
## What
- Backport #951 to `release/v3.x`.
- Persist range-proof L1 identity and invalidate noncanonical completed ranges and dependent pre-relay aggregations.
- Keep queued and late-completing requests invalidation-aware.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p op-succinct-validity --all-targets -- -D warnings`
- `cargo check -p op-succinct-validity --bin validity --no-default-features --features ethereum`
- `cargo check -p op-succinct-validity --bin validity --no-default-features --features altda`
- `cargo check -p op-succinct-validity --bin validity --no-default-features --features eigenda`
- `cargo check -p op-succinct-validity --bin validity --no-default-features --features celestia`
- `cargo test -p op-succinct-validity --lib` (36 non-DB tests passed; DB-backed tests were blocked locally by an embedded PostgreSQL binary built for a newer macOS)

## Notes
- The stable patch ID matches #951.
- Proposer and database only; no ELF or contract changes.
