### PR TITLE
ci: fix SP1 version consistency check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           filters: |
             code:
-              - '.github/workflows/lint.yml'
+              - '.github/workflows/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'justfile'
@@ -59,9 +59,9 @@ jobs:
         run: |
           SP1_VERSION=$(grep 'sp1-sdk' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "Expected SP1 version from Cargo.toml: $SP1_VERSION"
-          MISMATCHES=$(grep -rn 'sp1up -v' --include='Dockerfile*' | grep -v "$SP1_VERSION" || true)
-          MISMATCHES+=$(grep -rn 'sp1up -v' .github/workflows/ --exclude='lint.yml' | grep -v "$SP1_VERSION" || true)
-          MISMATCHES+=$(grep -n -- '--tag v' justfile | grep -v "$SP1_VERSION" || true)
+          MISMATCHES=$(grep -rnE 'sp1up -v[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' --include='Dockerfile*' | grep -vF "$SP1_VERSION" || true)
+          MISMATCHES+=$(grep -rnE 'sp1up -v[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/ | grep -vF "$SP1_VERSION" || true)
+          MISMATCHES+=$(grep -n -- '--tag v' justfile | grep -vF "$SP1_VERSION" || true)
           if [ -n "$MISMATCHES" ]; then
             echo "::error::SP1 version mismatch found. Expected $SP1_VERSION (from Cargo.toml):"
             echo "$MISMATCHES"


### PR DESCRIPTION
## Summary

- run the lint workflow when any GitHub Actions workflow changes
- match only versioned `sp1up` commands so the check does not match its own implementation
- compare versions as fixed strings

## Testing

- current SP1 `6.4.0` configuration passes the consistency check
- a simulated `6.4.1` workflow command is detected as a mismatch
- `cargo check --all-targets --all-features --tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features`