### PR TITLE
ci: validate SP1 version before Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,6 +27,21 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+      - name: Check Docker SP1 version
+        run: |
+          SP1_VERSION=$(grep 'sp1-sdk' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          if [ -z "$SP1_VERSION" ]; then
+            echo "::error::Could not read the SP1 SDK version from Cargo.toml"
+            exit 1
+          fi
+
+          MISMATCHES=$(grep -rn 'sp1up -v' --include='Dockerfile*' | grep -vF "$SP1_VERSION" || true)
+          if [ -n "$MISMATCHES" ]; then
+            echo "::error::Dockerfile SP1 versions must match Cargo.toml ($SP1_VERSION):"
+            echo "$MISMATCHES"
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary

- Check that every Dockerfile uses the SP1 SDK version from `Cargo.toml`.
- Stop the Docker workflow before image publication when a version differs.

## Motivation

The existing lint check runs separately from Docker publication.
This check applies the version rule in the publication workflow.

## Validation

- The check passes with the current Dockerfiles.
- The check fails when a Dockerfile uses another SP1 version.
- The workflow YAML parses successfully.