### PR TITLE
backport(ci): publish AltDA validity image (#954)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,6 +39,15 @@ jobs:
             type=ref,event=tag
             type=sha
 
+      - name: Docker meta for op-succinct-altda
+        id: meta-succinct-altda
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/op-succinct-altda
+          tags: |
+            type=ref,event=tag
+            type=sha
+
       - name: Docker meta for op-succinct-celestia
         id: meta-succinct-celestia
         uses: docker/metadata-action@v5
@@ -72,6 +81,17 @@ jobs:
           push: true
           tags: ${{ steps.meta-succinct.outputs.tags }}
           labels: ${{ steps.meta-succinct.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push op-succinct-altda
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: validity/Dockerfile.altda
+          push: true
+          tags: ${{ steps.meta-succinct-altda.outputs.tags }}
+          labels: ${{ steps.meta-succinct-altda.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## What
- backport #954 to `release/v3.x`
- publish `ghcr.io/succinctlabs/op-succinct/op-succinct-altda` from the existing `validity/Dockerfile.altda`

## Validation
- exact added-line diff matches #954
- YAML parses
- `docker buildx build --check -f validity/Dockerfile.altda .`
- one file changed: `20 insertions`