### PR TITLE
fix(signer): price L1 transactions with a floor and escalate stalled ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8067,6 +8067,7 @@ dependencies = [
  "op-succinct-host-utils",
  "rustls 0.23.37",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/utils/signer/Cargo.toml
+++ b/utils/signer/Cargo.toml
@@ -20,6 +20,7 @@ alloy-transport-http.workspace = true
 
 # general
 anyhow.workspace = true
+tracing.workspace = true
 tokio.workspace = true
 rustls = { version = "0.23", default-features = false, features = [
     "std",

--- a/utils/signer/src/lib.rs
+++ b/utils/signer/src/lib.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr, sync::Arc};
 use alloy_consensus::TxEnvelope;
 use alloy_eips::Decodable2718;
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, TxKind};
+use alloy_primitives::{Address, Bytes, TxHash, TxKind};
 use alloy_provider::{Provider, ProviderBuilder, Web3Signer};
 use alloy_rpc_types_eth::{TransactionReceipt, TransactionRequest};
 use alloy_signer::Signer as AlloySigner;
@@ -18,6 +18,148 @@ use tokio::{sync::Mutex, time::Duration};
 
 pub const NUM_CONFIRMATIONS: u64 = 3;
 pub const TIMEOUT_SECONDS: u64 = 60;
+
+const WEI_PER_GWEI: u128 = 1_000_000_000;
+
+/// Lower bound on `maxFeePerGas`, in gwei.
+///
+/// Automatic fee estimation derives `maxFeePerGas` from the current base fee, so when the network
+/// is cheap it produces a correspondingly small value. Base fee can rise 12.5% per block, and the
+/// smaller the starting price the fewer blocks it takes to overtake an in-flight transaction --
+/// after which that transaction can never be mined, and nonce ordering blocks every later
+/// transaction from the same account behind it.
+///
+/// The transactions this signer sends are small (a checkpoint is ~46k gas), so a floor at this
+/// level costs a negligible amount per transaction and removes that failure mode.
+pub const DEFAULT_FEE_FLOOR_GWEI: u128 = 3;
+
+/// Multiplier applied to the current gas price when computing `maxFeePerGas`.
+///
+/// Base fee rises at most 12.5% per block, so a 2x buffer is exhausted after ~6 consecutive full
+/// blocks. 4x covers ~12.
+pub const DEFAULT_BASE_FEE_MULTIPLIER: u128 = 4;
+
+/// How many times a transaction is re-sent at a higher price before giving up.
+pub const DEFAULT_MAX_BUMPS: u32 = 3;
+
+/// Floor on `maxPriorityFeePerGas`. A zero tip gives block builders no reason to include the
+/// transaction, and makes the +10% replacement threshold awkward to clear.
+const PRIORITY_FEE_FLOOR_WEI: u128 = 10_000_000; // 0.01 gwei
+
+/// Reads and parses an environment variable, warning if it is set but unparseable.
+///
+/// Silently falling back to the default is the wrong behaviour for an operational knob: a typo in
+/// a value set during an incident would take effect as "no change", with nothing in the logs to
+/// explain why.
+fn parse_env<T: std::str::FromStr>(name: &str) -> Option<T> {
+    match std::env::var(name) {
+        Err(_) => None,
+        Ok(raw) => match raw.trim().parse::<T>() {
+            Ok(value) => Some(value),
+            Err(_) => {
+                tracing::warn!(
+                    env_var = name,
+                    value = %raw,
+                    "Ignoring unparseable value; falling back to the default"
+                );
+                None
+            }
+        },
+    }
+}
+
+/// Fee strategy for L1 transactions.
+///
+/// Without one, a transaction priced from a low base fee can become unmineable when base fee
+/// rises, and nothing revisits it: it sits in the mempool indefinitely while nonce ordering holds
+/// back every subsequent transaction from the same account.
+#[derive(Clone, Copy, Debug)]
+pub struct GasPolicy {
+    /// Lower bound on `maxFeePerGas`, in wei.
+    pub fee_floor_wei: u128,
+    /// Multiplier applied to the current gas price.
+    pub base_fee_multiplier: u128,
+    /// Maximum number of price escalations before returning an error.
+    pub max_bumps: u32,
+}
+
+impl Default for GasPolicy {
+    fn default() -> Self {
+        Self {
+            fee_floor_wei: DEFAULT_FEE_FLOOR_GWEI * WEI_PER_GWEI,
+            base_fee_multiplier: DEFAULT_BASE_FEE_MULTIPLIER,
+            max_bumps: DEFAULT_MAX_BUMPS,
+        }
+    }
+}
+
+impl GasPolicy {
+    /// Reads the policy from the environment, falling back to the defaults.
+    ///
+    /// Overridable so a live incident can be handled by changing configuration rather than
+    /// shipping a build.
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        Self {
+            fee_floor_wei: parse_env("L1_GAS_FEE_FLOOR_GWEI")
+                .map(|gwei: u128| gwei.saturating_mul(WEI_PER_GWEI))
+                .unwrap_or(default.fee_floor_wei),
+            base_fee_multiplier: parse_env("L1_GAS_BASE_FEE_MULTIPLIER")
+                .filter(|m: &u128| {
+                    // A zero multiplier would price every transaction at the floor alone,
+                    // silently disabling the headroom this exists to provide.
+                    if *m == 0 {
+                        tracing::warn!(
+                            "L1_GAS_BASE_FEE_MULTIPLIER=0 ignored; using {}",
+                            DEFAULT_BASE_FEE_MULTIPLIER
+                        );
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .unwrap_or(default.base_fee_multiplier),
+            max_bumps: parse_env("L1_TX_MAX_BUMPS").unwrap_or(default.max_bumps),
+        }
+    }
+
+    /// Worst-case wall time one send can occupy, given a per-attempt confirmation timeout.
+    ///
+    /// Exposed so callers can reason about how long a send may block without needing to know that
+    /// escalation exists or how many attempts it makes.
+    pub fn worst_case_send_secs(&self, per_attempt_timeout_secs: u64) -> u64 {
+        u64::from(self.max_bumps).saturating_add(1).saturating_mul(per_attempt_timeout_secs)
+    }
+}
+
+/// `maxFeePerGas` for a new transaction: the current price with headroom, never below the floor.
+///
+/// `reference_price_wei` is whatever the node reports as the going rate (`eth_gasPrice`), which on
+/// an EIP-1559 chain already includes a tip estimate -- so the result errs high, deliberately.
+fn compute_max_fee(reference_price_wei: u128, priority_fee_wei: u128, policy: &GasPolicy) -> u128 {
+    reference_price_wei
+        .saturating_mul(policy.base_fee_multiplier)
+        .saturating_add(priority_fee_wei)
+        .max(policy.fee_floor_wei)
+}
+
+/// Fees for replacing a transaction that did not confirm in time.
+///
+/// EIP-1559 replacement requires **both** fields to rise by at least 10%; +25% clears that with
+/// margin. The `+1` keeps the increase strict even at values where integer arithmetic would
+/// otherwise round to a no-op -- a bump that does not increase is rejected as underpriced, which
+/// would leave the original transaction stuck.
+fn bump_fees(max_fee_wei: u128, priority_fee_wei: u128) -> (u128, u128) {
+    let bump = |v: u128| (v.saturating_mul(5) / 4).max(v.saturating_add(1));
+    (bump(max_fee_wei), bump(priority_fee_wei))
+}
+
+/// Whether the caller already priced this transaction, in which case its fees are left untouched.
+///
+/// Both fields must be set: filling in just one would pair a caller's value with a computed one.
+fn has_caller_fees(request: &TransactionRequest) -> bool {
+    request.max_fee_per_gas.is_some() && request.max_priority_fee_per_gas.is_some()
+}
 
 #[derive(Clone, Debug)]
 /// The type of signer to use for signing transactions.
@@ -106,11 +248,141 @@ impl Signer {
 
     /// Sends a transaction request, signed by the configured `signer`, with a caller-supplied
     /// confirmation timeout (in seconds).
+    ///
+    /// Prices the transaction under [`GasPolicy`] and, if it does not confirm within the timeout,
+    /// re-sends it at the **same nonce** with escalated fees. Without this a transaction that
+    /// fell behind a rising base fee stayed in the mempool indefinitely, and nonce ordering meant
+    /// it blocked every later transaction from the same account until someone intervened.
+    ///
+    /// A caller that priced the transaction itself keeps its fees; only the nonce is pinned.
     pub async fn send_transaction_request_with_timeout(
+        &self,
+        l1_rpc: Url,
+        transaction_request: TransactionRequest,
+        timeout_secs: u64,
+    ) -> Result<TransactionReceipt> {
+        let policy = GasPolicy::from_env();
+        let provider = ProviderBuilder::new().network::<Ethereum>().connect_http(l1_rpc.clone());
+
+        // Pin the nonce so every escalation replaces the same transaction rather than queueing a
+        // new one behind it. `SignerLock` serialises sends, so nothing else claims it meanwhile.
+        let mut request = transaction_request;
+        if request.nonce.is_none() {
+            let nonce = provider
+                .get_transaction_count(self.address())
+                .pending()
+                .await
+                .context("Failed to read pending nonce")?;
+            request.set_nonce(nonce);
+        }
+
+        let (mut max_fee, mut priority_fee) = if has_caller_fees(&request) {
+            (
+                request.max_fee_per_gas.unwrap_or_default(),
+                request.max_priority_fee_per_gas.unwrap_or_default(),
+            )
+        } else {
+            let gas_price = provider.get_gas_price().await.context("Failed to read gas price")?;
+            let priority = provider
+                .get_max_priority_fee_per_gas()
+                .await
+                .unwrap_or(PRIORITY_FEE_FLOOR_WEI)
+                .max(PRIORITY_FEE_FLOOR_WEI);
+            (compute_max_fee(gas_price, priority, &policy), priority)
+        };
+
+        let mut sent_hashes = Vec::new();
+        let mut attempt = 0;
+        loop {
+            let mut candidate = request.clone();
+            candidate.set_max_fee_per_gas(max_fee);
+            candidate.set_max_priority_fee_per_gas(priority_fee);
+
+            let mut this_hash = None;
+            match self
+                .dispatch_transaction(l1_rpc.clone(), candidate, timeout_secs, &mut this_hash)
+                .await
+            {
+                Ok(receipt) => return Ok(receipt),
+                Err(e) => {
+                    // Record this attempt BEFORE deciding anything. The invariant that keeps a
+                    // successful transaction from being reported as failed is: every `Err` return
+                    // below is preceded by a receipt lookup over *all* hashes broadcast so far,
+                    // including this attempt's.
+                    if let Some(hash) = this_hash {
+                        sent_hashes.push(hash);
+                    }
+
+                    // An escalation can lose the race: the transaction it replaces may have just
+                    // been mined, in which case the node rejects the replacement. That is success.
+                    for hash in &sent_hashes {
+                        if let Ok(Some(receipt)) = provider.get_transaction_receipt(*hash).await {
+                            return Ok(receipt);
+                        }
+                    }
+
+                    if attempt >= policy.max_bumps {
+                        // Distinguish "still sitting in the mempool" from "the nonce was consumed
+                        // by a transaction we cannot identify" -- the operator's next move
+                        // differs. Decided from the on-chain nonce rather than by matching error
+                        // text, which varies between clients.
+                        let nonce_consumed = match (
+                            request.nonce,
+                            provider.get_transaction_count(self.address()).await,
+                        ) {
+                            (Some(nonce), Ok(latest)) => latest > nonce,
+                            _ => false,
+                        };
+
+                        return Err(e.context(if nonce_consumed {
+                            format!(
+                                "nonce {:?} was consumed by a transaction other than the {} we \
+                                 broadcast (most likely the original, mined before a replacement \
+                                 reached the node). Its outcome is not knowable from here -- \
+                                 check the account's recent transactions.",
+                                request.nonce,
+                                sent_hashes.len()
+                            )
+                        } else {
+                            format!(
+                                "transaction did not confirm after {} attempts (final \
+                                 maxFeePerGas {} gwei); it is still pending",
+                                attempt + 1,
+                                max_fee / WEI_PER_GWEI
+                            )
+                        }));
+                    }
+
+                    let (next_max, next_priority) = bump_fees(max_fee, priority_fee);
+                    tracing::warn!(
+                        nonce = ?request.nonce,
+                        attempt = attempt + 1,
+                        max_bumps = policy.max_bumps,
+                        from_max_fee_gwei = max_fee / WEI_PER_GWEI,
+                        to_max_fee_gwei = next_max / WEI_PER_GWEI,
+                        error = ?e,
+                        "L1 transaction did not confirm; replacing it at the same nonce with \
+                         higher fees"
+                    );
+                    (max_fee, priority_fee) = (next_max, next_priority);
+                    attempt += 1;
+                }
+            }
+        }
+    }
+
+    /// Signs and broadcasts one attempt, waiting up to `timeout_secs` for confirmation.
+    ///
+    /// Extracted from `send_transaction_request_with_timeout` so the escalation loop above is
+    /// shared by all three signer kinds; the per-signer bodies are unchanged. `sent_hash` reports
+    /// the broadcast hash even when confirmation later times out, which the loop needs to tell
+    /// "still pending" from "confirmed while we were escalating".
+    async fn dispatch_transaction(
         &self,
         l1_rpc: Url,
         mut transaction_request: TransactionRequest,
         timeout_secs: u64,
+        sent_hash: &mut Option<TxHash>,
     ) -> Result<TransactionReceipt> {
         match self {
             Signer::Web3Signer(signer_url, signer_address) => {
@@ -134,10 +406,12 @@ impl Signer {
 
                 let tx_envelope = TxEnvelope::decode_2718(&mut raw.as_ref()).unwrap();
 
-                let receipt = provider
+                let pending = provider
                     .send_tx_envelope(tx_envelope)
                     .await
-                    .context("Failed to send transaction")?
+                    .context("Failed to send transaction")?;
+                *sent_hash = Some(*pending.tx_hash());
+                let receipt = pending
                     .with_required_confirmations(NUM_CONFIRMATIONS)
                     .with_timeout(Some(Duration::from_secs(timeout_secs)))
                     .get_receipt()
@@ -159,10 +433,12 @@ impl Signer {
                     transaction_request.to = Some(TxKind::Create);
                 }
 
-                let receipt = provider
+                let pending = provider
                     .send_transaction(transaction_request)
                     .await
-                    .context("Failed to send transaction")?
+                    .context("Failed to send transaction")?;
+                *sent_hash = Some(*pending.tx_hash());
+                let receipt = pending
                     .with_required_confirmations(NUM_CONFIRMATIONS)
                     .with_timeout(Some(Duration::from_secs(timeout_secs)))
                     .get_receipt()
@@ -185,10 +461,12 @@ impl Signer {
                     .wallet(wallet)
                     .connect_http(l1_rpc);
 
-                let receipt = provider
+                let pending = provider
                     .send_transaction(transaction_request)
                     .await
-                    .context("Failed to send KMS-signed transaction")?
+                    .context("Failed to send KMS-signed transaction")?;
+                *sent_hash = Some(*pending.tx_hash());
+                let receipt = pending
                     .with_required_confirmations(NUM_CONFIRMATIONS)
                     .with_timeout(Some(Duration::from_secs(timeout_secs)))
                     .get_receipt()
@@ -249,6 +527,130 @@ impl SignerLock {
         signer
             .send_transaction_request_with_timeout(l1_rpc, transaction_request, timeout_secs)
             .await
+    }
+}
+
+#[cfg(test)]
+mod gas_policy_tests {
+    use super::*;
+
+    const GWEI: u128 = 1_000_000_000;
+
+    fn policy() -> GasPolicy {
+        GasPolicy { fee_floor_wei: 3 * GWEI, base_fee_multiplier: 4, max_bumps: 3 }
+    }
+
+    /// The failure this prevents: when the network is cheap, a fee derived purely from the
+    /// current price is small enough that a later base fee overtakes it, at which point the
+    /// transaction can never be mined and blocks every later nonce behind it.
+    #[test]
+    fn floor_applies_when_the_network_is_cheap() {
+        let observed_low_price = 150_000_000; // 0.15 gwei
+        let priority = 10_000_000; // 0.01 gwei
+        let max_fee = compute_max_fee(observed_low_price, priority, &policy());
+
+        assert_eq!(max_fee, 3 * GWEI, "the floor must win when the multiplier result is tiny");
+        assert!(
+            max_fee > 1_250_000_000,
+            "must stay mineable after base fee climbs to 1.25 gwei, got {max_fee}"
+        );
+    }
+
+    #[test]
+    fn multiplier_applies_when_the_network_is_busy() {
+        let gas_price = 30 * GWEI;
+        let priority = 2 * GWEI;
+        let max_fee = compute_max_fee(gas_price, priority, &policy());
+
+        assert_eq!(max_fee, 30 * GWEI * 4 + 2 * GWEI);
+        assert!(max_fee > gas_price * 2 + priority, "must exceed a 2x buffer");
+    }
+
+    /// base fee rises at most 12.5% per block, so a 4x buffer has to cover a meaningful number of
+    /// consecutive full blocks.
+    #[test]
+    fn buffer_survives_a_sustained_base_fee_climb() {
+        let base_fee = 10 * GWEI;
+        let max_fee = compute_max_fee(base_fee, GWEI, &policy());
+
+        let mut climbed = base_fee;
+        let mut blocks = 0;
+        while climbed <= max_fee {
+            climbed = climbed * 1125 / 1000;
+            blocks += 1;
+        }
+        assert!(blocks >= 12, "4x buffer should cover >=12 blocks of max climb, got {blocks}");
+    }
+
+    /// EIP-1559 replacement requires BOTH fee fields to rise by at least 10%. A bump that fails
+    /// this is rejected as underpriced, leaving the original transaction stuck.
+    #[test]
+    fn bump_satisfies_the_replacement_threshold() {
+        for (max_fee, priority) in
+            [(3 * GWEI, GWEI / 100), (GWEI, 0), (1, 0), (100 * GWEI, 5 * GWEI)]
+        {
+            let (new_max, new_priority) = bump_fees(max_fee, priority);
+
+            assert!(
+                new_max * 100 >= max_fee * 110,
+                "maxFeePerGas {max_fee} -> {new_max} is under the +10% threshold"
+            );
+            assert!(
+                new_priority * 100 >= priority * 110,
+                "priority {priority} -> {new_priority} is under the +10% threshold"
+            );
+            assert!(new_max > max_fee, "must strictly increase, even from {max_fee}");
+        }
+    }
+
+    /// Escalation must be monotone; a plateau would retry at a price the network already rejected.
+    #[test]
+    fn repeated_bumps_strictly_increase() {
+        let (mut max_fee, mut priority) = (3 * GWEI, GWEI / 100);
+        for _ in 0..policy().max_bumps {
+            let (next_max, next_priority) = bump_fees(max_fee, priority);
+            assert!(next_max > max_fee);
+            assert!(next_priority >= priority);
+            (max_fee, priority) = (next_max, next_priority);
+        }
+        assert!(max_fee < 3 * GWEI * 3, "escalation overshot: {max_fee}");
+    }
+
+    /// A caller that priced its own transaction keeps those fees.
+    #[test]
+    fn caller_supplied_fees_are_not_overridden() {
+        let explicit = TransactionRequest::default()
+            .with_max_fee_per_gas(42 * GWEI)
+            .with_max_priority_fee_per_gas(7 * GWEI);
+        assert!(has_caller_fees(&explicit));
+
+        assert!(!has_caller_fees(&TransactionRequest::default()));
+        // Half-specified is not "specified": filling only one field would pair a caller value
+        // with a computed one.
+        assert!(!has_caller_fees(&TransactionRequest::default().with_max_fee_per_gas(42 * GWEI)));
+    }
+
+    #[test]
+    fn worst_case_send_covers_every_attempt() {
+        let p = policy();
+        assert_eq!(p.worst_case_send_secs(60), 4 * 60, "1 initial attempt + 3 escalations");
+
+        let no_bumps = GasPolicy { max_bumps: 0, ..policy() };
+        assert_eq!(no_bumps.worst_case_send_secs(60), 60);
+
+        // Must not overflow into a nonsensical small number on absurd input.
+        assert_eq!(
+            GasPolicy { max_bumps: u32::MAX, ..policy() }.worst_case_send_secs(u64::MAX),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn policy_defaults_match_the_documented_values() {
+        let p = GasPolicy::default();
+        assert_eq!(p.fee_floor_wei, DEFAULT_FEE_FLOOR_GWEI * GWEI);
+        assert_eq!(p.base_fee_multiplier, DEFAULT_BASE_FEE_MULTIPLIER);
+        assert_eq!(p.max_bumps, DEFAULT_MAX_BUMPS);
     }
 }
 


### PR DESCRIPTION
## Problem

A transaction sent while the network is cheap can be priced below a later base fee and become
permanently unmineable. Because nonces are consumed in order, it then blocks every subsequent
transaction from the same account. Nothing in the signer revisits such a transaction: on timeout
`send_transaction_request_with_timeout` returns an error and leaves it in the mempool, so the
queue only grows.

We hit this on a Mantle production proposer. 20 `checkpointBlockHash` transactions accumulated:

```
nonce 49653 (queue head)  maxFeePerGas 0.3228 gwei   <- below base fee, can never be mined
nonce 49654               maxFeePerGas 0.6407 gwei
nonce 49655               maxFeePerGas 1.2211 gwei
nonce 49656 .. 49672      maxFeePerGas 1.9 - 4.0 gwei  <- adequate, blocked purely by ordering
base fee at the time      1.25 gwei
```

17 of the 20 were priced perfectly well. Recovery required replacing the transactions by hand.

**This failed at _low_ gas, which is the opposite of the usual intuition about congestion.**
Automatic estimation derives `maxFeePerGas` from the current base fee, so the cheaper the network
the smaller the absolute buffer, and base fee needs only a handful of 12.5% steps to overtake it.
Here it went from ~0.15 to 1.25 gwei.

A second-order effect made it worse for us: `checkpointBlockHash` reads `blockhash()`, which only
covers 256 blocks, so 16 of the 20 were already guaranteed to revert even if mined. That part is
Mantle-specific and not addressed here.

## Change

Two things, both inside `send_transaction_request_with_timeout`, so all three signer kinds and
every call site benefit and no caller needs to change:

| Behaviour | Default | Env override |
|---|---|---|
| `maxFeePerGas` floor | 3 gwei | `L1_GAS_FEE_FLOOR_GWEI` |
| Gas price buffer | 4x | `L1_GAS_BASE_FEE_MULTIPLIER` |
| On timeout, re-send at the **same nonce**, +25% on both fee fields | up to 3 times | `L1_TX_MAX_BUMPS` |

The transactions this signer sends are small — a checkpoint is ~46k gas — so a 3 gwei floor costs
on the order of 0.00014 ETH per transaction, negligible against a stalled proposer. All three are
env-overridable so a live incident can be handled by configuration rather than a deploy.

### Three details that carry the correctness

1. **The nonce is pinned before the first send**, so an escalation *replaces* the transaction
   instead of queueing behind it. `SignerLock` already serialises sends, so nothing else claims
   the nonce meanwhile.
2. **An escalation can lose the race.** The transaction being replaced may be mined just as the
   replacement goes out, and the node then rejects the replacement — that is success, not failure.
   Every broadcast hash is recorded *before* waiting for confirmation, and every error return is
   preceded by a receipt lookup over all of them. Reporting a landed transaction as failed would
   make the caller send a duplicate.
3. **Callers that price their own transaction keep those fees.** Both fee fields must be set for
   that to apply, so a half-specified request is not paired with a computed value.

When attempts are exhausted, the error distinguishes "still pending" from "the nonce was consumed
by a transaction we cannot identify", decided from the on-chain nonce rather than by matching
client-specific error text, since the operator's next step differs between them.

## Testing

Unit tests cover the floor, the buffer (asserted to survive ≥12 consecutive blocks of maximum
base-fee climb), the EIP-1559 +10% replacement threshold across values including zero, monotonic
escalation, caller-fee precedence, and the worst-case timing helper.

Verified end to end against anvil with block production withheld:

```
L1 tx nonce Some(0) did not confirm (attempt 1); replacing at maxFeePerGas 15 -> 18 gwei
nonce 0: replacing ... mined in block Some(1)
```

`cargo fmt --all` and `cargo clippy --all-features --all-targets -- -D warnings
-A incomplete-features` are clean on the touched crate.

## Notes for reviewers

- Adds a `tracing` dependency to `op-succinct-signer-utils`; nothing in the crate logged before,
  and a silent escalation would be hard to operate.
- Defaults are chosen to be safe rather than cheap. If you would rather the floor were lower, or
  escalation off by default, that is a one-line change to the constants — happy to adjust.
- One interaction worth flagging: escalation lengthens the worst case of a single send to
  `(1 + L1_TX_MAX_BUMPS) * TX_CONFIRMATION_TIMEOUT`. In the validity proposer an iteration can
  send twice, and its chain lock lease is `LOOP_INTERVAL`, so with the defaults the slowest
  iteration can exceed the lease. That imbalance predates this change (two 60s sends already
  exceeded a 60s lease) but this widens it. Not addressed here since it is a proposer-side
  configuration concern, but worth knowing if you take this.
