### PR TITLE
fix(contracts): backport op-contracts v7 support

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -19,6 +19,7 @@ remappings = [
     "src/L2/=lib/optimism/packages/contracts-bedrock/src/L2/",
     "src/dispute/=lib/optimism/packages/contracts-bedrock/src/dispute/",
     "src/cannon/=lib/optimism/packages/contracts-bedrock/src/cannon/",
+    "src/universal/=lib/optimism/packages/contracts-bedrock/src/universal/",
     "interfaces/=lib/optimism/packages/contracts-bedrock/interfaces/",
     "@lib-keccak/=lib/lib-keccak/contracts/lib",
 ]

--- a/contracts/script/fp/DeployOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/DeployOPSuccinctFDG.s.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.15;
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 import {stdJson} from "forge-std/StdJson.sol";
-import {Claim, GameType, Hash, OutputRoot, Duration} from "src/dispute/lib/Types.sol";
+import {Claim, GameType, Hash, Proposal, Duration} from "src/dispute/lib/Types.sol";
 import {LibString} from "@solady/utils/LibString.sol";
 
 // Interfaces
@@ -13,17 +13,17 @@ import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
 import {IDisputeGameFactory} from "interfaces/dispute/IDisputeGameFactory.sol";
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
 import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
-import {ISuperchainConfig} from "interfaces/L1/ISuperchainConfig.sol";
-import {IOptimismPortal2} from "interfaces/L1/IOptimismPortal2.sol";
+import {ISystemConfig} from "interfaces/L1/ISystemConfig.sol";
 
 // Contracts
 import {AnchorStateRegistry} from "src/dispute/AnchorStateRegistry.sol";
 import {AccessManager} from "../../src/fp/AccessManager.sol";
-import {SuperchainConfig} from "src/L1/SuperchainConfig.sol";
 import {DisputeGameFactory} from "src/dispute/DisputeGameFactory.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Proxy} from "@optimism/src/universal/Proxy.sol";
+import {ProxyAdmin} from "@optimism/src/universal/ProxyAdmin.sol";
 import {OPSuccinctFaultDisputeGame} from "../../src/fp/OPSuccinctFaultDisputeGame.sol";
 import {SP1MockVerifier} from "@sp1-contracts/src/SP1MockVerifier.sol";
+import {MockSystemConfig} from "../../src/utils/MockSystemConfig.sol";
 
 // Utils
 import {Utils} from "../../test/helpers/Utils.sol";
@@ -76,17 +76,35 @@ contract DeployOPSuccinctFDG is Script, Utils {
 
     function deployContracts(FDGConfig memory config) internal returns (DeployedContracts memory) {
         DisputeGameFactory factory;
+        ProxyAdmin proxyAdmin;
 
         // Check if using existing DGF (for e2e tests where OptimismPortal2 must use the same DGF)
-        if (config.existingDisputeGameFactoryProxy != address(0)) {
+        bool useExistingDgf = config.existingDisputeGameFactoryProxy != address(0);
+
+        if (useExistingDgf) {
             // Use existing DisputeGameFactory - required for e2e tests where
             // OptimismPortal2 is already configured with a specific DGF
             factory = DisputeGameFactory(config.existingDisputeGameFactoryProxy);
             console.log("Using existing DisputeGameFactory:", address(factory));
+
+            // Deploy ProxyAdmin for AnchorStateRegistry (still needed for new components)
+            proxyAdmin = new ProxyAdmin(msg.sender);
+            console.log("ProxyAdmin deployed at:", address(proxyAdmin));
         } else {
-            // Deploy factory proxy.
-            ERC1967Proxy factoryProxy = new ERC1967Proxy(
-                address(new DisputeGameFactory()),
+            // Deploy ProxyAdmin with msg.sender as owner.
+            proxyAdmin = new ProxyAdmin(msg.sender);
+            console.log("ProxyAdmin deployed at:", address(proxyAdmin));
+
+            // Deploy factory implementation.
+            DisputeGameFactory factoryImpl = new DisputeGameFactory();
+
+            // Deploy factory proxy using Optimism Proxy pattern.
+            Proxy factoryProxy = new Proxy(address(proxyAdmin));
+
+            // Initialize the factory through ProxyAdmin.
+            proxyAdmin.upgradeAndCall(
+                payable(address(factoryProxy)),
+                address(factoryImpl),
                 abi.encodeWithSelector(DisputeGameFactory.initialize.selector, msg.sender)
             );
             factory = DisputeGameFactory(address(factoryProxy));
@@ -97,11 +115,12 @@ contract DeployOPSuccinctFDG is Script, Utils {
         // Deploy MockOptimismPortal2 or get OptimismPortal2
         address payable portalAddress = deployOrGetOptimismPortal2(config, gameType);
 
-        OutputRoot memory startingAnchorRoot =
-            OutputRoot({root: Hash.wrap(config.startingRoot), l2BlockNumber: config.startingL2BlockNumber});
+        Proposal memory startingAnchorRoot =
+            Proposal({root: Hash.wrap(config.startingRoot), l2SequenceNumber: config.startingL2BlockNumber});
 
         // Deploy anchor state registry
-        AnchorStateRegistry registry = deployAnchorStateRegistry(config, factory, portalAddress, startingAnchorRoot);
+        AnchorStateRegistry registry =
+            deployAnchorStateRegistry(config, factory, startingAnchorRoot, gameType, proxyAdmin);
 
         // Deploy and configure access manager
         AccessManager accessManager = deployAccessManager(config, address(factory));
@@ -161,8 +180,9 @@ contract DeployOPSuccinctFDG is Script, Utils {
     function deployAnchorStateRegistry(
         FDGConfig memory config,
         DisputeGameFactory factory,
-        address payable portalAddress,
-        OutputRoot memory startingAnchorRoot
+        Proposal memory startingAnchorRoot,
+        GameType gameType,
+        ProxyAdmin proxyAdmin
     ) internal returns (AnchorStateRegistry) {
         // Check if using existing ASR (for e2e tests where games must use the same ASR as OptimismPortal2)
         if (config.existingAnchorStateRegistry != address(0)) {
@@ -171,16 +191,36 @@ contract DeployOPSuccinctFDG is Script, Utils {
             return registry;
         }
 
-        // Deploy the anchor state registry proxy.
-        ERC1967Proxy registryProxy = new ERC1967Proxy(
-            address(new AnchorStateRegistry()),
+        // Use existing SystemConfig or deploy MockSystemConfig for testing
+        address systemConfigAddress;
+        if (config.systemConfigAddress != address(0)) {
+            systemConfigAddress = config.systemConfigAddress;
+            console.log("Using existing SystemConfig:", systemConfigAddress);
+        } else {
+            // Deploy MockSystemConfig for testing
+            // Pass msg.sender as guardian for deployment scripts
+            MockSystemConfig mockSystemConfig = new MockSystemConfig(msg.sender);
+            systemConfigAddress = address(mockSystemConfig);
+            console.log("Deployed MockSystemConfig:", systemConfigAddress);
+        }
+
+        // Deploy the anchor state registry implementation with finality delay
+        AnchorStateRegistry registryImpl = new AnchorStateRegistry(config.disputeGameFinalityDelaySeconds);
+
+        // Deploy the anchor state registry proxy using Optimism Proxy pattern.
+        Proxy registryProxy = new Proxy(address(proxyAdmin));
+
+        // Initialize the registry through ProxyAdmin.
+        proxyAdmin.upgradeAndCall(
+            payable(address(registryProxy)),
+            address(registryImpl),
             abi.encodeCall(
                 AnchorStateRegistry.initialize,
                 (
-                    ISuperchainConfig(address(new SuperchainConfig())),
+                    ISystemConfig(systemConfigAddress),
                     IDisputeGameFactory(address(factory)),
-                    IOptimismPortal2(portalAddress),
-                    startingAnchorRoot
+                    startingAnchorRoot,
+                    gameType
                 )
             )
         );

--- a/contracts/script/fp/UpgradeOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/UpgradeOPSuccinctFDG.s.sol
@@ -73,10 +73,9 @@ contract UpgradeOPSuccinctFDG is Script {
             AccessManager(vm.envAddress("ACCESS_MANAGER"))
         );
 
-        // Generate the calldata for setImplementation.
-        bytes memory calldata_ = abi.encodeWithSelector(
-            DisputeGameFactory.setImplementation.selector, gameType, IDisputeGame(address(newImpl))
-        );
+        // Generate the calldata for setImplementation (using explicit signature for overloaded function).
+        bytes memory calldata_ =
+            abi.encodeWithSignature("setImplementation(uint32,address)", GameType.unwrap(gameType), address(newImpl));
 
         string memory calldataString = string.concat("Upgrade Calldata: ", vm.toString(calldata_));
         console.log(calldataString);

--- a/contracts/script/validity/OPSuccinctDGFDeployer.s.sol
+++ b/contracts/script/validity/OPSuccinctDGFDeployer.s.sol
@@ -11,6 +11,7 @@ import {console} from "forge-std/console.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {GameType, GameTypes} from "src/dispute/lib/Types.sol";
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
+import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
 import {LibString} from "@solady/utils/LibString.sol";
 
 contract OPSuccinctDFGDeployer is Script, Utils {
@@ -31,8 +32,11 @@ contract OPSuccinctDFGDeployer is Script, Utils {
             }
         }
 
+        // Get anchor state registry from environment.
+        IAnchorStateRegistry anchorStateRegistry = IAnchorStateRegistry(vm.envAddress("ANCHOR_STATE_REGISTRY"));
+
         // Initialize the dispute game based on the existing L2OO_ADDRESS.
-        OPSuccinctDisputeGame game = new OPSuccinctDisputeGame(address(l2OutputOracleProxy));
+        OPSuccinctDisputeGame game = new OPSuccinctDisputeGame(address(l2OutputOracleProxy), anchorStateRegistry);
 
         // Deploy the factory implementation
         DisputeGameFactory factoryImpl = new DisputeGameFactory();

--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -12,7 +12,7 @@ import {
     GameType,
     Hash,
     LibClock,
-    OutputRoot,
+    Proposal,
     Timestamp
 } from "src/dispute/lib/Types.sol";
 import {
@@ -132,8 +132,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     AccessManager internal immutable ACCESS_MANAGER;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 2.1.0
+    string public constant version = "2.1.0";
 
     /// @notice The starting timestamp of the game.
     Timestamp public createdAt;
@@ -158,7 +158,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
 
     /// @notice The starting output root of the game that is proven from in case of a challenge.
     /// @dev This should match the claim root of the parent game.
-    OutputRoot public startingOutputRoot;
+    Proposal public startingOutputRoot;
 
     /// @notice A boolean for whether or not the game type was respected when the game was created.
     bool public wasRespectedGameTypeWhenCreated;
@@ -264,8 +264,8 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
                 revert InvalidParentGame();
             }
 
-            startingOutputRoot = OutputRoot({
-                l2BlockNumber: OPSuccinctFaultDisputeGame(address(proxy)).l2BlockNumber(),
+            startingOutputRoot = Proposal({
+                l2SequenceNumber: OPSuccinctFaultDisputeGame(address(proxy)).l2SequenceNumber(),
                 root: Hash.wrap(OPSuccinctFaultDisputeGame(address(proxy)).rootClaim().raw())
             });
 
@@ -275,20 +275,20 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             // INVARIANT: The parent game's L2 block must be ahead of the anchor. This prevents
             // duplicate games (same startingOutputRoot via parent index vs uint32.max) and ensures
             // that after a game type switch, proposals resume from the anchor rather than a stale parent.
-            (, uint256 anchorL2BlockNum) = ANCHOR_STATE_REGISTRY.getAnchorRoot();
-            if (startingOutputRoot.l2BlockNumber <= anchorL2BlockNum) {
+            (, uint256 anchorL2SeqNum) = ANCHOR_STATE_REGISTRY.getAnchorRoot();
+            if (startingOutputRoot.l2SequenceNumber <= anchorL2SeqNum) {
                 revert InvalidParentGame();
             }
         } else {
             // When there is no parent game, start from the current anchor root. This allows
             // resuming from the latest anchor after game type switches (e.g., retirement recovery).
-            (Hash anchorRoot, uint256 anchorL2BlockNum) = ANCHOR_STATE_REGISTRY.getAnchorRoot();
-            startingOutputRoot = OutputRoot({root: anchorRoot, l2BlockNumber: anchorL2BlockNum});
+            (Hash anchorRoot, uint256 anchorL2SeqNum) = ANCHOR_STATE_REGISTRY.getAnchorRoot();
+            startingOutputRoot = Proposal({root: anchorRoot, l2SequenceNumber: anchorL2SeqNum});
         }
 
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
-        if (l2BlockNumber() <= startingOutputRoot.l2BlockNumber) {
+        if (l2SequenceNumber() <= startingOutputRoot.l2SequenceNumber) {
             revert UnexpectedRootClaim(rootClaim());
         }
 
@@ -316,9 +316,15 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             GameType.unwrap(ANCHOR_STATE_REGISTRY.respectedGameType()) == GameType.unwrap(GAME_TYPE);
     }
 
+    /// @notice The L2 sequence number (block number) for which this game is proposing an output root.
+    function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_) {
+        l2SequenceNumber_ = _getArgUint256(0x54);
+    }
+
     /// @notice The L2 block number for which this game is proposing an output root.
+    /// @dev Alias for l2SequenceNumber() for backward compatibility.
     function l2BlockNumber() public pure returns (uint256 l2BlockNumber_) {
-        l2BlockNumber_ = _getArgUint256(0x54);
+        l2BlockNumber_ = l2SequenceNumber();
     }
 
     /// @notice The parent index of the game.
@@ -328,7 +334,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
 
     /// @notice Only the starting block number of the game.
     function startingBlockNumber() external view returns (uint256 startingBlockNumber_) {
-        startingBlockNumber_ = startingOutputRoot.l2BlockNumber;
+        startingBlockNumber_ = startingOutputRoot.l2SequenceNumber;
     }
 
     /// @notice Starting output root of the game.
@@ -382,7 +388,7 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             l1Head: Hash.unwrap(l1Head()),
             l2PreRoot: Hash.unwrap(startingOutputRoot.root),
             claimRoot: rootClaim().raw(),
-            claimBlockNum: l2BlockNumber(),
+            claimBlockNum: l2SequenceNumber(),
             rollupConfigHash: ROLLUP_CONFIG_HASH,
             rangeVkeyCommitment: RANGE_VKEY_COMMITMENT,
             proverAddress: msg.sender
@@ -584,6 +590,13 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
     /// @return rootClaim_ The root claim of the DisputeGame.
     function rootClaim() public pure returns (Claim rootClaim_) {
         rootClaim_ = Claim.wrap(_getArgBytes32(0x14));
+    }
+
+    /// @notice Getter for the root claim for a given L2 chain ID.
+    /// @dev OP Succinct games contain one output root and are not super games.
+    /// @return rootClaim_ The root claim of the DisputeGame.
+    function rootClaimByChainId(uint256) public pure returns (Claim rootClaim_) {
+        rootClaim_ = rootClaim();
     }
 
     /// @notice Getter for the parent hash of the L1 block when the dispute game was created.

--- a/contracts/src/utils/MockPermissionedDisputeGame.sol
+++ b/contracts/src/utils/MockPermissionedDisputeGame.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import {Clone} from "@solady/utils/Clone.sol";
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
 import {IDisputeGameFactory} from "interfaces/dispute/IDisputeGameFactory.sol";
-import {GameStatus, GameType, Claim, Hash, Timestamp, OutputRoot} from "src/dispute/lib/Types.sol";
+import {GameStatus, GameType, Claim, Hash, Timestamp, Proposal} from "src/dispute/lib/Types.sol";
 
 /// @notice Minimal permissioned dispute game used exclusively for tests.
 /// Exposes the legacy `claimData(uint256)` selector to emulate the ABI mismatch
@@ -21,7 +21,7 @@ contract MockPermissionedDisputeGame is Clone, IDisputeGame {
     Timestamp private _createdAt;
     Timestamp private _resolvedAt;
     ClaimData public claimData;
-    OutputRoot private _startingOutputRoot;
+    Proposal private _startingOutputRoot;
 
     constructor(IDisputeGameFactory _disputeGameFactory) {
         DISPUTE_GAME_FACTORY = _disputeGameFactory;
@@ -36,12 +36,12 @@ contract MockPermissionedDisputeGame is Clone, IDisputeGame {
         if (parentIndex() != type(uint32).max) {
             (,, IDisputeGame proxy) = DISPUTE_GAME_FACTORY.gameAtIndex(parentIndex());
 
-            _startingOutputRoot = OutputRoot({
-                l2BlockNumber: MockPermissionedDisputeGame(address(proxy)).l2BlockNumber(),
+            _startingOutputRoot = Proposal({
+                l2SequenceNumber: MockPermissionedDisputeGame(address(proxy)).l2SequenceNumber(),
                 root: Hash.wrap(MockPermissionedDisputeGame(address(proxy)).rootClaim().raw())
             });
         } else {
-            _startingOutputRoot = OutputRoot({l2BlockNumber: 0, root: Hash.wrap(bytes32(0))});
+            _startingOutputRoot = Proposal({l2SequenceNumber: 0, root: Hash.wrap(bytes32(0))});
         }
 
         claimData = ClaimData({parentIndex: parentIndex(), claim: rootClaim()});
@@ -78,12 +78,16 @@ contract MockPermissionedDisputeGame is Clone, IDisputeGame {
         rootClaim_ = Claim.wrap(_getArgBytes32(0x14));
     }
 
+    function rootClaimByChainId(uint256) public pure returns (Claim rootClaim_) {
+        rootClaim_ = rootClaim();
+    }
+
     function l1Head() public pure returns (Hash l1Head_) {
         l1Head_ = Hash.wrap(_getArgBytes32(0x34));
     }
 
-    function l2BlockNumber() external pure returns (uint256 l2BlockNumber_) {
-        l2BlockNumber_ = _getArgUint256(0x54);
+    function l2SequenceNumber() external pure returns (uint256 l2SequenceNumber_) {
+        l2SequenceNumber_ = _getArgUint256(0x54);
     }
 
     function parentIndex() public pure returns (uint32 parentIndex_) {

--- a/contracts/src/utils/MockSystemConfig.sol
+++ b/contracts/src/utils/MockSystemConfig.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {ISuperchainConfig} from "interfaces/L1/ISuperchainConfig.sol";
+import {SuperchainConfig} from "src/L1/SuperchainConfig.sol";
+
+/// @notice Minimal mock SystemConfig for AnchorStateRegistry tests.
+contract MockSystemConfig {
+    ISuperchainConfig private _superchainConfig;
+    address private _guardian;
+
+    constructor(address guardian_) {
+        _superchainConfig = ISuperchainConfig(address(new SuperchainConfig()));
+        _guardian = guardian_;
+    }
+
+    /// @notice Returns whether the system is paused.
+    function paused() external view returns (bool) {
+        return _superchainConfig.paused();
+    }
+
+    /// @notice Returns the SuperchainConfig contract.
+    function superchainConfig() external view returns (ISuperchainConfig) {
+        return _superchainConfig;
+    }
+
+    /// @notice Returns the guardian address.
+    function guardian() external view returns (address) {
+        return _guardian;
+    }
+}

--- a/contracts/src/validity/OPSuccinctDisputeGame.sol
+++ b/contracts/src/validity/OPSuccinctDisputeGame.sol
@@ -5,6 +5,7 @@ import {OPSuccinctL2OutputOracle} from "./OPSuccinctL2OutputOracle.sol";
 import {Clone} from "@solady/utils/Clone.sol";
 import {ISemver} from "interfaces/universal/ISemver.sol";
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
+import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
 import {Claim, GameStatus, GameType, GameTypes, Hash, Timestamp} from "@optimism/src/dispute/lib/Types.sol";
 import {GameNotInProgress, OutOfOrderResolution} from "@optimism/src/dispute/lib/Errors.sol";
 
@@ -15,6 +16,9 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
 
     /// @notice The address of the L2 output oracle proxy contract.
     address internal immutable L2_OUTPUT_ORACLE;
+
+    /// @notice The anchor state registry contract.
+    IAnchorStateRegistry internal immutable ANCHOR_STATE_REGISTRY;
 
     /// @notice The timestamp of the game's global creation.
     Timestamp public createdAt;
@@ -29,11 +33,12 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
     bool public wasRespectedGameTypeWhenCreated;
 
     /// @notice Semantic version.
-    /// @custom:semver v3.0.0
-    string public constant version = "v3.0.0";
+    /// @custom:semver v4.1.0
+    string public constant version = "v4.1.0";
 
-    constructor(address _l2OutputOracle) {
+    constructor(address _l2OutputOracle, IAnchorStateRegistry _anchorStateRegistry) {
         L2_OUTPUT_ORACLE = _l2OutputOracle;
+        ANCHOR_STATE_REGISTRY = _anchorStateRegistry;
     }
 
     ////////////////////////////////////////////////////////////
@@ -48,7 +53,7 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
         OPSuccinctL2OutputOracle oracle = OPSuccinctL2OutputOracle(L2_OUTPUT_ORACLE);
 
         oracle.proposeL2Output(
-            configName(), rootClaim().raw(), l2BlockNumber(), l1BlockNumber(), proof(), proverAddress()
+            configName(), rootClaim().raw(), l2SequenceNumber(), l1BlockNumber(), proof(), proverAddress()
         );
 
         this.resolve();
@@ -77,6 +82,13 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
         return Claim.wrap(_getArgBytes32(0x14));
     }
 
+    /// @notice Getter for the root claim for a given L2 chain ID.
+    /// @dev OP Succinct games contain one output root and are not super games.
+    /// @return rootClaim_ The root claim of the DisputeGame.
+    function rootClaimByChainId(uint256) public pure returns (Claim rootClaim_) {
+        rootClaim_ = rootClaim();
+    }
+
     /// @notice Getter for the parent hash of the L1 block when the dispute game was created.
     /// @dev `clones-with-immutable-args` argument #3
     /// @return The parent hash of the L1 block when the dispute game was created.
@@ -84,9 +96,9 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
         return Hash.wrap(_getArgBytes32(0x34));
     }
 
-    /// @notice The l2BlockNumber of the disputed output root in the `L2OutputOracle`.
-    function l2BlockNumber() public pure returns (uint256 l2BlockNumber_) {
-        l2BlockNumber_ = _getArgUint256(0x54);
+    /// @notice The l2SequenceNumber (block number) of the disputed output root in the `L2OutputOracle`.
+    function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_) {
+        l2SequenceNumber_ = _getArgUint256(0x54);
     }
 
     /// @notice The l2BlockNumber of the disputed output root in the `L2OutputOracle`.
@@ -170,5 +182,11 @@ contract OPSuccinctDisputeGame is ISemver, Clone, IDisputeGame {
     /// @return l2OutputOracle_ The address of the L2OutputOracle.
     function l2OutputOracle() external view returns (address l2OutputOracle_) {
         l2OutputOracle_ = L2_OUTPUT_ORACLE;
+    }
+
+    /// @notice Returns the anchor state registry contract.
+    /// @return registry_ The IAnchorStateRegistry contract instance.
+    function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_) {
+        registry_ = ANCHOR_STATE_REGISTRY;
     }
 }

--- a/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
+++ b/contracts/test/fp/OPSuccinctFaultDisputeGame.t.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.15;
 
 // Testing
 import "forge-std/Test.sol";
+import {Proxy} from "@optimism/src/universal/Proxy.sol";
+import {ProxyAdmin} from "@optimism/src/universal/ProxyAdmin.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 // Libraries
-import {Claim, Duration, GameStatus, GameType, Hash, OutputRoot, Timestamp} from "src/dispute/lib/Types.sol";
+import {Claim, Duration, GameStatus, GameType, Hash, Proposal, Timestamp} from "src/dispute/lib/Types.sol";
 import {
     BadAuth,
     IncorrectBondAmount,
@@ -31,19 +33,18 @@ import {DisputeGameFactory} from "src/dispute/DisputeGameFactory.sol";
 import {OPSuccinctFaultDisputeGame} from "src/fp/OPSuccinctFaultDisputeGame.sol";
 import {SP1MockVerifier} from "@sp1-contracts/src/SP1MockVerifier.sol";
 import {AnchorStateRegistry} from "src/dispute/AnchorStateRegistry.sol";
-import {SuperchainConfig} from "src/L1/SuperchainConfig.sol";
 import {AccessManager} from "src/fp/AccessManager.sol";
 
 // Interfaces
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
 import {IDisputeGameFactory} from "interfaces/dispute/IDisputeGameFactory.sol";
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
-import {ISuperchainConfig} from "interfaces/L1/ISuperchainConfig.sol";
-import {IOptimismPortal2} from "interfaces/L1/IOptimismPortal2.sol";
+import {ISystemConfig} from "interfaces/L1/ISystemConfig.sol";
 import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
 
 // Utils
 import {MockOptimismPortal2} from "../../src/utils/MockOptimismPortal2.sol";
+import {MockSystemConfig} from "../../src/utils/MockSystemConfig.sol";
 
 contract OPSuccinctFaultDisputeGameTest is Test {
     // Event definitions matching those in OPSuccinctFaultDisputeGame.
@@ -52,7 +53,8 @@ contract OPSuccinctFaultDisputeGameTest is Test {
     event Resolved(GameStatus indexed status);
 
     DisputeGameFactory factory;
-    ERC1967Proxy factoryProxy;
+    Proxy factoryProxy;
+    ProxyAdmin proxyAdmin;
 
     OPSuccinctFaultDisputeGame gameImpl;
     OPSuccinctFaultDisputeGame parentGame;
@@ -83,12 +85,20 @@ contract OPSuccinctFaultDisputeGameTest is Test {
     OPSuccinctFaultDisputeGame separateParentGame;
 
     function setUp() public {
+        // Deploy ProxyAdmin with this test contract as owner.
+        proxyAdmin = new ProxyAdmin(address(this));
+
         // Deploy the implementation contract for DisputeGameFactory.
         DisputeGameFactory factoryImpl = new DisputeGameFactory();
 
-        // Deploy a proxy pointing to the factory implementation.
-        factoryProxy = new ERC1967Proxy(
-            address(factoryImpl), abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
+        // Deploy an Optimism Proxy pointing to ProxyAdmin.
+        factoryProxy = new Proxy(address(proxyAdmin));
+
+        // Initialize the factory through ProxyAdmin.
+        proxyAdmin.upgradeAndCall(
+            payable(address(factoryProxy)),
+            address(factoryImpl),
+            abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
         );
 
         // Cast the proxy to the factory contract.
@@ -98,23 +108,27 @@ contract OPSuccinctFaultDisputeGameTest is Test {
         SP1MockVerifier sp1Verifier = new SP1MockVerifier();
 
         // Create an anchor state registry.
-        SuperchainConfig superchainConfig = new SuperchainConfig();
+        // Pass address(this) as guardian so the test contract can call guardian-restricted functions.
+        MockSystemConfig mockSystemConfig = new MockSystemConfig(address(this));
         portal = new MockOptimismPortal2(gameType, disputeGameFinalityDelaySeconds);
-        OutputRoot memory startingAnchorRoot = OutputRoot({root: Hash.wrap(keccak256("genesis")), l2BlockNumber: 0});
+        Proposal memory startingAnchorRoot = Proposal({root: Hash.wrap(keccak256("genesis")), l2SequenceNumber: 0});
 
-        ERC1967Proxy proxy = new ERC1967Proxy(
-            address(new AnchorStateRegistry()),
+        AnchorStateRegistry registryImpl = new AnchorStateRegistry(disputeGameFinalityDelaySeconds);
+        Proxy registryProxy = new Proxy(address(proxyAdmin));
+        proxyAdmin.upgradeAndCall(
+            payable(address(registryProxy)),
+            address(registryImpl),
             abi.encodeCall(
                 AnchorStateRegistry.initialize,
                 (
-                    ISuperchainConfig(address(superchainConfig)),
+                    ISystemConfig(address(mockSystemConfig)),
                     IDisputeGameFactory(address(factory)),
-                    IOptimismPortal2(payable(address(portal))),
-                    startingAnchorRoot
+                    startingAnchorRoot,
+                    gameType
                 )
             )
         );
-        anchorStateRegistry = AnchorStateRegistry(address(proxy));
+        anchorStateRegistry = AnchorStateRegistry(address(registryProxy));
 
         // Create a new access manager with a 2 week permissionless timeout.
         accessManager = new AccessManager(2 weeks, IDisputeGameFactory(address(factory)));
@@ -208,10 +222,11 @@ contract OPSuccinctFaultDisputeGameTest is Test {
 
         // Check the child game fields.
         assertEq(game.gameType().raw(), gameType.raw());
+        assertEq(game.version(), "2.1.0");
         assertEq(game.rootClaim().raw(), rootClaim.raw());
         assertEq(game.maxChallengeDuration().raw(), maxChallengeDuration.raw());
         assertEq(game.maxProveDuration().raw(), maxProveDuration.raw());
-        assertEq(game.l2BlockNumber(), l2BlockNumber);
+        assertEq(game.l2SequenceNumber(), l2BlockNumber);
         assertEq(game.createdAt().raw(), block.timestamp);
         assertEq(game.extraData(), abi.encodePacked(l2BlockNumber, parentIndex));
         assertEq(game.parentIndex(), parentIndex);
@@ -251,6 +266,10 @@ contract OPSuccinctFaultDisputeGameTest is Test {
         uint256 currentTime = block.timestamp;
         uint256 expectedDeadline = currentTime + maxChallengeDuration.raw();
         assertEq(deadline_.raw(), expectedDeadline);
+    }
+
+    function testRootClaimByChainId() public view {
+        assertEq(game.rootClaimByChainId(block.chainid).raw(), rootClaim.raw());
     }
 
     // =========================================
@@ -584,7 +603,9 @@ contract OPSuccinctFaultDisputeGameTest is Test {
     // Test: Cannot create a game with a blacklisted parent game
     // =========================================
     function testParentGameNotValid() public {
-        portal.blacklistDisputeGame(IDisputeGame(address(game)));
+        // In v5.0.0, blacklisting is done through AnchorStateRegistry (requires guardian).
+        // This test contract is the guardian via MockSystemConfig.
+        anchorStateRegistry.blacklistDisputeGame(IDisputeGame(address(game)));
 
         vm.startPrank(proposer);
         vm.deal(proposer, 1 ether);
@@ -596,28 +617,29 @@ contract OPSuccinctFaultDisputeGameTest is Test {
     }
 
     // =========================================
-    // Test: Cannot create a game with a parent game that is not respected
+    // Test: Cannot create a game with a retired parent game
+    // Note: In v5.0.0, "respected" status is based on wasRespectedGameTypeWhenCreated flag,
+    // not current game type. The retirement mechanism is used to invalidate old games.
     // =========================================
-    function testParentGameNotRespected() public {
-        // Create a game that is not respected at index 2.
+    function testParentGameRetired() public {
+        // Create a game at index 2.
         vm.startPrank(proposer);
         vm.deal(proposer, 1 ether);
         factory.create{value: 1 ether}(
-            gameType, Claim.wrap(keccak256("not-respected-parent-game")), abi.encodePacked(uint256(3000), uint32(1))
+            gameType, Claim.wrap(keccak256("will-be-retired-parent")), abi.encodePacked(uint256(3000), uint32(1))
         );
         vm.stopPrank();
 
-        // Set the respected game type to a different game type.
-        portal.setRespectedGameType(GameType.wrap(43));
+        // Update the retirement timestamp (guardian function) to retire all existing games.
+        // This test contract is the guardian via MockSystemConfig.
+        anchorStateRegistry.updateRetirementTimestamp();
 
-        // Try to create a game with a parent game that is not respected.
+        // Try to create a game with a retired parent game.
         vm.startPrank(proposer);
         vm.deal(proposer, 1 ether);
         vm.expectRevert(InvalidParentGame.selector);
         factory.create{value: 1 ether}(
-            gameType,
-            Claim.wrap(keccak256("child-with-not-respected-parent")),
-            abi.encodePacked(uint256(4000), uint32(2))
+            gameType, Claim.wrap(keccak256("child-with-retired-parent")), abi.encodePacked(uint256(4000), uint32(2))
         );
         vm.stopPrank();
     }
@@ -698,9 +720,17 @@ contract OPSuccinctFaultDisputeGameTest is Test {
         // Deploy the implementation contract for new DisputeGameFactory.
         DisputeGameFactory newFactoryImpl = new DisputeGameFactory();
 
-        // Deploy a proxy pointing to the new factory implementation.
-        ERC1967Proxy newFactoryProxy = new ERC1967Proxy(
-            address(newFactoryImpl), abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
+        // Deploy a new ProxyAdmin for this factory.
+        ProxyAdmin newProxyAdmin = new ProxyAdmin(address(this));
+
+        // Deploy an Optimism Proxy pointing to the new ProxyAdmin.
+        Proxy newFactoryProxy = new Proxy(address(newProxyAdmin));
+
+        // Initialize the new factory through ProxyAdmin.
+        newProxyAdmin.upgradeAndCall(
+            payable(address(newFactoryProxy)),
+            address(newFactoryImpl),
+            abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
         );
 
         // Cast the proxy to the DisputeGameFactory interface.

--- a/contracts/test/helpers/JSONDecoder.sol
+++ b/contracts/test/helpers/JSONDecoder.sol
@@ -51,6 +51,7 @@ contract JSONDecoder {
         bytes32 rollupConfigHash;
         uint256 startingL2BlockNumber;
         bytes32 startingRoot;
+        address systemConfigAddress;
         bool useSp1MockVerifier;
         address verifierAddress;
     }

--- a/contracts/test/validity/OPSuccinctDisputeGame.t.sol
+++ b/contracts/test/validity/OPSuccinctDisputeGame.t.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.15;
 
 // Testing
 import "forge-std/Test.sol";
+import {Proxy} from "@optimism/src/universal/Proxy.sol";
+import {ProxyAdmin} from "@optimism/src/universal/ProxyAdmin.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 // Libraries
-import {Claim, GameStatus, GameType, GameTypes, Hash, OutputRoot, Timestamp} from "src/dispute/lib/Types.sol";
+import {Claim, GameStatus, GameType, GameTypes, Hash, Proposal, Timestamp} from "src/dispute/lib/Types.sol";
 import {AlreadyInitialized, GameNotInProgress, NoCreditToClaim, GameNotFinalized} from "src/dispute/lib/Errors.sol";
 import {Utils} from "../helpers/Utils.sol";
 
@@ -16,8 +18,6 @@ import {OPSuccinctDisputeGame} from "src/validity/OPSuccinctDisputeGame.sol";
 import {OPSuccinctL2OutputOracle} from "src/validity/OPSuccinctL2OutputOracle.sol";
 import {AnchorStateRegistry} from "src/dispute/AnchorStateRegistry.sol";
 import {SuperchainConfig} from "src/L1/SuperchainConfig.sol";
-import {Proxy} from "@optimism/src/universal/Proxy.sol";
-
 // Interfaces
 import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
 import {IDisputeGameFactory} from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -27,18 +27,22 @@ import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol"
 
 // Utils
 import {MockOptimismPortal2} from "../../src/utils/MockOptimismPortal2.sol";
+import {MockSystemConfig} from "../../src/utils/MockSystemConfig.sol";
+import {ISystemConfig} from "interfaces/L1/ISystemConfig.sol";
 
 contract OPSuccinctDisputeGameTest is Test, Utils {
     // Event definitions matching those in OPSuccinctDisputeGame.
     event Resolved(GameStatus indexed status);
 
     DisputeGameFactory factory;
-    ERC1967Proxy factoryProxy;
+    Proxy factoryProxy;
+    ProxyAdmin proxyAdmin;
 
     OPSuccinctDisputeGame gameImpl;
     OPSuccinctDisputeGame game;
 
     OPSuccinctL2OutputOracle l2OutputOracle;
+    AnchorStateRegistry anchorStateRegistry;
 
     address proposer = address(0x123);
 
@@ -51,12 +55,20 @@ contract OPSuccinctDisputeGameTest is Test, Utils {
     uint256 l1BlockNumber = 1000;
 
     function setUp() public {
+        // Deploy ProxyAdmin with this test contract as owner.
+        proxyAdmin = new ProxyAdmin(address(this));
+
         // Deploy the implementation contract for DisputeGameFactory.
         DisputeGameFactory factoryImpl = new DisputeGameFactory();
 
-        // Deploy a proxy pointing to the factory implementation.
-        factoryProxy = new ERC1967Proxy(
-            address(factoryImpl), abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
+        // Deploy an Optimism Proxy pointing to ProxyAdmin.
+        factoryProxy = new Proxy(address(proxyAdmin));
+
+        // Initialize the factory through ProxyAdmin.
+        proxyAdmin.upgradeAndCall(
+            payable(address(factoryProxy)),
+            address(factoryImpl),
+            abi.encodeWithSelector(DisputeGameFactory.initialize.selector, address(this))
         );
 
         // Cast the proxy to the factory contract.
@@ -65,8 +77,31 @@ contract OPSuccinctDisputeGameTest is Test, Utils {
         // Deploy L2OutputOracle using Utils helper functions.
         (l2OutputOracle,) = deployL2OutputOracleWithStandardParams(proposer, address(0), address(this));
 
+        // Deploy the anchor state registry.
+        MockSystemConfig mockSystemConfig = new MockSystemConfig(address(this));
+        uint256 disputeGameFinalityDelaySeconds = 604800; // 7 days
+        Proposal memory startingAnchorRoot = Proposal({root: Hash.wrap(keccak256("genesis")), l2SequenceNumber: 0});
+
+        AnchorStateRegistry registryImpl = new AnchorStateRegistry(disputeGameFinalityDelaySeconds);
+        Proxy registryProxy = new Proxy(address(proxyAdmin));
+        proxyAdmin.upgradeAndCall(
+            payable(address(registryProxy)),
+            address(registryImpl),
+            abi.encodeCall(
+                AnchorStateRegistry.initialize,
+                (
+                    ISystemConfig(address(mockSystemConfig)),
+                    IDisputeGameFactory(address(factory)),
+                    startingAnchorRoot,
+                    gameType
+                )
+            )
+        );
+        anchorStateRegistry = AnchorStateRegistry(address(registryProxy));
+
         // Deploy the implementation of OPSuccinctDisputeGame.
-        gameImpl = new OPSuccinctDisputeGame(address(l2OutputOracle));
+        gameImpl =
+            new OPSuccinctDisputeGame(address(l2OutputOracle), IAnchorStateRegistry(address(anchorStateRegistry)));
 
         // Register our reference implementation under the specified gameType.
         factory.setImplementation(gameType, IDisputeGame(address(gameImpl)));
@@ -108,14 +143,19 @@ contract OPSuccinctDisputeGameTest is Test, Utils {
 
         // Check the game fields.
         assertEq(game.gameType().raw(), gameType.raw());
+        assertEq(game.version(), "v4.1.0");
         assertEq(game.gameCreator(), address(l2OutputOracle));
         assertEq(game.rootClaim().raw(), rootClaim);
-        assertEq(game.l2BlockNumber(), l2BlockNumber);
+        assertEq(game.l2SequenceNumber(), l2BlockNumber);
         assertEq(game.l1BlockNumber(), l1BlockNumber);
         assertEq(game.proverAddress(), proposer);
         assertEq(game.configName(), l2OutputOracle.GENESIS_CONFIG_NAME());
         assertEq(keccak256(game.proof()), keccak256(bytes("")));
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    function testRootClaimByChainId() public view {
+        assertEq(game.rootClaimByChainId(block.chainid).raw(), rootClaim);
     }
 
     // =========================================

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -402,6 +402,7 @@ pub struct FaultDisputeGameConfig {
     pub rollup_config_hash: String,
     pub starting_l2_block_number: u64,
     pub starting_root: String,
+    pub system_config_address: String,
     pub use_sp1_mock_verifier: bool,
     pub verifier_address: String,
 }

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -49,7 +49,7 @@ sol! {
     #[allow(missing_docs)]
     #[sol(rpc)]
     interface IFaultDisputeGame {
-        function l2BlockNumber() external view returns (uint256 l2BlockNumber_);
+        function l2SequenceNumber() external view returns (uint256 l2SequenceNumber_);
     }
 
     #[sol(rpc)]
@@ -60,7 +60,11 @@ sol! {
         /// @notice Getter for the creator of the dispute game.
         function gameCreator() public pure returns (address creator_);
 
+        /// @notice The L2 sequence number (block number) for which this game is proposing an output root.
+        function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_);
+
         /// @notice The L2 block number for which this game is proposing an output root.
+        /// @dev Alias for l2SequenceNumber() for backward compatibility.
         function l2BlockNumber() public pure returns (uint256 l2BlockNumber_);
 
         /// @notice Only the starting block number of the game.

--- a/fault-proof/tests/common/env.rs
+++ b/fault-proof/tests/common/env.rs
@@ -135,6 +135,7 @@ pub fn test_config(
         rollup_config_hash: rollup_config_hash.to_string(),
         starting_l2_block_number,
         starting_root,
+        system_config_address: Address::ZERO.to_string(),
         use_sp1_mock_verifier: true,
         verifier_address: Address::ZERO.to_string(),
     }
@@ -380,20 +381,40 @@ impl TestEnvironment {
             DisputeGameFactory::setInitBondCall { _gameType: game_type, _initBond: init_bond };
         self.send_factory_tx(set_init_call.abi_encode(), None).await?;
 
-        let set_impl_call =
-            DisputeGameFactory::setImplementationCall { _gameType: game_type, _impl: legacy_impl };
+        let set_impl_call = DisputeGameFactory::setImplementation_0Call {
+            _gameType: game_type,
+            _impl: legacy_impl,
+        };
         self.send_factory_tx(set_impl_call.abi_encode(), None).await?;
 
         info!("✓ Setup legacy game type {game_type} with implementation at {legacy_impl}");
         Ok(legacy_impl)
     }
 
-    /// Set the respected game type on the OptimismPortal2.
+    /// Set the respected game type on the AnchorStateRegistry.
+    /// In v5.0.0, respected game type is stored in AnchorStateRegistry, not OptimismPortal2.
     pub async fn set_respected_game_type(&self, game_type: u32) -> Result<()> {
-        let set_type_call = MockOptimismPortal2::setRespectedGameTypeCall { _gameType: game_type };
-        self.send_portal_tx(set_type_call.abi_encode(), None).await?;
+        let set_type_call = AnchorStateRegistry::setRespectedGameTypeCall { _gameType: game_type };
+        self.send_anchor_state_registry_tx(set_type_call.abi_encode(), None).await?;
         info!("✓ Set respected game type to {game_type}");
         Ok(())
+    }
+
+    pub async fn send_anchor_state_registry_tx(
+        &self,
+        call: Vec<u8>,
+        value: Option<Uint<256, 4>>,
+    ) -> Result<()> {
+        let proposer_signer =
+            SignerLock::new(Signer::new_local_signer(self.private_keys.proposer)?);
+        send_contract_transaction(
+            &proposer_signer,
+            &self.rpc_config.l1_rpc,
+            self.deployed.anchor_state_registry,
+            Bytes::from(call),
+            value,
+        )
+        .await
     }
 
     pub async fn send_factory_tx(&self, call: Vec<u8>, value: Option<Uint<256, 4>>) -> Result<()> {
@@ -473,10 +494,11 @@ impl TestEnvironment {
 
     pub async fn mock_optimism_portal2(
         &self,
-        anchor_registry: AnchorStateRegistryInstance<impl alloy_provider::Provider + Clone>,
     ) -> Result<MockOptimismPortal2Instance<impl alloy_provider::Provider + Clone>> {
         let provider = self.provider_with_role(Role::Proposer)?;
-        let portal_addr = anchor_registry.portal().call().await?;
+        // In v5.0.0, AnchorStateRegistry no longer has a portal() method.
+        // Use the portal address from deployed contracts instead.
+        let portal_addr = self.deployed.portal;
         let portal = MockOptimismPortal2::new(portal_addr, provider);
         Ok(portal)
     }

--- a/fault-proof/tests/integration.rs
+++ b/fault-proof/tests/integration.rs
@@ -548,7 +548,7 @@ mod integration {
         if is_retired {
             let parent_created_at = parent_game.createdAt().call().await?;
 
-            let portal = env.mock_optimism_portal2(anchor_registry).await?;
+            let portal = env.mock_optimism_portal2().await?;
 
             let respected_game_type_updated_at = portal.respectedGameTypeUpdatedAt().call().await?;
 

--- a/scripts/utils/bin/fetch_fault_dispute_game_config.rs
+++ b/scripts/utils/bin/fetch_fault_dispute_game_config.rs
@@ -53,6 +53,9 @@ use serde_json::Value;
 /// ## Contract Configuration
 /// - `OPTIMISM_PORTAL2_ADDRESS`: Address of the OptimismPortal2 contract. If not provided or set to
 ///   zero address, a MockOptimismPortal2 will be deployed (default: zero address)
+/// - `SYSTEM_CONFIG_ADDRESS`: Address of the SystemConfig contract. If not provided, it is
+///   auto-derived from the rollup config. For testing, if set to zero address, a MockSystemConfig
+///   will be deployed (default: derived from rollup config)
 ///
 /// ## Starting State Configuration
 /// - `STARTING_L2_BLOCK_NUMBER`: L2 block number to use as the starting point for the dispute game.
@@ -148,6 +151,18 @@ async fn update_fdg_config() -> Result<()> {
             "0x0000000000000000000000000000000000000000".to_string()
         });
 
+    // SystemConfig configuration - derive from rollup config by default.
+    // For production deployments, this is required for proper guardian functionality.
+    // For testing, if zero address, a MockSystemConfig will be deployed.
+    let rollup_config =
+        data_fetcher.rollup_config.as_ref().ok_or(anyhow::anyhow!("Rollup config not found"))?;
+
+    let system_config_address = env::var("SYSTEM_CONFIG_ADDRESS").unwrap_or_else(|_| {
+        // Default to the address from rollup config
+        format!("{:?}", rollup_config.l1_system_config_address)
+    });
+    log::info!("Using SystemConfig address: {system_config_address}");
+
     // Get starting block number - use `latest finalized - dispute game finality delay` if
     // `STARTING_L2_BLOCK_NUMBER` is unset. The default is rooted at the literal L2 finalized
     // block, *independent of `L1_BLOCK_TAG`*. Bootstrap config (which ends up baked into a
@@ -160,11 +175,7 @@ async fn update_fdg_config() -> Result<()> {
             let finalized_l2_header = data_fetcher.get_l2_header(BlockId::finalized()).await?;
             let finalized_l2_block = finalized_l2_header.number;
 
-            let block_time = &data_fetcher
-                .rollup_config
-                .as_ref()
-                .ok_or(anyhow::anyhow!("Rollup config not found"))?
-                .block_time;
+            let block_time = &rollup_config.block_time;
 
             let num_blocks_for_finality = dispute_game_finality_delay_seconds / block_time;
             let search_start = finalized_l2_block.saturating_sub(num_blocks_for_finality);
@@ -234,6 +245,7 @@ async fn update_fdg_config() -> Result<()> {
         rollup_config_hash: shared_config.rollup_config_hash,
         starting_l2_block_number,
         starting_root: starting_output_root,
+        system_config_address,
         use_sp1_mock_verifier: shared_config.use_sp1_mock_verifier,
         verifier_address: shared_config.verifier_address,
     };


### PR DESCRIPTION
## Summary

- Update op-contracts from v3.0.0 to v7.0.0 on `release/v3.x`.
- Backport the required dispute-game and AnchorStateRegistry interface changes.
- Add `rootClaimByChainId` and regression tests.
- Preserve `l2BlockNumber` for older deployed games.

## Motivation

Karst requires op-contracts v7. A direct dependency update does not compile on `release/v3.x`.

## Validation

- `FOUNDRY_PROFILE=ci forge fmt --check src/ test/ script/`
- `FOUNDRY_PROFILE=ci forge build --sizes`
- `FOUNDRY_PROFILE=ci forge test -vvv` (61 passed)
- `cargo fmt --all -- --check`
- Not completed locally: Rust check, clippy, and tests. The build host ran out of disk space before project compilation.

## Notes

This backports #962 plus the required v3-to-v5 interface migration.
It proves source compatibility only. Katana upgrade simulation remains separate.