### PR TITLE
fix(validity): retry failed proofs before fetching request details

### DIFF
--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, ops::Range, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap, future::Future, ops::Range, str::FromStr, sync::Arc, time::Duration,
+};
 
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, B256, U256};
@@ -26,7 +28,10 @@ use op_succinct_proof_utils::{
 use op_succinct_signer_utils::SignerLock;
 use sp1_sdk::{
     network::{
-        proto::types::{ExecutionStatus, FulfillmentStatus},
+        proto::{
+            types::{ExecutionStatus, FulfillmentStatus},
+            GetProofRequestStatusResponse,
+        },
         NetworkMode,
     },
     Elf, HashableKey, NetworkProver, Prover, ProverClient, ProvingKey, SP1Proof,
@@ -93,6 +98,74 @@ fn highest_contiguous_end(
     }
 
     Ok(found.then_some(current_end))
+}
+
+async fn handle_terminal_proof_failure<F, Fut>(
+    request: OPSuccinctRequest,
+    status: &GetProofRequestStatusResponse,
+    current_time: u64,
+    handle_failed: F,
+) -> Result<bool>
+where
+    F: FnOnce(OPSuccinctRequest, i32) -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    if current_time > status.deadline() {
+        if let Err(error) = handle_failed(request.clone(), status.execution_status()).await {
+            ValidityGauge::RetryErrorCount.increment(1.0);
+            return Err(error);
+        }
+
+        ValidityGauge::ProofRequestRetryCount.increment(1.0);
+        ValidityGauge::ProofRequestTimeoutErrorCount.increment(1.0);
+
+        warn!(
+            proof_id = request.id,
+            start_block = request.start_block,
+            end_block = request.end_block,
+            req_type = ?request.req_type,
+            deadline = status.deadline(),
+            current_time,
+            "Proof request timed out"
+        );
+        return Ok(true);
+    }
+
+    if status.fulfillment_status() != FulfillmentStatus::Unfulfillable as i32 {
+        return Ok(false);
+    }
+
+    match request.req_type {
+        RequestType::Range => {
+            warn!(
+                proof_id = request.id,
+                start_block = request.start_block,
+                end_block = request.end_block,
+                proof_request_time = ?request.proof_request_time,
+                total_tx_fees = %request.total_tx_fees,
+                total_transactions = request.total_nb_transactions,
+                witnessgen_duration_s = request.witnessgen_duration,
+                total_eth_gas_used = request.total_eth_gas_used,
+                total_l1_fees = %request.total_l1_fees,
+                execution_status = ?status.execution_status(),
+                "Range proof request failed - unfulfillable"
+            );
+        }
+        RequestType::Aggregation => {
+            warn!(
+                proof_id = request.id,
+                start_block = request.start_block,
+                end_block = request.end_block,
+                witnessgen_duration_s = request.witnessgen_duration,
+                execution_status = ?status.execution_status(),
+                "Aggregation proof request failed - unfulfillable"
+            );
+        }
+    }
+
+    handle_failed(request, status.execution_status()).await?;
+    ValidityGauge::ProofRequestRetryCount.increment(1.0);
+    Ok(true)
 }
 
 /// Configuration for the driver.
@@ -609,112 +682,60 @@ where
                 )
                 .await?;
 
-            let request_details = self
-                .network_call_with_timeout(
-                    network_prover.get_proof_request(proof_request_id),
-                    "waiting for proof request details",
-                    &request,
-                )
-                .await?;
-
             // Check if current time exceeds deadline. If so, the proof has timed out.
             let current_time =
                 std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_secs();
+            let request_invalidated =
+                self.driver_config.driver_db_client.is_request_invalidated(request.id).await?;
 
-            if self.driver_config.driver_db_client.is_request_invalidated(request.id).await? {
-                if network_prover.network_mode() == NetworkMode::Mainnet &&
-                    request_details.as_ref().is_some_and(|details| {
-                        details.fulfillment_status == FulfillmentStatus::Requested as i32
-                    })
-                {
-                    self.network_call_with_timeout(
-                        network_prover.cancel_request(proof_request_id),
-                        "cancelling invalidated proof request",
-                        &request,
-                    )
-                    .await?;
-                    self.driver_config
-                        .driver_db_client
-                        .finish_invalidated_request(request.id)
-                        .await?;
-                } else if status.fulfillment_status() == FulfillmentStatus::Fulfilled as i32 ||
+            if request_invalidated &&
+                (status.fulfillment_status() == FulfillmentStatus::Fulfilled as i32 ||
                     status.fulfillment_status() == FulfillmentStatus::Unfulfillable as i32 ||
-                    current_time > status.deadline()
-                {
-                    self.driver_config
-                        .driver_db_client
-                        .finish_invalidated_request(request.id)
-                        .await?;
-                }
+                    current_time > status.deadline())
+            {
+                self.driver_config.driver_db_client.finish_invalidated_request(request.id).await?;
                 return Ok(());
             }
 
-            // Cancel the request in the network if the auction timeout is exceeded.
-            if let Some(request_details) = request_details {
-                let auction_deadline =
-                    request_details.created_at + self.requester_config.auction_timeout;
-                if network_prover.network_mode() == NetworkMode::Mainnet &&
-                    request_details.fulfillment_status == FulfillmentStatus::Requested as i32 &&
-                    current_time > auction_deadline
-                {
-                    // Cancel the request in the network.
-                    self.network_call_with_timeout(
-                        network_prover.cancel_request(proof_request_id),
-                        "cancelling proof request",
-                        &request,
-                    )
-                    .await?;
-
-                    // Mark the request as cancelled in the database.
-                    match self.proof_requester.handle_cancelled_request(request.clone()).await {
-                        Ok(_) => ValidityGauge::ProofRequestRetryCount.increment(1.0),
-                        Err(e) => {
-                            ValidityGauge::RetryErrorCount.increment(1.0);
-                            return Err(e);
-                        }
-                    }
-
-                    ValidityGauge::ProofRequestTimeoutErrorCount.increment(1.0);
-
-                    warn!(
-                        proof_id = request.id,
-                        start_block = request.start_block,
-                        end_block = request.end_block,
-                        req_type = ?request.req_type,
-                        auction_deadline,
-                        current_time,
-                        "Proof request auction deadline exceeded"
-                    );
-
-                    return Ok(());
-                }
+            if !request_invalidated &&
+                handle_terminal_proof_failure(
+                    request.clone(),
+                    &status,
+                    current_time,
+                    |request, execution_status| {
+                        self.proof_requester.handle_failed_request(request, execution_status)
+                    },
+                )
+                .await?
+            {
+                return Ok(());
             }
 
-            if current_time > status.deadline() {
-                match self
-                    .proof_requester
-                    .handle_failed_request(request.clone(), status.execution_status())
-                    .await
-                {
-                    Ok(_) => ValidityGauge::ProofRequestRetryCount.increment(1.0),
-                    Err(e) => {
-                        ValidityGauge::RetryErrorCount.increment(1.0);
-                        return Err(e);
+            if request_invalidated {
+                if network_prover.network_mode() == NetworkMode::Mainnet {
+                    let request_details = self
+                        .network_call_with_timeout(
+                            network_prover.get_proof_request(proof_request_id),
+                            "waiting for proof request details",
+                            &request,
+                        )
+                        .await?;
+
+                    if request_details.as_ref().is_some_and(|details| {
+                        details.fulfillment_status == FulfillmentStatus::Requested as i32
+                    }) {
+                        self.network_call_with_timeout(
+                            network_prover.cancel_request(proof_request_id),
+                            "cancelling invalidated proof request",
+                            &request,
+                        )
+                        .await?;
+                        self.driver_config
+                            .driver_db_client
+                            .finish_invalidated_request(request.id)
+                            .await?;
                     }
                 }
-
-                ValidityGauge::ProofRequestTimeoutErrorCount.increment(1.0);
-
-                warn!(
-                    proof_id = request.id,
-                    start_block = request.start_block,
-                    end_block = request.end_block,
-                    req_type = ?request.req_type,
-                    deadline = status.deadline(),
-                    current_time,
-                    "Proof request timed out"
-                );
-
                 return Ok(());
             }
 
@@ -795,40 +816,53 @@ where
                         );
                     }
                 }
-            } else if status.fulfillment_status() == FulfillmentStatus::Unfulfillable as i32 {
-                // Log failure of range and aggregation proofs.
-                match request.req_type {
-                    RequestType::Range => {
+                return Ok(());
+            }
+
+            // Mainnet auction cancellation requires request details; reserved requests do not.
+            if network_prover.network_mode() == NetworkMode::Mainnet {
+                let request_details = self
+                    .network_call_with_timeout(
+                        network_prover.get_proof_request(proof_request_id),
+                        "waiting for proof request details",
+                        &request,
+                    )
+                    .await?;
+
+                if let Some(request_details) = request_details {
+                    let auction_deadline =
+                        request_details.created_at + self.requester_config.auction_timeout;
+                    if request_details.fulfillment_status == FulfillmentStatus::Requested as i32 &&
+                        current_time > auction_deadline
+                    {
+                        self.network_call_with_timeout(
+                            network_prover.cancel_request(proof_request_id),
+                            "cancelling proof request",
+                            &request,
+                        )
+                        .await?;
+
+                        match self.proof_requester.handle_cancelled_request(request.clone()).await {
+                            Ok(_) => ValidityGauge::ProofRequestRetryCount.increment(1.0),
+                            Err(e) => {
+                                ValidityGauge::RetryErrorCount.increment(1.0);
+                                return Err(e);
+                            }
+                        }
+
+                        ValidityGauge::ProofRequestTimeoutErrorCount.increment(1.0);
+
                         warn!(
                             proof_id = request.id,
                             start_block = request.start_block,
                             end_block = request.end_block,
-                            proof_request_time = ?request.proof_request_time,
-                            total_tx_fees = %request.total_tx_fees,
-                            total_transactions = request.total_nb_transactions,
-                            witnessgen_duration_s = request.witnessgen_duration,
-                            total_eth_gas_used = request.total_eth_gas_used,
-                            total_l1_fees = %request.total_l1_fees,
-                            execution_status = ?status.execution_status(),
-                            "Range proof request failed - unfulfillable"
-                        );
-                    }
-                    RequestType::Aggregation => {
-                        warn!(
-                            proof_id = request.id,
-                            start_block = request.start_block,
-                            end_block = request.end_block,
-                            witnessgen_duration_s = request.witnessgen_duration,
-                            execution_status = ?status.execution_status(),
-                            "Aggregation proof request failed - unfulfillable"
+                            req_type = ?request.req_type,
+                            auction_deadline,
+                            current_time,
+                            "Proof request auction deadline exceeded"
                         );
                     }
                 }
-
-                self.proof_requester
-                    .handle_failed_request(request, status.execution_status())
-                    .await?;
-                ValidityGauge::ProofRequestRetryCount.increment(1.0);
             }
         } else {
             // There should never be a proof request in Prove status without a proof request id.
@@ -2201,7 +2235,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{highest_contiguous_end, select_checkpoint_block_number};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex as StdMutex,
+    };
+
+    use sp1_sdk::network::proto::{
+        base_types, types::FulfillmentStatus, GetProofRequestStatusResponse,
+    };
+
+    use super::{
+        handle_terminal_proof_failure, highest_contiguous_end, select_checkpoint_block_number,
+        OPSuccinctRequest, RequestStatus, RequestType,
+    };
 
     #[test]
     fn checkpoint_falls_back_to_safe_when_no_batch_max() {
@@ -2238,5 +2284,57 @@ mod tests {
     fn contiguous_ranges_reject_empty_range() {
         let error = highest_contiguous_end(100, &[(100, 100)]).unwrap_err();
         assert!(error.to_string().contains("empty or reversed"));
+    }
+
+    #[tokio::test]
+    async fn unfulfillable_status_is_handled_before_request_details() {
+        #[derive(Default)]
+        struct FailureState {
+            failed_request_ids: Vec<i64>,
+            recreated_ranges: Vec<(i64, i64)>,
+        }
+
+        let request = OPSuccinctRequest {
+            id: 496,
+            status: RequestStatus::Prove,
+            req_type: RequestType::Range,
+            start_block: 2_433_375,
+            end_block: 2_433_675,
+            ..Default::default()
+        };
+        let status =
+            GetProofRequestStatusResponse::Base(base_types::GetProofRequestStatusResponse {
+                fulfillment_status: FulfillmentStatus::Unfulfillable as i32,
+                deadline: u64::MAX,
+                ..Default::default()
+            });
+        let state = Arc::new(StdMutex::new(FailureState::default()));
+        let callback_state = state.clone();
+        let details_requests = AtomicUsize::new(0);
+
+        let handled =
+            handle_terminal_proof_failure(request, &status, 0, move |failed_request, _| {
+                let callback_state = callback_state.clone();
+                async move {
+                    let mut state = callback_state.lock().unwrap();
+                    state.failed_request_ids.push(failed_request.id);
+                    state
+                        .recreated_ranges
+                        .push((failed_request.start_block, failed_request.end_block));
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        if !handled {
+            details_requests.fetch_add(1, Ordering::Relaxed);
+            panic!("proof request details timed out");
+        }
+
+        let state = state.lock().unwrap();
+        assert_eq!(details_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(state.failed_request_ids, [496]);
+        assert_eq!(state.recreated_ranges, [(2_433_375, 2_433_675)]);
     }
 }

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -100,15 +100,17 @@ fn highest_contiguous_end(
     Ok(found.then_some(current_end))
 }
 
-async fn handle_terminal_proof_failure<F, Fut>(
+async fn handle_terminal_proof_failure_before_request_details<F, FailureFut, DetailsFut, T>(
     request: OPSuccinctRequest,
     status: &GetProofRequestStatusResponse,
     current_time: u64,
     handle_failed: F,
-) -> Result<bool>
+    request_details: DetailsFut,
+) -> Result<Option<T>>
 where
-    F: FnOnce(OPSuccinctRequest, i32) -> Fut,
-    Fut: Future<Output = Result<()>>,
+    F: FnOnce(OPSuccinctRequest, i32) -> FailureFut,
+    FailureFut: Future<Output = Result<()>>,
+    DetailsFut: Future<Output = Result<T>>,
 {
     if current_time > status.deadline() {
         if let Err(error) = handle_failed(request.clone(), status.execution_status()).await {
@@ -128,11 +130,11 @@ where
             current_time,
             "Proof request timed out"
         );
-        return Ok(true);
+        return Ok(None);
     }
 
     if status.fulfillment_status() != FulfillmentStatus::Unfulfillable as i32 {
-        return Ok(false);
+        return Ok(Some(request_details.await?));
     }
 
     match request.req_type {
@@ -165,7 +167,7 @@ where
 
     handle_failed(request, status.execution_status()).await?;
     ValidityGauge::ProofRequestRetryCount.increment(1.0);
-    Ok(true)
+    Ok(None)
 }
 
 /// Configuration for the driver.
@@ -697,20 +699,6 @@ where
                 return Ok(());
             }
 
-            if !request_invalidated &&
-                handle_terminal_proof_failure(
-                    request.clone(),
-                    &status,
-                    current_time,
-                    |request, execution_status| {
-                        self.proof_requester.handle_failed_request(request, execution_status)
-                    },
-                )
-                .await?
-            {
-                return Ok(());
-            }
-
             if request_invalidated {
                 if network_prover.network_mode() == NetworkMode::Mainnet {
                     let request_details = self
@@ -738,6 +726,34 @@ where
                 }
                 return Ok(());
             }
+
+            let request_details = async {
+                if status.fulfillment_status() == FulfillmentStatus::Fulfilled as i32 ||
+                    network_prover.network_mode() != NetworkMode::Mainnet
+                {
+                    return Ok(None);
+                }
+
+                self.network_call_with_timeout(
+                    network_prover.get_proof_request(proof_request_id),
+                    "waiting for proof request details",
+                    &request,
+                )
+                .await
+            };
+            let Some(request_details) = handle_terminal_proof_failure_before_request_details(
+                request.clone(),
+                &status,
+                current_time,
+                |request, execution_status| {
+                    self.proof_requester.handle_failed_request(request, execution_status)
+                },
+                request_details,
+            )
+            .await?
+            else {
+                return Ok(());
+            };
 
             // If the proof request has been fulfilled, update the request to status Complete and
             // add the proof bytes to the database.
@@ -819,16 +835,7 @@ where
                 return Ok(());
             }
 
-            // Mainnet auction cancellation requires request details; reserved requests do not.
             if network_prover.network_mode() == NetworkMode::Mainnet {
-                let request_details = self
-                    .network_call_with_timeout(
-                        network_prover.get_proof_request(proof_request_id),
-                        "waiting for proof request details",
-                        &request,
-                    )
-                    .await?;
-
                 if let Some(request_details) = request_details {
                     let auction_deadline =
                         request_details.created_at + self.requester_config.auction_timeout;
@@ -2235,18 +2242,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, Mutex as StdMutex,
-    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use sp1_sdk::network::proto::{
         base_types, types::FulfillmentStatus, GetProofRequestStatusResponse,
     };
 
     use super::{
-        handle_terminal_proof_failure, highest_contiguous_end, select_checkpoint_block_number,
-        OPSuccinctRequest, RequestStatus, RequestType,
+        handle_terminal_proof_failure_before_request_details, highest_contiguous_end,
+        select_checkpoint_block_number, OPSuccinctRequest, RequestStatus, RequestType,
     };
 
     #[test]
@@ -2288,12 +2292,6 @@ mod tests {
 
     #[tokio::test]
     async fn unfulfillable_status_is_handled_before_request_details() {
-        #[derive(Default)]
-        struct FailureState {
-            failed_request_ids: Vec<i64>,
-            recreated_ranges: Vec<(i64, i64)>,
-        }
-
         let request = OPSuccinctRequest {
             id: 496,
             status: RequestStatus::Prove,
@@ -2308,33 +2306,32 @@ mod tests {
                 deadline: u64::MAX,
                 ..Default::default()
             });
-        let state = Arc::new(StdMutex::new(FailureState::default()));
-        let callback_state = state.clone();
+        let failure_calls = AtomicUsize::new(0);
         let details_requests = AtomicUsize::new(0);
+        let failure_calls_for_handler = &failure_calls;
 
-        let handled =
-            handle_terminal_proof_failure(request, &status, 0, move |failed_request, _| {
-                let callback_state = callback_state.clone();
-                async move {
-                    let mut state = callback_state.lock().unwrap();
-                    state.failed_request_ids.push(failed_request.id);
-                    state
-                        .recreated_ranges
-                        .push((failed_request.start_block, failed_request.end_block));
-                    Ok(())
-                }
-            })
-            .await
-            .unwrap();
-
-        if !handled {
+        let request_details = async {
             details_requests.fetch_add(1, Ordering::Relaxed);
-            panic!("proof request details timed out");
-        }
+            Err::<(), _>(anyhow::anyhow!("proof request details timed out"))
+        };
+        let result = handle_terminal_proof_failure_before_request_details(
+            request,
+            &status,
+            0,
+            |failed_request, _| async move {
+                assert_eq!(failed_request.id, 496);
+                assert_eq!(failed_request.start_block, 2_433_375);
+                assert_eq!(failed_request.end_block, 2_433_675);
+                failure_calls_for_handler.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+            request_details,
+        )
+        .await
+        .unwrap();
 
-        let state = state.lock().unwrap();
+        assert!(result.is_none());
+        assert_eq!(failure_calls.load(Ordering::Relaxed), 1);
         assert_eq!(details_requests.load(Ordering::Relaxed), 0);
-        assert_eq!(state.failed_request_ids, [496]);
-        assert_eq!(state.recreated_ranges, [(2_433_375, 2_433_675)]);
     }
 }


### PR DESCRIPTION
## What

- Handle terminal proof failures and overall deadlines before fetching optional proof-request details.
- Keep request details for behavior that needs them: Mainnet auction cancellation and fulfilled-proof execution statistics.
- Add an ordering regression covering the JPM failure shape: `UNFULFILLABLE` status, a details future that fails if polled, and exactly one failed-request handler invocation.

## Why

The validity proposer fetched proof-request details before handling `UNFULFILLABLE`, so a details timeout returned early and left the failed local request blocking subsequent ranges.

## Validation

- `cargo test -p op-succinct-validity unfulfillable_status_is_handled_before_request_details -- --nocapture`
- `cargo test -p op-succinct-validity proposer::tests -- --nocapture`
- `cargo check --all-targets --all-features --tests`
- `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- `cargo fmt --all -- --check`
- `git diff --check`

The full validity library suite reached 37 passing tests, but 22 database-backed tests could not start because the cached Theseus PostgreSQL 18.4 binary targets a newer macOS release than the host.
The sysgo recovery test was stopped after its proposer reached external SPN and received `PermissionDenied: no reservation found for requester`; no proof request was accepted.

## Notes

Not deployed.
After merge, the fix must be backported through `release/v3.x`, included in a new AggLayer tag/image, and then rolled out and verified on JPM separately.
