### PR TITLE
fix(contracts): support op-contracts v7 interface

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -132,8 +132,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     AccessManager internal immutable ACCESS_MANAGER;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.0.0
-    string public constant version = "2.0.0";
+    /// @custom:semver 2.1.0
+    string public constant version = "2.1.0";
 
     /// @notice The starting timestamp of the game.
     Timestamp public createdAt;
@@ -590,6 +590,13 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     /// @return rootClaim_ The root claim of the DisputeGame.
     function rootClaim() public pure returns (Claim rootClaim_) {
         rootClaim_ = Claim.wrap(_getArgBytes32(0x14));
+    }
+
+    /// @notice Getter for the root claim for a given L2 chain ID.
+    /// @dev OP Succinct games contain one output root and are not super games.
+    /// @return rootClaim_ The root claim of the DisputeGame.
+    function rootClaimByChainId(uint256) public pure returns (Claim rootClaim_) {
+        rootClaim_ = rootClaim();
     }
 
     /// @notice Getter for the parent hash of the L1 block when the dispute game was created.

--- a/contracts/src/utils/MockPermissionedDisputeGame.sol
+++ b/contracts/src/utils/MockPermissionedDisputeGame.sol
@@ -78,6 +78,10 @@ contract MockPermissionedDisputeGame is Clone, IDisputeGame {
         rootClaim_ = Claim.wrap(_getArgBytes32(0x14));
     }
 
+    function rootClaimByChainId(uint256) public pure returns (Claim rootClaim_) {
+        rootClaim_ = rootClaim();
+    }
+
     function l1Head() public pure returns (Hash l1Head_) {
         l1Head_ = Hash.wrap(_getArgBytes32(0x34));
     }

--- a/contracts/src/utils/MockSystemConfig.sol
+++ b/contracts/src/utils/MockSystemConfig.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import {ISuperchainConfig} from "interfaces/L1/ISuperchainConfig.sol";
 import {SuperchainConfig} from "src/L1/SuperchainConfig.sol";
 
-/// @notice Minimal mock SystemConfig for testing AnchorStateRegistry with v5.0.0
+/// @notice Minimal mock SystemConfig for AnchorStateRegistry tests.
 contract MockSystemConfig {
     ISuperchainConfig private _superchainConfig;
     address private _guardian;

--- a/contracts/src/validity/OPSuccinctDisputeGame.sol
+++ b/contracts/src/validity/OPSuccinctDisputeGame.sol
@@ -33,8 +33,8 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
     bool public wasRespectedGameTypeWhenCreated;
 
     /// @notice Semantic version.
-    /// @custom:semver v4.0.0
-    string public constant version = "v4.0.0";
+    /// @custom:semver v4.1.0
+    string public constant version = "v4.1.0";
 
     constructor(address _l2OutputOracle, IAnchorStateRegistry _anchorStateRegistry) {
         L2_OUTPUT_ORACLE = _l2OutputOracle;
@@ -80,6 +80,13 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
     /// @return The root claim of the DisputeGame.
     function rootClaim() public pure returns (Claim) {
         return Claim.wrap(_getArgBytes32(0x14));
+    }
+
+    /// @notice Getter for the root claim for a given L2 chain ID.
+    /// @dev OP Succinct games contain one output root and are not super games.
+    /// @return rootClaim_ The root claim of the DisputeGame.
+    function rootClaimByChainId(uint256) public pure returns (Claim rootClaim_) {
+        rootClaim_ = rootClaim();
     }
 
     /// @notice Getter for the parent hash of the L1 block when the dispute game was created.

--- a/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
+++ b/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
@@ -222,6 +222,7 @@ contract OPSuccinctFaultDisputeGameTest is Test {
 
         // Check the child game fields.
         assertEq(game.gameType().raw(), gameType.raw());
+        assertEq(game.version(), "2.1.0");
         assertEq(game.rootClaim().raw(), rootClaim.raw());
         assertEq(game.maxChallengeDuration().raw(), maxChallengeDuration.raw());
         assertEq(game.maxProveDuration().raw(), maxProveDuration.raw());
@@ -265,6 +266,10 @@ contract OPSuccinctFaultDisputeGameTest is Test {
         uint256 currentTime = block.timestamp;
         uint256 expectedDeadline = currentTime + maxChallengeDuration.raw();
         assertEq(deadline_.raw(), expectedDeadline);
+    }
+
+    function testRootClaimByChainId() public view {
+        assertEq(game.rootClaimByChainId(block.chainid).raw(), rootClaim.raw());
     }
 
     // =========================================

--- a/contracts/test/validity/OPSuccinctDisputeGame.t.sol
+++ b/contracts/test/validity/OPSuccinctDisputeGame.t.sol
@@ -77,7 +77,7 @@ contract OPSuccinctDisputeGameTest is Test, Utils {
         // Deploy L2OutputOracle using Utils helper functions.
         (l2OutputOracle,) = deployL2OutputOracleWithStandardParams(proposer, address(0), address(this));
 
-        // Deploy anchor state registry for v5.0.0 compatibility.
+        // Deploy the anchor state registry.
         MockSystemConfig mockSystemConfig = new MockSystemConfig(address(this));
         uint256 disputeGameFinalityDelaySeconds = 604800; // 7 days
         Proposal memory startingAnchorRoot = Proposal({root: Hash.wrap(keccak256("genesis")), l2SequenceNumber: 0});
@@ -143,6 +143,7 @@ contract OPSuccinctDisputeGameTest is Test, Utils {
 
         // Check the game fields.
         assertEq(game.gameType().raw(), gameType.raw());
+        assertEq(game.version(), "v4.1.0");
         assertEq(game.gameCreator(), address(l2OutputOracle));
         assertEq(game.rootClaim().raw(), rootClaim);
         assertEq(game.l2SequenceNumber(), l2BlockNumber);
@@ -151,6 +152,10 @@ contract OPSuccinctDisputeGameTest is Test, Utils {
         assertEq(game.configName(), l2OutputOracle.GENESIS_CONFIG_NAME());
         assertEq(keccak256(game.proof()), keccak256(bytes("")));
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    function testRootClaimByChainId() public view {
+        assertEq(game.rootClaimByChainId(block.chainid).raw(), rootClaim);
     }
 
     // =========================================


### PR DESCRIPTION
## Summary

- Update the Optimism smart contract dependency to op-contracts v7.0.0.
- Add `rootClaimByChainId` to the single-chain OP Succinct dispute games.
- Increase the game versions and add focused tests.

## Motivation

op-contracts v7 adds `rootClaimByChainId` to `IDisputeGame`. The dependency update failed to compile without these implementations.

## Validation

- `forge fmt --check src/ test/ script/`
- `forge build --sizes`
- `forge test -vvv`, 62 passed

## Caveats

This PR proves source compatibility. The Katana upgrade batch still needs a fork simulation before activation.