### PR TITLE
docs(fault-proof): explain bond sizing economics

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -36,6 +36,7 @@
     - [How to run the FP Challenger](./fault_proofs/challenger.md)
     - [Running with Docker](./fault_proofs/docker.md)
   - [Resources](./fault_proofs/resources.md)
+    - [Bond Economics and Sizing](./fault_proofs/bond_economics.md)
     - [Gas Costs](./fault_proofs/gas_costs.md)
     - [Testing Guide](./fault_proofs/testing.md)
     - [Pre-Flight Validation](./fault_proofs/preflight.md)

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -16,8 +16,6 @@
   - [Validity Proposer](./validity/validity-mode.md)
     - [Proposer Configuration](./validity/proposer.md)
     - [Proposer Lifecycle](./validity/proposer-lifecycle.md)
-    - [Gas Costs]()
-    - [Testing Guide]()
   - [Upgrading OP Succinct](./validity/upgrade.md)
   - [Data Availability](./validity/data-availability/intro.md)
     - [Celestia](./validity/data-availability/celestia.md)

--- a/book/fault_proofs/bond_economics.md
+++ b/book/fault_proofs/bond_economics.md
@@ -1,0 +1,168 @@
+# Bond Economics and Sizing
+
+OP Succinct Lite uses a proposer bond and a challenger bond for each dispute game.
+The SP1 proof verifies the proposed state transition.
+The bonds price participation and fund the response to a challenge.
+Operators must also maintain at least one funded challenger that monitors games.
+
+Each game accepts one challenge.
+A challenge starts one proof window.
+This single-round flow lets operators size bonds around the cost and concurrency of one game.
+
+## Bond Roles
+
+| Bond | Posted by | Purpose | Normal outcome |
+|------|-----------|---------|----------------|
+| Proposer bond | The game creator when it creates a game | Prices game creation and backs the proposal | Returned after a defender win |
+| Challenger bond | The challenger when it calls `challenge()` | Prices challenges and funds the proof response | Paid to the prover after a valid proof |
+
+The proposer bond is the `DisputeGameFactory` initial bond for the game type.
+The challenger bond is an immutable value in the game implementation.
+Both deposits remain in the game contract until the game is resolved, finalized, and claimed.
+
+The contract distributes the bonds as follows:
+
+| Game outcome | Proposer bond | Challenger bond |
+|--------------|---------------|-----------------|
+| Unchallenged | Returned to proposer | No challenger bond was posted |
+| Unchallenged with a valid proof | Returned to proposer | No challenger bond was posted, so the prover receives no reward |
+| Challenged with a valid proof | Returned to proposer | Paid to the prover |
+| Challenged without a valid proof before the deadline | Paid to challenger | Returned to challenger |
+| Improper game | Refunded to proposer | Refunded to challenger if one was posted |
+
+See [Architecture: Reward Distribution](./fault_proof_architecture.md#reward-distribution) for the contract flow.
+If a parent game resolves with `CHALLENGER_WINS`, its descendants also lose.
+An unchallenged descendant has no challenger recipient, so its proposer bond is lost.
+
+## Size the Challenger Bond
+
+Use the marginal cost of defending one production game as the sizing base.
+Include every cost that a nuisance challenge forces an honest defender to pay.
+Express each cost in ETH before applying the sizing multiplier.
+
+```text
+defense cost
+  = range proof cost
+  + aggregation proof cost
+  + L1 proof submission cost
+  + operating buffer
+
+challenger bond = about 10 * conservative defense cost
+```
+
+Treat 10 times the defense cost as a starting point.
+Confirm that an honest challenger can fund the resulting bond and L1 gas before deployment.
+A high challenger bond can reduce the number of parties that can challenge an invalid proposal.
+
+Use this process to estimate the defense cost:
+
+1. Select historical L2 ranges that match `PROPOSAL_INTERVAL_IN_BLOCKS` and the expected production workload.
+2. Include high-load ranges and the production data availability mode.
+3. Split each game range as the proposer does with `RANGE_SPLIT_COUNT`.
+4. Run the [cost estimator](../advanced/cost-estimation-tools.md#cost-estimator) for each segment with `--no-safe-head-split` and the game L1 head.
+5. Sum the reported SP1 gas and convert it to ETH with the current proving price and exchange rate.
+6. Add aggregation proving, L1 proof submission, and an operating buffer.
+7. Use the highest credible result from the sample.
+
+The cost estimator reports range-program execution statistics and SP1 gas.
+It does not calculate the full monetary cost of defending a game.
+Aggregation proving and the L1 transaction must be added separately.
+
+One game accepts one challenge, while several games can be challenged at the same time.
+Provision enough challenger liquidity for the expected number of concurrent invalid games.
+Provision enough proving capacity to defend all valid games within `MAX_PROVE_DURATION`.
+
+```text
+challenger liquidity
+  = challenger bond * concurrent challenges
+  + L1 gas reserve
+```
+
+## Size the Proposer Bond
+
+The proposer posts a new initial bond for every game that it creates.
+The bond cannot fund the next game while it remains locked in the current game.
+The main sizing constraint is the amount of proposer capital that can remain locked across open games.
+
+Estimate a conservative lock horizon:
+
+```text
+proposal period
+  = PROPOSAL_INTERVAL_IN_BLOCKS * average L2 block time
+
+lock horizon
+  = MAX_CHALLENGE_DURATION
+  + MAX_PROVE_DURATION
+  + DISPUTE_GAME_FINALITY_DELAY_SECONDS
+  + operating buffer
+
+peak open games
+  = ceil(lock horizon / proposal period)
+  + concurrency buffer
+
+proposer capital
+  = INITIAL_BOND_WEI * peak open games
+  + L1 gas reserve
+```
+
+The full lock horizon covers a challenge submitted near the end of the challenge window.
+An unchallenged game usually releases its credit sooner because it does not use the proving window.
+Parent-game dependencies, failed transactions, and delayed claims can extend the observed lock time.
+Use the measured peak number of unclaimed games to refine the estimate after launch.
+
+Choose an initial bond that leaves enough capital for the calculated peak and a safe operating reserve.
+The amount should also make invalid or abandoned proposals costly.
+Permissionless proposing requires extra attention to that deterrence value.
+
+## Example
+
+This example shows the method with illustrative values.
+Measure the inputs for each production deployment.
+
+Assume the following configuration:
+
+- Average L2 block time: 2 seconds.
+- Proposal interval: 1,800 blocks, or 1 hour.
+- Maximum challenge duration: 7 days.
+- Maximum prove duration: 1 day.
+- Dispute game finality delay: 7 days.
+- Initial bond: 0.01 ETH per game.
+- Conservative defense cost: 0.005 ETH per game.
+
+The conservative lock horizon is 15 days before adding an operating buffer.
+An hourly proposal cadence produces about 360 open games during that period.
+The proposer therefore needs about 3.6 ETH for game bonds, plus the concurrency buffer and L1 gas reserve.
+The challenger bond starts near 0.05 ETH under the 10 times rule.
+The operator must then confirm that an honest challenger can fund this amount across the expected concurrency.
+
+## Configure and Review Bonds
+
+Set `INITIAL_BOND_WEI` and `CHALLENGER_BOND_WEI` during [contract deployment](./deploy.md#optional-environment-variables).
+Use `cast --to-wei <value> eth` to convert ETH to wei.
+
+Read the current proposer bond from the factory:
+
+```bash
+cast call <FACTORY_ADDRESS> \
+  "initBonds(uint32)(uint256)" <GAME_TYPE> \
+  --rpc-url <L1_RPC>
+```
+
+Read the current game implementation and challenger bond:
+
+```bash
+cast call <FACTORY_ADDRESS> \
+  "gameImpls(uint32)(address)" <GAME_TYPE> \
+  --rpc-url <L1_RPC>
+
+cast call <GAME_IMPLEMENTATION> \
+  "challengerBond()(uint256)" \
+  --rpc-url <L1_RPC>
+```
+
+The factory initial bond can be changed for future games.
+Changing the challenger bond requires a [new game implementation](./upgrade.md).
+Existing games keep the deposits that they received at creation and challenge time.
+
+Recalculate both bonds after changes to workload, proposal interval, data availability mode, program version, proving price, L1 fees, or asset exchange rates.
+Monitor the number of unclaimed games and the available proposer and challenger balances after deployment.

--- a/book/fault_proofs/bond_economics.md
+++ b/book/fault_proofs/bond_economics.md
@@ -2,43 +2,24 @@
 
 OP Succinct Lite uses a proposer bond and a challenger bond for each dispute game.
 The SP1 proof verifies the proposed state transition.
-The bonds price participation and fund the response to a challenge.
-Operators must also maintain at least one funded challenger that monitors games.
+The bonds make nuisance proposals and challenges costly and provide a reward for defending a valid proposal.
 
-Each game accepts one challenge.
-A challenge starts one proof window.
-This single-round flow lets operators size bonds around the cost and concurrency of one game.
+Each game accepts one challenge and opens one proof window.
+Several games can be challenged at the same time, so operators must account for concurrent games.
 
 ## Bond Roles
 
-| Bond | Posted by | Purpose | Normal outcome |
-|------|-----------|---------|----------------|
-| Proposer bond | The game creator when it creates a game | Prices game creation and backs the proposal | Returned after a defender win |
-| Challenger bond | The challenger when it calls `challenge()` | Prices challenges and funds the proof response | Paid to the prover after a valid proof |
+| Bond | Posted by | Purpose |
+|------|-----------|---------|
+| Proposer bond | The game creator | Prices game creation and locks proposer capital while the game is open |
+| Challenger bond | The challenger | Prices challenges and rewards a valid defense |
 
-The proposer bond is the `DisputeGameFactory` initial bond for the game type.
-The challenger bond is an immutable value in the game implementation.
-Both deposits remain in the game contract until the game is resolved, finalized, and claimed.
-
-The contract distributes the bonds as follows:
-
-| Game outcome | Proposer bond | Challenger bond |
-|--------------|---------------|-----------------|
-| Unchallenged | Returned to proposer | No challenger bond was posted |
-| Unchallenged with a valid proof | Returned to proposer | No challenger bond was posted, so the prover receives no reward |
-| Challenged with a valid proof | Returned to proposer | Paid to the prover |
-| Challenged without a valid proof before the deadline | Paid to challenger | Returned to challenger |
-| Improper game | Refunded to proposer | Refunded to challenger if one was posted |
-
-See [Architecture: Reward Distribution](./fault_proof_architecture.md#reward-distribution) for the contract flow.
-If a parent game resolves with `CHALLENGER_WINS`, its descendants also lose.
-An unchallenged descendant has no challenger recipient, so its proposer bond is lost.
+Both bonds remain locked until the game is resolved, finalized, and claimed.
+See [Architecture: Reward Distribution](./fault_proof_architecture.md#reward-distribution) for the payout rules and contract flow.
 
 ## Size the Challenger Bond
 
-Use the marginal cost of defending one production game as the sizing base.
-Include every cost that a nuisance challenge forces an honest defender to pay.
-Express each cost in ETH before applying the sizing multiplier.
+Use the conservative cost of defending one challenged production game as the sizing base.
 
 ```text
 defense cost
@@ -51,40 +32,21 @@ challenger bond = about 10 * conservative defense cost
 ```
 
 Treat 10 times the defense cost as a starting point.
-Confirm that an honest challenger can fund the resulting bond and L1 gas before deployment.
-A high challenger bond can reduce the number of parties that can challenge an invalid proposal.
+The defender must pay the proving and L1 submission costs before it can claim the challenger bond.
+Reserve enough proving funds to defend concurrent games within `MAX_PROVE_DURATION`.
 
-Use this process to estimate the defense cost:
+Use representative production ranges and the production data availability mode when estimating range proof demand.
+The [cost estimator](../advanced/cost-estimation-tools.md#cost-estimator) reports range-program execution statistics and SP1 gas.
+It does not provide the proving rate or exchange rate, and it does not include aggregation proving or L1 submission.
+These values are operator inputs when converting the estimate to ETH.
 
-1. Select historical L2 ranges that match `PROPOSAL_INTERVAL_IN_BLOCKS` and the expected production workload.
-2. Include high-load ranges and the production data availability mode.
-3. Split each game range as the proposer does with `RANGE_SPLIT_COUNT`.
-4. Run the [cost estimator](../advanced/cost-estimation-tools.md#cost-estimator) for each segment with `--no-safe-head-split` and the game L1 head.
-5. Sum the reported SP1 gas and convert it to ETH with the current proving price and exchange rate.
-6. Add aggregation proving, L1 proof submission, and an operating buffer.
-7. Use the highest credible result from the sample.
-
-The cost estimator reports range-program execution statistics and SP1 gas.
-It does not calculate the full monetary cost of defending a game.
-Aggregation proving and the L1 transaction must be added separately.
-
-One game accepts one challenge, while several games can be challenged at the same time.
-Provision enough challenger liquidity for the expected number of concurrent invalid games.
-Provision enough proving capacity to defend all valid games within `MAX_PROVE_DURATION`.
-
-```text
-challenger liquidity
-  = challenger bond * concurrent challenges
-  + L1 gas reserve
-```
+Confirm that at least one honest challenger can fund the selected bond and L1 gas.
+A bond that is too high can reduce the number of parties able to challenge an invalid proposal.
 
 ## Size the Proposer Bond
 
 The proposer posts a new initial bond for every game that it creates.
-The bond cannot fund the next game while it remains locked in the current game.
-The main sizing constraint is the amount of proposer capital that can remain locked across open games.
-
-Estimate a conservative lock horizon:
+The main sizing constraint is the amount of proposer capital locked across open games.
 
 ```text
 proposal period
@@ -105,64 +67,17 @@ proposer capital
   + L1 gas reserve
 ```
 
-The full lock horizon covers a challenge submitted near the end of the challenge window.
-An unchallenged game usually releases its credit sooner because it does not use the proving window.
-Parent-game dependencies, failed transactions, and delayed claims can extend the observed lock time.
-Use the measured peak number of unclaimed games to refine the estimate after launch.
+The lock horizon covers a challenge submitted near the end of the challenge window.
+Parent-game dependencies, failed transactions, and delayed claims can extend it.
+After launch, use the measured peak number of unclaimed games to refine the estimate.
 
-Choose an initial bond that leaves enough capital for the calculated peak and a safe operating reserve.
-The amount should also make invalid or abandoned proposals costly.
-Permissionless proposing requires extra attention to that deterrence value.
-
-## Example
-
-This example shows the method with illustrative values.
-Measure the inputs for each production deployment.
-
-Assume the following configuration:
-
-- Average L2 block time: 2 seconds.
-- Proposal interval: 1,800 blocks, or 1 hour.
-- Maximum challenge duration: 7 days.
-- Maximum prove duration: 1 day.
-- Dispute game finality delay: 7 days.
-- Initial bond: 0.01 ETH per game.
-- Conservative defense cost: 0.005 ETH per game.
-
-The conservative lock horizon is 15 days before adding an operating buffer.
-An hourly proposal cadence produces about 360 open games during that period.
-The proposer therefore needs about 3.6 ETH for game bonds, plus the concurrency buffer and L1 gas reserve.
-The challenger bond starts near 0.05 ETH under the 10 times rule.
-The operator must then confirm that an honest challenger can fund this amount across the expected concurrency.
+The initial bond should leave enough capital for the calculated peak and an operating reserve.
+It should also make invalid or abandoned proposals costly, especially when proposing is permissionless.
 
 ## Configure and Review Bonds
 
 Set `INITIAL_BOND_WEI` and `CHALLENGER_BOND_WEI` during [contract deployment](./deploy.md#optional-environment-variables).
-Use `cast --to-wei <value> eth` to convert ETH to wei.
+See the [upgrade guide](./upgrade.md) when changing bond configuration after deployment.
 
-Read the current proposer bond from the factory:
-
-```bash
-cast call <FACTORY_ADDRESS> \
-  "initBonds(uint32)(uint256)" <GAME_TYPE> \
-  --rpc-url <L1_RPC>
-```
-
-Read the current game implementation and challenger bond:
-
-```bash
-cast call <FACTORY_ADDRESS> \
-  "gameImpls(uint32)(address)" <GAME_TYPE> \
-  --rpc-url <L1_RPC>
-
-cast call <GAME_IMPLEMENTATION> \
-  "challengerBond()(uint256)" \
-  --rpc-url <L1_RPC>
-```
-
-The factory initial bond can be changed for future games.
-Changing the challenger bond requires a [new game implementation](./upgrade.md).
-Existing games keep the deposits that they received at creation and challenge time.
-
-Recalculate both bonds after changes to workload, proposal interval, data availability mode, program version, proving price, L1 fees, or asset exchange rates.
-Monitor the number of unclaimed games and the available proposer and challenger balances after deployment.
+Review both bonds after changes to workload, proposal interval, data availability mode, program version, proving rate, L1 fees, or asset exchange rates.
+Monitor the number of unclaimed games and the available proposer, challenger, and proving balances.

--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -75,7 +75,7 @@ The deployment script deploys the contracts with the following parameters:
 
 Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 
-See [Bond Economics and Sizing](./bond_economics.md) for the sizing method and liquidity checks for these values.
+See [Bond Economics and Sizing](./bond_economics.md) for bond roles and sizing considerations.
 
 ### Fallback Timeout Mechanism
 

--- a/book/fault_proofs/deploy.md
+++ b/book/fault_proofs/deploy.md
@@ -75,7 +75,7 @@ The deployment script deploys the contracts with the following parameters:
 
 Use `cast --to-wei <value> eth` to convert the value to wei to avoid mistakes.
 
-These values depend on the L2 chain, and the total value secured. Generally, to prevent frivolous challenges, `CHALLENGER_BOND` should be set to at least 10x of the proving cost needed to prove a game.
+See [Bond Economics and Sizing](./bond_economics.md) for the sizing method and liquidity checks for these values.
 
 ### Fallback Timeout Mechanism
 


### PR DESCRIPTION
## Summary

- Add a concise OP Succinct Lite guide for sizing challenger and proposer bonds.
- Explain the 10x starting point, required cost inputs, and concurrent funding needs.
- Link payout, deployment, and upgrade details to their owning guides.

## Motivation

Bond sizing guidance was limited to a single 10x sentence.
The new guide states what the cost estimator provides and which monetary inputs remain operator inputs.

## Validation

- `mdbook build`
- `mdbook-linkcheck --standalone`
- `git diff --check`
