### PR TITLE
ci: publish AltDA validity image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,6 +39,15 @@ jobs:
             type=ref,event=tag
             type=sha
 
+      - name: Docker meta for op-succinct-altda
+        id: meta-succinct-altda
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/op-succinct-altda
+          tags: |
+            type=ref,event=tag
+            type=sha
+
       - name: Docker meta for op-succinct-celestia
         id: meta-succinct-celestia
         uses: docker/metadata-action@v5
@@ -72,6 +81,17 @@ jobs:
           push: true
           tags: ${{ steps.meta-succinct.outputs.tags }}
           labels: ${{ steps.meta-succinct.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push op-succinct-altda
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: validity/Dockerfile.altda
+          push: true
+          tags: ${{ steps.meta-succinct-altda.outputs.tags }}
+          labels: ${{ steps.meta-succinct-altda.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## What

- publish `ghcr.io/succinctlabs/op-succinct/op-succinct-altda`
- reuse the existing `validity/Dockerfile.altda`
- apply the same ref and SHA tagging used by the other validity images

## Why

AltDA validity support and its Dockerfile already exist, but the Docker workflow does not build or publish that image.
Operators currently have to build it themselves, unlike the Ethereum, Celestia, and EigenDA variants.

## Validation

- `git diff --check`
- parsed `.github/workflows/docker-build.yml` with Ruby YAML
- verified the workflow references `validity/Dockerfile.altda`
- `docker buildx build --check -f validity/Dockerfile.altda .`

No Rust code, ELF artifacts, feature definitions, or existing image targets changed.
