### PR TITLE
ci(v3): pin Foundry toolchains

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: nightly-d592b3e0f142d694c3be539702704a4a73238773
     - run: rustup toolchain install stable --profile minimal
     - name: Install protobuf compiler
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Show Forge version
         working-directory: contracts/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-d592b3e0f142d694c3be539702704a4a73238773
       
       - name: Run cargo check
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Summary

- Pin the Foundry revision used for Rust binding generation.
- Pin the Foundry release used for smart contract tests.

## Motivation

Floating Foundry channels can change generated bindings and test behavior without a repository change.
These pins keep the release branch reproducible.

## Validation

- Cargo check, formatting, and Clippy passed with the pinned binding toolchain.
- Forge formatting and build passed with Foundry v1.7.1.
- 58 of 59 local Forge tests passed. The remaining test requires the CI L1 RPC secret.
- The optimized Cargo suite reached its RPC-dependent integration test. Local RPC configuration was not available.
