### PR TITLE
ci: pin Foundry toolchains

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: nightly-d592b3e0f142d694c3be539702704a4a73238773
     - run: rustup toolchain install stable --profile minimal
     - name: Install protobuf compiler
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Show Forge version
         working-directory: contracts/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-d592b3e0f142d694c3be539702704a4a73238773
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

- Pin the Foundry revision used by Rust binding generation.
- Pin contract formatting and tests to Foundry v1.7.1.
- Prevent upstream Foundry releases from changing CI behavior without a repository change.

## Testing

- `cargo check --all-targets --all-features --tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- `forge fmt --check src/ test/ script/`
- `forge build --sizes`
- `forge test -vvv` (61 local tests passed; one RPC-backed test requires CI configuration)
- `just tests` (all executed local tests passed except one integration test requiring repository RPC configuration)