### PR TITLE
ci(v3): validate SP1 version before Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,6 +27,21 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+      - name: Check Docker SP1 version
+        run: |
+          SP1_VERSION=$(grep 'sp1-sdk' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          if [ -z "$SP1_VERSION" ]; then
+            echo "::error::Could not read the SP1 SDK version from Cargo.toml"
+            exit 1
+          fi
+
+          MISMATCHES=$(grep -rn 'sp1up -v' --include='Dockerfile*' | grep -vF "$SP1_VERSION" || true)
+          if [ -n "$MISMATCHES" ]; then
+            echo "::error::Dockerfile SP1 versions must match Cargo.toml ($SP1_VERSION):"
+            echo "$MISMATCHES"
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
           SP1_VERSION=$(grep 'sp1-sdk' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "Expected SP1 version from Cargo.toml: $SP1_VERSION"
           MISMATCHES=$(grep -rn 'sp1up -v' --include='Dockerfile*' | grep -v "$SP1_VERSION" || true)
-          MISMATCHES+=$(grep -rn 'sp1up -v' .github/workflows/ --exclude='lint.yml' | grep -v "$SP1_VERSION" || true)
+          MISMATCHES+=$(grep -rn 'sp1up -v' .github/workflows/ --exclude='lint.yml' --exclude='docker-build.yml' | grep -v "$SP1_VERSION" || true)
           MISMATCHES+=$(grep -n -- '--tag v' justfile | grep -v "$SP1_VERSION" || true)
           if [ -n "$MISMATCHES" ]; then
             echo "::error::SP1 version mismatch found. Expected $SP1_VERSION (from Cargo.toml):"


### PR DESCRIPTION
## Summary

- Check Dockerfile SP1 versions before the Docker workflow publishes images.
- Exclude the Docker validator from the existing workflow version scan.

## Motivation

The v3.x Docker workflow publishes images independently from lint.
The added check stops publication when a Dockerfile version differs from `Cargo.toml`.
The lint exclusion prevents the scanner from treating the Docker validator code as a version pin.

## Validation

- The Docker check passes on `release/v3.x` with SP1 `6.4.0`.
- The old workflow scan reproduces one false match.
- The updated workflow scan reports no mismatches.
- Both workflow files parse as YAML.
